### PR TITLE
Improve unlabeled exceptions, and use them in US tax code and allocations familiales examples

### DIFF
--- a/examples/allocations_familiales/decrets_divers.catala_fr
+++ b/examples/allocations_familiales/decrets_divers.catala_fr
@@ -74,14 +74,14 @@ tranche est celle dont les revenus sont supérieurs au plafond de base de
 
 /*
 champ d'application AllocationsFamiliales :
-  exception base_plafond_I_d521_3
+  exception
   définition plafond_I_d521_3 sous condition 
     date_courante >=@ |01/01/2020| et date_courante <=@ |31/12/2020|
   conséquence égal à 57 759 € +€
     5 775 € *€ (entier_vers_décimal de 
       (nombre de enfants_à_charge_droit_ouvert_prestation_familiale))
 
-  exception base_plafond_II_d521_3 
+  exception 
   définition plafond_II_d521_3 sous condition 
     date_courante >=@ |01/01/2020| et date_courante <=@ |31/12/2020|
   conséquence égal à 80 831 € +€
@@ -172,7 +172,7 @@ décembre 2021. Il est majoré de 5 827 euros par enfant à charge.
 
 /*
 champ d'application AllocationsFamiliales :
-  exception base_plafond_I_d521_3
+  exception
   définition plafond_I_d521_3 sous condition 
     date_courante >=@ |01/01/2021| et date_courante <=@ |31/12/2021|
   conséquence égal à 58 279 € +€
@@ -188,7 +188,7 @@ décembre 2021. Il est majoré de 5 827 euros par enfant à charge.
 
 /*
 champ d'application AllocationsFamiliales :
-  exception base_plafond_II_d521_3 
+  exception 
   définition plafond_II_d521_3 sous condition 
     date_courante >=@ |01/01/2021| et date_courante <=@ |31/12/2021|
   conséquence égal à 81 558 € +€

--- a/examples/allocations_familiales/epilogue.catala_fr
+++ b/examples/allocations_familiales/epilogue.catala_fr
@@ -32,7 +32,6 @@ champ d'application AllocationsFamiliales:
     non (droit_ouvert_majoration de enfant)
   conséquence égal à 0 €
 
-  étiquette définition_droit_ouvert_complément
   règle droit_ouvert_complément rempli
 
   définition enfant_le_plus_âgé.enfants égal à enfants_à_charge 

--- a/examples/allocations_familiales/securite_sociale_D.catala_fr
+++ b/examples/allocations_familiales/securite_sociale_D.catala_fr
@@ -14,7 +14,6 @@ est défini selon le barème suivant :
 /*
 # Composantes des allocations familiales
 champ d'application AllocationsFamiliales :
-  étiquette définition_montant_initial_base
   définition montant_initial_base égal à
     montant_initial_base_deuxième_enfant +€
     montant_initial_base_troisième_enfant_et_plus
@@ -154,7 +153,7 @@ différence entre, d'une part, ce plafond de ressources majoré de la somme
 définie à l'alinéa précédent et, d'autre part, le montant des ressources.
 /*
 champ d'application AllocationsFamiliales :
-  exception base_dépassement
+  exception
   définition dépassement_plafond_ressources de allocation
   sous condition
     (ressources_ménage >€ plafond_I_d521_3) et
@@ -162,7 +161,7 @@ champ d'application AllocationsFamiliales :
   conséquence égal à
     plafond_I_d521_3 +€ allocation *€ 12,0 -€ ressources_ménage
 
-  exception base_dépassement
+  exception
   définition dépassement_plafond_ressources de allocation
   sous condition
     (ressources_ménage >€ plafond_II_d521_3) et
@@ -171,7 +170,6 @@ champ d'application AllocationsFamiliales :
     plafond_II_d521_3 +€ allocation *€ 12,0 -€ ressources_ménage
 
   # Dans les autres cas, le dépassement est nul
-  étiquette base_dépassement
   définition dépassement_plafond_ressources de allocations égal à 0 €
 
   définition montant_versé_complément_pour_base_et_majoration égal à
@@ -262,7 +260,6 @@ I.-Le plafond prévu au 1° du I des articles D. 521-1 et D. 521-2 est fixé à
 55 950 euros. Il est majoré de 5 595 euros par enfant à charge.
 /*
 champ d'application AllocationsFamiliales :
-  étiquette base_plafond_I_d521_3
   définition plafond_I_d521_3 égal à 55 950 € +€
     5 595 € *€ (entier_vers_décimal de 
       (nombre de enfants_à_charge_droit_ouvert_prestation_familiale))
@@ -272,7 +269,6 @@ II.-Le plafond prévu au 2° du I des articles D. 521-1 et D. 521-2 est fixé à
 78 300 euros. Il est majoré de 5 595 euros par enfant à charge.
 /*
 champ d'application AllocationsFamiliales :
-  étiquette base_plafond_II_d521_3
   définition plafond_II_d521_3 égal à 78 300 € +€
     5 595 € *€ (entier_vers_décimal de 
       (nombre de enfants_à_charge_droit_ouvert_prestation_familiale))
@@ -307,7 +303,7 @@ fixé à 5,88 p. 100 de la base mensuelle prévue à l'article L. 755-3.
 # Composantes des allocations familiales
 champ d'application AllocationsFamiliales :
   
-  exception définition_montant_initial_base
+  exception
   définition montant_initial_base sous condition
     prestations_familiales.régime_outre_mer_l751_1 et 
     nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1

--- a/examples/allocations_familiales/securite_sociale_L.catala_fr
+++ b/examples/allocations_familiales/securite_sociale_L.catala_fr
@@ -93,7 +93,6 @@ champ d'application PrestationsFamiliales :
 Les allocations familiales sont dues à partir du deuxième enfant à charge.
 /*
 champ d'application AllocationsFamiliales :
-  étiquette définitition_droit_ouvert_base 
   règle droit_ouvert_base sous condition
     nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 2
   conséquence rempli
@@ -118,7 +117,6 @@ champ d'application AllocationsFamiliales :
     prestations_familiales.conditions_hors_âge de enfant
   conséquence  rempli
 
-  étiquette base_droit_ouvert_forfaitaire
   règle droit_ouvert_forfaitaire de enfant sous condition
     (nombre de enfants_à_charge >= nombre_enfants_l521_1) et
     (enfant.âge = prestations_familiales.âge_l512_3_2) et
@@ -174,10 +172,8 @@ Les allocations sont versées à la personne qui assume, dans quelques condition
 que ce soit, la charge effective et permanente de l'enfant.
 /*
 champ d'application AllocationsFamiliales :
-  étiquette définition_prise_en_compte
   définition prise_en_compte de enfant égal à Complète
 
-  étiquette définition_versement
   définition versement de enfant égal à Normal
 */
 
