### PR TITLE
Fixed typo.

### DIFF
--- a/src/catala/utils/cli.ml
+++ b/src/catala/utils/cli.ml
@@ -57,7 +57,7 @@ let unstyled = Arg.(value & flag & info [ "unstyled" ] ~doc:"Removes styling fro
 let optimize = Arg.(value & flag & info [ "optimize"; "O" ] ~doc:"Run compiler optimizations")
 
 let trace_opt =
-  Arg.(value & flag & info [ "trace"; "t" ] ~doc:"Displays a trace of the intepreter's computation")
+  Arg.(value & flag & info [ "trace"; "t" ] ~doc:"Displays a trace of the interpreter's computation")
 
 let wrap_weaved_output =
   Arg.(


### PR DESCRIPTION
# Summary

There was a typo in the help file of `catala`, it said "intepreter's" instead of "interpreter's".

# Affected files

`src/catala/utils/cli.ml`