### PR TITLE
POC: Using cmake instead of Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _opam/
 src/**/.merlin
 legifrance_oauth*
 *.html
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+project(catala)
+cmake_minimum_required(VERSION 3.20)
+
+add_custom_target(update_parser_messages
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND dune build @update-parser-messages --auto-promote | true
+)
+
+add_custom_target(format
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND make --no-print-directory format
+)
+
+add_custom_target(build_catala
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND dune build ./src/catala/catala.exe
+)
+
+add_custom_target(build
+    DEPENDS update_parser_messages format build_catala
+)
+
+add_custom_target(test_examples
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND make --no-print-directory -C ./examples tests
+    DEPENDS build
+)
+

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ want to compile it from the sources of this repository. For that, see
 Use `catala --help` to get more information about the command line
 options available.
 
-The top-level `Makefile` contains a lot of useful targets to run. To display
-them, use
+The top-level CMakelists.txt contains definitions of targets that will be generated and then used. To generate them, call
 
-        make help
+    mkdir -p build/ && cmake -B build
+
+Now, you can call e.g. `cmake --build build/ --target help` from the top directory or `make help` from build directory.
+
+<!-- TODO: change make -> cmake --build build/ in some places -->
+
 
 ## Examples
 


### PR DESCRIPTION
Hi all,

What do you think about adding using cmake in this project? It'd be an easier way to maintain buildsystem, dependencies between targets, etc.

1st commit is an example of how `test_examples` would work. Oneliner:
```
mkdir -p build/ && cmake -B build && cmake --build build/ --target test_examples
```