@@ -192,24 +188,24 @@ les conditions d'application du présent alinéa.
 /*
 champ d'application AllocationsFamiliales :
   # Premier cas : garde alternée, parents désignent un unique allocataire
-  exception définition_prise_en_compte
+  exception
   définition prise_en_compte de enfant sous condition 
     enfant.garde_alternée sous forme OuiAllocataireUnique
   conséquence égal à Complète
 
-  exception définition_versement
+  exception
   définition versement de enfant sous condition 
     enfant.garde_alternée sous forme OuiAllocataireUnique
   conséquence égal à Normal
 
   # Deuxième cas : garde alternée, parents partagent la charge pour
   # l'allocation
-  exception définition_prise_en_compte
+  exception
   définition prise_en_compte de enfant sous condition 
     enfant.garde_alternée sous forme OuiPartageAllocations
   conséquence égal à Partagée
 
-  exception définition_versement
+  exception
   définition versement de enfant sous condition 
     enfant.garde_alternée sous forme OuiPartageAllocations
   conséquence égal à Normal
@@ -238,7 +234,7 @@ de l'enfant dans son foyer.
 
 /*
 champ d'application AllocationsFamiliales :
-  exception définition_versement
+  exception
   définition versement de enfant sous condition 
     enfant.pris_en_charge_par_services_sociaux sous forme
       OuiAllocationVerséeAuxServicesSociaux
@@ -266,7 +262,6 @@ l'exception du plus âgé, ouvre droit à partir d'un âge minimum à une
 majoration des allocations familiales.
 /*
 champ d'application AllocationsFamiliales :
-  étiquette base_droit_ouvert_majoration
   règle droit_ouvert_majoration de enfant
   sous condition
     (non (est_enfant_le_plus_âgé de enfant)) et
@@ -279,7 +274,7 @@ bénéficient de ladite majoration pour chaque enfant à charge à partir
 de l'âge mentionné au premier alinéa.
 /*
 champ d'application AllocationsFamiliales :
-  exception base_droit_ouvert_majoration
+  exception
   règle droit_ouvert_majoration de enfant
   sous condition
     (nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 
@@ -355,7 +350,7 @@ Les allocations familiales sont dues, pour tout enfant, à la personne qui a
 effectivement la charge de celui-ci.
 /*
 champ d'application AllocationsFamiliales:
-  exception définitition_droit_ouvert_base
+  exception
   règle droit_ouvert_base sous condition
     prestations_familiales.régime_outre_mer_l751_1 et
     (nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 1)
@@ -368,13 +363,13 @@ applicables lorsque le ménage ou la personne a un seul enfant à charge.
 # et au complément dégressif.
 
 champ d'application AllocationsFamiliales :
-  exception base_droit_ouvert_forfaitaire
+  exception
   règle droit_ouvert_forfaitaire de enfant sous condition
      prestations_familiales.régime_outre_mer_l751_1 et
      (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)
   conséquence non rempli
 
-  exception définition_droit_ouvert_complément
+  exception
   règle droit_ouvert_complément sous condition
     prestations_familiales.régime_outre_mer_l751_1 et
     (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)

--- a/examples/allocations_familiales/securite_sociale_R.catala_fr
+++ b/examples/allocations_familiales/securite_sociale_R.catala_fr
@@ -21,7 +21,6 @@ articles L. 141-1 à L. 141-9 du code du travail, multiplié par 169.
 
 /*
 champ d'application PrestationsFamiliales :
-  étiquette définition_plafond_l512_3_2
   définition plafond_l512_3_2 égal à
    (smic.brut_horaire *€ 55 %) *€ 169,0
 */
