### PR TITLE
add menhirLib to Nix dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,23 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-nix:
+  build-nix-21-05:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=channel:nixos-21.05
+    - run: nix-build release.nix
+    - run: nix-shell --run "echo OK"
+  
+  build-nix-unstable:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v14.1
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build release.nix
     - run: nix-shell --run "echo OK"
 

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildDunePackage, ansiterminal, sedlex_2, menhir
-, unionfind, bindlib, cmdliner, re, zarith, zarith_stubs_js, ocamlgraph
+, menhirLib, unionfind, bindlib, cmdliner, re, zarith, zarith_stubs_js, ocamlgraph
 , calendar, visitors, benchmark, js_of_ocaml, js_of_ocaml-ppx, camomile, cppo }:
 
 buildDunePackage rec {
@@ -16,6 +16,7 @@ buildDunePackage rec {
     ansiterminal
     sedlex_2
     menhir
+    menhirLib
     cmdliner
     re
     zarith

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,25 @@
-{ lib, fetchFromGitHub, buildDunePackage, ansiterminal, sedlex_2, menhir
-, menhirLib, unionfind, bindlib, cmdliner, re, zarith, zarith_stubs_js, ocamlgraph
-, calendar, visitors, benchmark, js_of_ocaml, js_of_ocaml-ppx, camomile, cppo }:
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, ansiterminal
+, sedlex_2
+, menhir
+, unionfind
+, bindlib
+, cmdliner
+, re
+, zarith
+, zarith_stubs_js
+, ocamlgraph
+, calendar
+, visitors
+, benchmark
+, js_of_ocaml
+, js_of_ocaml-ppx
+, camomile
+, cppo
+, menhirLib ? null #for nixos-unstable compatibility.
+}:
 
 buildDunePackage rec {
   pname = "catala";
@@ -32,7 +51,7 @@ buildDunePackage rec {
 
     unionfind
     bindlib
-  ];
+  ] ++ (if isNull menhirLib then [ ] else [ menhirLib ]);
   doCheck = true;
 
   patches = [ ./.nix/no-web.patch ];


### PR DESCRIPTION
I was having some trouble building Catala with Nix - it was missing the dependency `menhirLib` - so `menhirLib` has been added to the  `default.nix` file here as a dependency of catala. The nix build should be fixed.