### PR TITLE
fix(compiler): correct the handling of the Division_by_zero exception

### DIFF
--- a/src/catala/dcalc/interpreter.ml
+++ b/src/catala/dcalc/interpreter.ml
@@ -1,6 +1,6 @@
 (* This file is part of the Catala compiler, a specification language for tax and social benefits
    computation rules. Copyright (C) 2020 Inria, contributor: Denis Merigoux
-   <denis.merigoux@inria.fr>
+   <denis.merigoux@inria.fr>, Emile Rolley <emile.rolley@tuta.io>
 
    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
    in compliance with the License. You may obtain a copy of the License at
@@ -38,6 +38,15 @@ let log_indent = ref 0
 
 let rec evaluate_operator (ctx : Ast.decl_ctx) (op : A.operator Pos.marked)
     (args : A.expr Pos.marked list) : A.expr Pos.marked =
+  let apply_or_raise_err (div : unit -> A.expr) (op : A.operator Pos.marked) : A.expr =
+    try div ()
+    with Division_by_zero ->
+      Errors.raise_multispanned_error "division by zero at runtime"
+        [
+          (Some "The division operator:", Pos.get_position op);
+          (Some "The null denominator:", Pos.get_position (List.nth args 1));
+        ]
+  in
   Pos.same_pos_as
     (match (Pos.unmark op, List.map Pos.unmark args) with
     | A.Ternop A.Fold, [ _f; _init; EArray es ] ->
@@ -53,38 +62,24 @@ let rec evaluate_operator (ctx : Ast.decl_ctx) (op : A.operator Pos.marked)
     | A.Binop (A.Sub KInt), [ ELit (LInt i1); ELit (LInt i2) ] -> A.ELit (LInt Runtime.(i1 -! i2))
     | A.Binop (A.Mult KInt), [ ELit (LInt i1); ELit (LInt i2) ] -> A.ELit (LInt Runtime.(i1 *! i2))
     | A.Binop (A.Div KInt), [ ELit (LInt i1); ELit (LInt i2) ] ->
-        if i2 <> Runtime.integer_of_int 0 then A.ELit (LInt Runtime.(i1 /! i2))
-        else
-          Errors.raise_multispanned_error "division by zero at runtime"
-            [
-              (Some "The division operator:", Pos.get_position op);
-              (Some "The null denominator:", Pos.get_position (List.nth args 2));
-            ]
+        apply_or_raise_err
+          (fun _ ->
+            if i2 <> Runtime.integer_of_int 0 then A.ELit (LInt Runtime.(i1 /! i2))
+            else raise Division_by_zero)
+          op
     | A.Binop (A.Add KRat), [ ELit (LRat i1); ELit (LRat i2) ] -> A.ELit (LRat Runtime.(i1 +& i2))
     | A.Binop (A.Sub KRat), [ ELit (LRat i1); ELit (LRat i2) ] -> A.ELit (LRat Runtime.(i1 -& i2))
     | A.Binop (A.Mult KRat), [ ELit (LRat i1); ELit (LRat i2) ] -> A.ELit (LRat Runtime.(i1 *& i2))
-    | A.Binop (A.Div KRat), [ ELit (LRat i1); ELit (LRat i2) ] -> (
-        try A.ELit (LRat Runtime.(i1 /& i2))
-        with _ ->
-          Errors.raise_multispanned_error "division by zero at runtime"
-            [
-              (Some "The division operator:", Pos.get_position op);
-              (Some "The null denominator:", Pos.get_position (List.nth args 2));
-            ])
+    | A.Binop (A.Div KRat), [ ELit (LRat i1); ELit (LRat i2) ] ->
+        apply_or_raise_err (fun _ -> A.ELit (LRat Runtime.(i1 /& i2))) op
     | A.Binop (A.Add KMoney), [ ELit (LMoney i1); ELit (LMoney i2) ] ->
         A.ELit (LMoney Runtime.(i1 +$ i2))
     | A.Binop (A.Sub KMoney), [ ELit (LMoney i1); ELit (LMoney i2) ] ->
         A.ELit (LMoney Runtime.(i1 -$ i2))
     | A.Binop (A.Mult KMoney), [ ELit (LMoney i1); ELit (LRat i2) ] ->
         A.ELit (LMoney Runtime.(i1 *$ i2))
-    | A.Binop (A.Div KMoney), [ ELit (LMoney i1); ELit (LMoney i2) ] -> (
-        try A.ELit (LRat Runtime.(i1 /$ i2))
-        with _ ->
-          Errors.raise_multispanned_error "division by zero at runtime"
-            [
-              (Some "The division operator:", Pos.get_position op);
-              (Some "The null denominator:", Pos.get_position (List.nth args 2));
-            ])
+    | A.Binop (A.Div KMoney), [ ELit (LMoney i1); ELit (LMoney i2) ] ->
+        apply_or_raise_err (fun _ -> A.ELit (LRat Runtime.(i1 /$ i2))) op
     | A.Binop (A.Add KDuration), [ ELit (LDuration i1); ELit (LDuration i2) ] ->
         A.ELit (LDuration Runtime.(i1 +^ i2))
     | A.Binop (A.Sub KDuration), [ ELit (LDuration i1); ELit (LDuration i2) ] ->

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,9 +24,8 @@ reset_tests: $(subst output/,,$(subst .out,.in,$(wildcard */*/output/*.out)))
 # Forces all the tests to be redone
 .FORCE:
 
-# FIXME: .catala should be replaced by the corresponding regexp.
 %.run: .FORCE
-	$(CATALA) $(word 1,$(subst ., ,$*)).catala -s $(word 3,$(subst ., ,$*))
+	$(CATALA) $(word 1,$(subst ., ,$*)).$(word 2, $(subst ., , $*)) -s $(word 3,$(subst ., ,$*))
 
 # Usage: make <test_dir>/output/<test_name>.catala_<language>.<scope_name>.out
 # This rule runs the test and compares against the expected output. If the

--- a/tests/test_arithmetic/bad/division_by_zero.catala_en
+++ b/tests/test_arithmetic/bad/division_by_zero.catala_en
@@ -1,0 +1,31 @@
+## `Division_by_zero` exception management
+
+### with integers
+
+```catala
+declaration scope Int:
+  context i content integer
+
+scope Int:
+  definition i equals 1 / 0
+```
+
+### with decimals
+
+```catala
+declaration scope Dec:
+  context i content decimal
+
+scope Dec:
+  definition i equals 1. /. 0.
+```
+
+### with money
+
+```catala
+declaration scope Money:
+  context i content decimal
+
+scope Money:
+  definition i equals $10.0 /$ $0.0
+```

--- a/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Dec.out
+++ b/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Dec.out
@@ -1,0 +1,17 @@
+[ERROR] division by zero at runtime
+[ERROR] 
+[ERROR] The division operator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 20 |   definition i equals 1. /. 0.
+[ERROR]    |                          ^^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with decimals
+[ERROR] 
+[ERROR] The null denominator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 20 |   definition i equals 1. /. 0.
+[ERROR]    |                             ^^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with decimals

--- a/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Int.out
+++ b/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Int.out
@@ -1,0 +1,17 @@
+[ERROR] division by zero at runtime
+[ERROR] 
+[ERROR] The division operator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 10 |   definition i equals 1 / 0
+[ERROR]    |                         ^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with integers
+[ERROR] 
+[ERROR] The null denominator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 10 |   definition i equals 1 / 0
+[ERROR]    |                           ^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with integers

--- a/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Money.out
+++ b/tests/test_arithmetic/bad/output/division_by_zero.catala_en.Money.out
@@ -1,0 +1,17 @@
+[ERROR] division by zero at runtime
+[ERROR] 
+[ERROR] The division operator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 30 |   definition i equals $10.0 /$ $0.0
+[ERROR]    |                             ^^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with money
+[ERROR] 
+[ERROR] The null denominator:
+[ERROR]   --> test_arithmetic/bad/division_by_zero.catala_en
+[ERROR]    | 
+[ERROR] 30 |   definition i equals $10.0 /$ $0.0
+[ERROR]    |                                ^^^^
+[ERROR]    + `Division_by_zero` exception management
+[ERROR]    +-+ with money

--- a/tests/test_date/bad/output/uncomparable_duration.catala_en.Ge.out
+++ b/tests/test_date/bad/output/uncomparable_duration.catala_en.Ge.out
@@ -1,0 +1,15 @@
+[ERROR] Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 40 |   definition d equals 1 month >=^ 2 day
+[ERROR]    |                       ^^^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `>=^` operator
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 40 |   definition d equals 1 month >=^ 2 day
+[ERROR]    |                                   ^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `>=^` operator

--- a/tests/test_date/bad/output/uncomparable_duration.catala_en.Gt.out
+++ b/tests/test_date/bad/output/uncomparable_duration.catala_en.Gt.out
@@ -1,0 +1,15 @@
+[ERROR] Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 30 |   definition d equals 1 month >^ 2 day
+[ERROR]    |                       ^^^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<=^` operator
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 30 |   definition d equals 1 month >^ 2 day
+[ERROR]    |                                  ^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<=^` operator

--- a/tests/test_date/bad/output/uncomparable_duration.catala_en.Le.out
+++ b/tests/test_date/bad/output/uncomparable_duration.catala_en.Le.out
@@ -1,0 +1,15 @@
+[ERROR] Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 20 |   definition d equals 1 month <=^ 2 day
+[ERROR]    |                       ^^^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<=^` operator
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 20 |   definition d equals 1 month <=^ 2 day
+[ERROR]    |                                   ^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<=^` operator

--- a/tests/test_date/bad/output/uncomparable_duration.catala_en.Lt.out
+++ b/tests/test_date/bad/output/uncomparable_duration.catala_en.Lt.out
@@ -1,0 +1,15 @@
+[ERROR] Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 10 |   definition d equals 1 month <^ 2 day
+[ERROR]    |                       ^^^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<^` operator
+[ERROR] 
+[ERROR]   --> test_date/bad/uncomparable_duration.catala_en
+[ERROR]    | 
+[ERROR] 10 |   definition d equals 1 month <^ 2 day
+[ERROR]    |                                  ^^^^^
+[ERROR]    + `UncomparableDurations` exception management
+[ERROR]    +-+ `<^` operator

--- a/tests/test_date/bad/uncomparable_duration.catala_en
+++ b/tests/test_date/bad/uncomparable_duration.catala_en
@@ -1,0 +1,41 @@
+## `UncomparableDurations` exception management
+
+### `<^` operator
+
+```catala
+declaration scope Lt:
+  context d content boolean
+
+scope Lt:
+  definition d equals 1 month <^ 2 day
+```
+
+### `<=^` operator
+
+```catala
+declaration scope Le:
+  context d content boolean
+
+scope Le:
+  definition d equals 1 month <=^ 2 day
+```
+
+### `<=^` operator
+
+```catala
+declaration scope Gt:
+  context d content boolean
+
+scope Gt:
+  definition d equals 1 month >^ 2 day
+```
+
+### `>=^` operator
+
+```catala
+declaration scope Ge:
+  context d content boolean
+
+scope Ge:
+  definition d equals 1 month >=^ 2 day
+```


### PR DESCRIPTION
An invalid index was used to get the null denomitator.

#### Changelog

* Fix and factorize the exception handling in `Dcalc.interpreter`.
* Add some unit tests for `Division_by_zero` and `UncomparableDurations` exceptions.
* Fix the `.run` rule of the `./tests/Makefile` in order to manage all catala file extensions.