### PR TITLE
CamlCase -> CamelCase

### DIFF
--- a/examples/tutorial_en/tutorial_en.catala_en
+++ b/examples/tutorial_en/tutorial_en.catala_en
@@ -60,7 +60,7 @@ individual:
 /* 
 declaration structure Individual:
   # The name of the structure "Individual", must start with an
-  # uppercase letter: this is the CamlCase convention.
+  # uppercase letter: this is the CamelCase convention.
   data income content money
   # In this line, "income" is the name of the structure field and 
   # "money" is the type of what is stored in that field.
@@ -83,7 +83,7 @@ enumerations are modeled in Catala using an enumeration type, like:
 @@Begin metadata@@
 /*
 declaration enumeration TaxCredit:
-# The name "TaxCredit" is also written in CamlCase 
+# The name "TaxCredit" is also written in CamelCase 
 -- NoTaxCredit
 # This line says that "TaxCredit" can be a "NoTaxCredit" situation
 -- ChildrenTaxCredit content integer 
@@ -108,7 +108,7 @@ programming. Scopes also have to be declared in metadata, so here we go:
 @@Begin metadata@@
 /*
 declaration scope IncomeTaxComputation:
-  # Scope names use CamlCase
+  # Scope names use CamelCase
   context individual content Individual
   # This line declares a context element of the scope, which is akin to 
   # a function parameter in computer science term. This is the piece of 

--- a/examples/tutoriel_fr/tutoriel_fr.catala_fr
+++ b/examples/tutoriel_fr/tutoriel_fr.catala_fr
@@ -62,7 +62,7 @@ personne :
 /* 
 déclaration structure Personne:
   # Le nom de la structure "Personne", doit commencer
-  # par une lettre majuscule: c'est la convention CamlCase.
+  # par une lettre majuscule: c'est la convention CamelCase.
   donnée revenu contenu argent
   # A cette ligne, revenu est le nom du champ de la structure et
   # "argent" est le type de de données de ce champ. 
@@ -86,7 +86,7 @@ sont modélisés en Catala par le type énumération, comme suit :
 @@Début métadonnées@@
 /*
 déclaration énumération CréditImpôt:
-# Le nom "CréditImpôt" s'écrit aussi en CamlCase
+# Le nom "CréditImpôt" s'écrit aussi en CamelCase
 -- AucunCréditImpôt
 # Cette ligne indique que "CréditImpôt" peut être en situation 
 # "AucunCréditImpôt"
@@ -114,7 +114,7 @@ préalablement dans les métadonnées, de la manière suivante:
 @@Début métadonnées@@
 /*
 déclaration champ d'application CalculImpôtRevenu:
-  # Les champs d'application utilisent le CamlCase
+  # Les champs d'application utilisent le CamelCase
   contexte personne contenu Personne
   # Cette ligne déclare un élémént de contexte du champ d'application,
   # cela ressemble à un paramètre de fonction en informatique. C'est la

--- a/src/catala/catala_surface/ast.ml
+++ b/src/catala/catala_surface/ast.ml
@@ -17,7 +17,7 @@
 module Pos = Utils.Pos
 
 type constructor = string
-(** Constructors are CamlCase *)
+(** Constructors are CamelCase *)
 
 type ident = string
 (** Idents are snake_case *)


### PR DESCRIPTION
Camel case comes from the shape of a camel, and not from OCaml.

This PR fixes all the occurences of "CamlCase" in the repository to "CamelCase".