### PR TITLE
Add missing dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 install-dependencies-ocaml:
 	opam install \
+		ocamlformat \
 		ANSITerminal \
 		sedlex \
 		menhir \


### PR DESCRIPTION
Currently, ocamlformat is not installed by `make install-dependencies`, which leads to the following error while running `make build`:

```bash
~/Documents/git/catala master 2m 20s                       
❯ make build                                               
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C src/catala/parsing parser_errors.ml                         
make[1]: `parser_errors.ml' is up to date.
dune build                                                                                                            
    ocamlopt src/legifrance_catala.exe                                                                                
ld: warning: directory not found for option '-L/opt/local/lib'                                                        
/Applications/Xcode.app/Contents/Developer/usr/bin/make format                                                        
dune build @fmt --auto-promote | true                                                                                 
Error: Program ocamlformat not found in the tree or in PATH                                                           
 (context: default)                                                                                                   
Done: 119/183 (jobs: 2)File "syntax_highlighting/fr/pygments/pygments/tests/examplefiles/test.re", line 1, characters 0-0:
Done: 120/183 (jobs: 2)File "syntax_highlighting/en/pygments/pygments/tests/examplefiles/test.re", line 1, characters 0-0:
         git (internal) (exit 1)                                                                                      
```

This pull request fixes this problem.