### PR TITLE
Fix #118: remove code block delimiters in generated HTML files

### DIFF
--- a/examples/tutoriel_fr/Makefile
+++ b/examples/tutoriel_fr/Makefile
@@ -1,4 +1,4 @@
 CATALA_LANG=fr
-SRC=tutorial_fr.catala_fr
+SRC=tutoriel_fr.catala_fr
 
 include ../Makefile.common.mk

--- a/src/catala/literate/html.ml
+++ b/src/catala/literate/html.ml
@@ -37,6 +37,12 @@ let raise_failed_pygments (command : string) (error_code : int) : 'a =
     (Printf.sprintf "Weaving to HTML failed: pygmentize command \"%s\" returned with error code %d"
        command error_code)
 
+(** Partial application allowing to remove code block delimiters. *)
+let remove_code_block_delimiters : string -> string =
+  let delim = R.regexp "```(catala){0,1}" in
+  let delim_subst = function "```catala" | "```" -> "" | s -> s in
+  R.substitute ~rex:delim ~subst:delim_subst
+
 (** Usage: [wrap_html source_files custom_pygments language fmt wrapped]
 
     Prints an HTML complete page structure around the [wrapped] content. *)
@@ -119,7 +125,7 @@ let pygmentize_code (c : string Pos.marked) (language : C.backend_lang) : string
   let oc = open_in temp_file_out in
   let output = really_input_string oc (in_channel_length oc) in
   close_in oc;
-  output
+  remove_code_block_delimiters output
 
 (** {1 Weaving} *)
 

--- a/src/catala/literate/html.ml
+++ b/src/catala/literate/html.ml
@@ -49,11 +49,7 @@ let remove_cb_last_lines : string -> string =
 
 (** Partial application allowing to substitute operators by their unicode representation. *)
 let substitute_arithmetics_op : string -> string =
-  (* (EmileRolley) NOTE: [date] should match the new ISO format. + I don't get why this must be in
-     the regex...*)
-  let date = "\\d\\d/\\d\\d/\\d\\d\\d\\d" in
-  let syms = R.regexp (date ^ "|!=|<=|>=|--|->|\\*|\\/") in
-  let syms_subst = function
+  R.substitute ~rex:(R.regexp "!=|<=|>=|--|->|\\*|\\/") ~subst:(function
     | "!=" -> "≠"
     | "<=" -> "≤"
     | ">=" -> "≥"
@@ -61,9 +57,7 @@ let substitute_arithmetics_op : string -> string =
     | "->" -> "→"
     | "*" -> "×"
     | "/" -> "÷"
-    | s -> s
-  in
-  R.substitute ~rex:syms ~subst:syms_subst
+    | s -> s)
 
 (** Usage: [wrap_html source_files custom_pygments language fmt wrapped]
 


### PR DESCRIPTION
> Related issue: #118

## Question

~~1. I don't understand why this regexp is needed: https://github.com/CatalaLang/catala/compare/master...EmileRolley:fix-remove-catala-markers?expand=1#diff-173106f4bf5075fa7e6f2d0614d92e15637db5c7a94263d75e98ab553842e8f0R54~~
(_removed_)

## Changelog

* add substitutions in order to remove trailling code block delimiters.
* fix wrong file name in `examples/tutoriel_fr/Makefile`.