@@ -177,7 +176,7 @@ vigueur dans chacun des départements mentionnés à l'article L. 751-1 ,
 multiplié par 169.
 /*
 champ d'application PrestationsFamiliales :
-  exception définition_plafond_l512_3_2
+  exception
   définition plafond_l512_3_2
   sous condition régime_outre_mer_l751_1
   conséquence égal à

--- a/examples/us_tax_code/section_121.catala_en
+++ b/examples/us_tax_code/section_121.catala_en
@@ -154,10 +154,8 @@ scope Section121SinglePerson:
     else $0
   
 scope Section121:
-  label base_requirements_met
   definition section121a_requirements_met equals section121Person1.requirements_met
 
-  label base_income_excluded 
   definition income_excluded_from_gross_income_uncapped equals 
     section121Person1.income_excluded_from_gross_income_uncapped
 
@@ -183,7 +181,6 @@ scope Section121SinglePerson:
       income_excluded_from_gross_income_uncapped
 
 scope Section121: 
-    label base_gain_cap
     definition gain_cap equals section121Person1.gain_cap 
 
     definition income_excluded_from_gross_income equals 
@@ -239,12 +236,12 @@ scope Section121:
       section_121_b_3_applies of data_couple.person2.other_section_121a_sale)) 
   consequence fulfilled
     
-  exception base_requirements_met
+  exception
   rule section121a_requirements_met under condition 
     section_121_b_2_A_condition 
   consequence fulfilled
   
-  exception base_gain_cap 
+  exception 
   definition gain_cap under condition 
     section_121_b_2_A_condition
   consequence equals $500,000
@@ -261,7 +258,7 @@ scope Section121 under condition
   (return_type with pattern JointReturn) and 
   not (section_121_b_2_A_condition):
 
-  exception base_gain_cap 
+  exception 
   definition gain_cap equals 
     section121Person1.gain_cap +$ section121Person2.gain_cap
 
@@ -305,7 +302,7 @@ scope Section121 under condition
   # single_data.date_of_spouse_death instead of date_of_sale_or_exchange
   :
 
-  exception base_gain_cap 
+  exception 
   definition gain_cap equals $500,000
   
 */

--- a/tests/test_exception/ambiguous_unlabeled_exception.catala.A.out
+++ b/tests/test_exception/ambiguous_unlabeled_exception.catala.A.out
@@ -1,7 +1,13 @@
-[ERROR] An unlabeled exception refers to several definitions, including this one. Disambiguate by using labels.
+[ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 [ERROR] 
 [ERROR]   --> test_exception/ambiguous_unlabeled_exception.catala
 [ERROR]    | 
 [ERROR] 10 |   def x := 1
-[ERROR]    |       ^
+[ERROR]    |            
+[ERROR] 11 | 
+[ERROR]    | 
+[ERROR] 12 |   exception 
+[ERROR]    |   ^^^^^^^^^^
+[ERROR] 13 |   def x := 2
+[ERROR]    |   ^^^^^^^^^^^
 [ERROR]    + Test

--- a/tests/test_exception/missing_unlabeled_definition.catala.A.out
+++ b/tests/test_exception/missing_unlabeled_definition.catala.A.out
@@ -1,7 +1,11 @@
-[ERROR] No definition associated to this exception
+[ERROR] This exception does not have a corresponding definition
 [ERROR] 
 [ERROR]  --> test_exception/missing_unlabeled_definition.catala
 [ERROR]   | 
+[ERROR] 7 | scope A:
+[ERROR]   |        
+[ERROR] 8 |   exception 
+[ERROR]   |   ^^^^^^^^^^
 [ERROR] 9 |   def x := 1
-[ERROR]   |       ^
+[ERROR]   |   ^^^^^^^^^^^
 [ERROR]   + Test

--- a/tests/test_exception/one_ambiguous_exception.catala.A.out
+++ b/tests/test_exception/one_ambiguous_exception.catala.A.out
@@ -1,7 +1,13 @@
-[ERROR] An unlabeled exception refers to several definitions, including this one. Disambiguate by using labels.
+[ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 [ERROR] 
 [ERROR]   --> test_exception/one_ambiguous_exception.catala
 [ERROR]    | 
 [ERROR] 16 |   def y := 4
-[ERROR]    |       ^
+[ERROR]    |            
+[ERROR] 17 | 
+[ERROR]    | 
+[ERROR] 18 |   exception
+[ERROR]    |   ^^^^^^^^^
+[ERROR] 19 |   def y := 3
+[ERROR]    |   ^^^^^^^^^^^
 [ERROR]    + Test

--- a/tests/test_exception/split_unlabeled_exception.catala
+++ b/tests/test_exception/split_unlabeled_exception.catala
@@ -1,0 +1,15 @@
+@Test@
+
+/*
+new scope A:
+  param x content int
+
+scope A:
+  def x := 0
+*/
+
+/*
+scope A:
+  exception
+  def x := 1
+*/

--- a/tests/test_exception/split_unlabeled_exception.catala.A.out
+++ b/tests/test_exception/split_unlabeled_exception.catala.A.out
@@ -1,0 +1,2 @@
+[RESULT] Computation successful! Results:
+[RESULT] x = 1


### PR DESCRIPTION
The previous support for unlabeled exceptions was limited to definitions and exceptions defined inside of the same code block.
The file tests/test_exception/split_unlabeled_exception.catala shows an example that was previously failing, although it should be considered a valid use of unlabeled exceptions. Examples in the US tax code and in allocations familiales, although larger, follow a similar pattern. Thus using unlabeled exceptions was not possible there.

This PR enables support for unlabeled exceptions in the same scope across code blocks.
The main difference is that the generation of default rulenames for default definitions is done during the name resolution pass, instead of during the desugaring pass. This allows to have a global context with rulenames for default definitions already generated, instead of generating and forgetting them after each iteration over a scope use during desugaring.

For each scope, default_rulemap is now a map to a new datatype, unique_name, which, for a given scope definition, differentiates between 
* The absence of a default definition (no associated value)
* Ambiguous default definitions (either several default definitions possible, or a labeled definition)
* A Unique default definition, for which a fresh rulename has been generated

During the desugaring phase, it is then sufficient to check that every unlabeled exception is associated to a unique default definition.

Using this improvement, this PR also simplifies the existing examples to use unlabeled exceptions when possible.