### PR TITLE
Fix(build/doc): remove warnings due to .ml* files

### DIFF
--- a/compiler/desugared/desugared.mld
+++ b/compiler/desugared/desugared.mld
@@ -1,9 +1,9 @@
 {0 Desugared representation }
 
-This representation is the second in the compilation chain 
-(see {{: index.html#architecture} Architecture}). Its main difference 
-with {{: surface.html} the surface representation} is that the legislative 
-text has been discarded and all the definitions of each variables have been 
+This representation is the second in the compilation chain
+(see {{: index.html#architecture} Architecture}). Its main difference
+with {{: surface.html} the surface representation} is that the legislative
+text has been discarded and all the definitions of each variables have been
 collected in the same place rather than being scattered across the code base.
 
 The module describing the abstract syntax tree is:
@@ -18,13 +18,13 @@ Related modules:
 
 Before the translation to the {{: scopelang.html} scope language},
 {!module: Desugared.Dependency} checks that within
-a scope, there is no computational circular dependency between the variables 
+a scope, there is no computational circular dependency between the variables
 of the scope. When the dependency graph is a DAG,
-{!module: Desugared.Desugared_to_scope} performs a topological ordering to 
-produce an ordered list of the scope definitions compatible with the 
-computation order. All the graph computations are done using the 
+{!module: Desugared.Desugared_to_scope} performs a topological ordering to
+produce an ordered list of the scope definitions compatible with the
+computation order. All the graph computations are done using the
 {{:http://ocamlgraph.lri.fr/} Ocamlgraph} library.
 
 The other important piece of work performed by
 {!module: Desugared.Desugared_to_scope} is the construction of the default trees
-(see {!constructor: Dcalc.Ast.EDefault}) from the list of prioritized rules.
+(see {!Dcalc.Ast.EDefault}) from the list of prioritized rules.

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -19,7 +19,7 @@ module Pos = Utils.Pos
 (** Associates a {!type: Cli.backend_lang} with its string represtation. *)
 let languages = [ ("en", Cli.En); ("fr", Cli.Fr); ("pl", Cli.Pl) ]
 
-(** Associates a file extension with its corresponding {!type: Cli.frontend_lang} string
+(** Associates a file extension with its corresponding {!type: Cli.backend_lang} string
     representation. *)
 let extensions = [ (".catala_fr", "fr"); (".catala_en", "en"); (".catala_pl", "pl") ]
 

--- a/compiler/lcalc/lcalc.mld
+++ b/compiler/lcalc/lcalc.mld
@@ -26,7 +26,7 @@ certified.
 
 Related modules:
 
-{!modules: Lcalc.To_ocaml Lcalc.To_python Lcalc.Backends}
+{!modules: Lcalc.To_ocaml Scalc.To_python Lcalc.Backends}
 
 The OCaml backend of the lambda calculus is merely a syntactic formatting,
 since the core of the OCaml value language is effectively a lambda calculus.

--- a/compiler/scalc/scalc.mld
+++ b/compiler/scalc/scalc.mld
@@ -25,5 +25,5 @@ are eliminated in favor of tagged unions.
 
 Related modules:
 
-{!modules: Lcalc.To_python}
+{!modules: Scalc.To_python}
 

--- a/compiler/scopelang/scopelang.mld
+++ b/compiler/scopelang/scopelang.mld
@@ -1,10 +1,10 @@
 {0 The scope language }
 
-This representation is the third in the compilation chain 
-(see {{: index.html#architecture} Architecture}). Its main difference 
+This representation is the third in the compilation chain
+(see {{: index.html#architecture} Architecture}). Its main difference
 with the previous {{: desugared.html} desugared representation} is that inside
-a scope, the definitions are ordered according to their computational 
-dependency order, and each definition is a {!constructor: Dcalc.Ast.EDefault} tree 
+a scope, the definitions are ordered according to their computational
+dependency order, and each definition is a {!Dcalc.Ast.EDefault} tree
 instead of a flat list of rules.
 
 The module describing the abstract syntax tree is:
@@ -13,7 +13,7 @@ The module describing the abstract syntax tree is:
 
 Printing helpers can be found in {!module: Scopelang.Print}.
 
-This intermediate representation corresponds to the scope language 
+This intermediate representation corresponds to the scope language
 presented in the {{: https://github.com/CatalaLang/catala/raw/master/doc/formalization/formalization.pdf}
 Catala formalization}.
 
@@ -23,7 +23,7 @@ Related modules:
 
 {!modules: Scopelang.Dependency Scopelang.Scope_to_dcalc}
 
-The translation from the scope language to the 
+The translation from the scope language to the
 {{: dcalc.html} default calculus} involves three big features:
 
 {ol
@@ -32,7 +32,7 @@ The translation from the scope language to the
 {li Transform the list of scopes into a program}
 }
 
-1 and 3 involve computing dependency graphs for respectively the structs and 
-enums on one hand, and the inter-scope dependencies on the other hand. Both 
-can be found in {!module: Scopelang.Dependency}, while 
+1 and 3 involve computing dependency graphs for respectively the structs and
+enums on one hand, and the inter-scope dependencies on the other hand. Both
+can be found in {!module: Scopelang.Dependency}, while
 {!module: Scopelang.Scope_to_dcalc} is mostly responsible for 2.

--- a/compiler/surface/desugaring.mli
+++ b/compiler/surface/desugaring.mli
@@ -12,7 +12,7 @@
    or implied. See the License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Translation from {!module: Surface.Ast} to {!module: Desugaring.Ast}.
+(** Translation from {!module: Surface.Ast} to {!module: Desugared.Ast}.
 
     - Removes syntactic sugars
     - Separate code from legislation *)

--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -778,8 +778,8 @@ let lex_law (lexbuf : lexbuf) : token =
     | Star (Compl '\n'), ('\n' | eof) -> LAW_TEXT (Utf8.lexeme lexbuf)
     | _ -> L.raise_lexer_error (Pos.from_lpos prev_pos) prev_lexeme
 
-(** Entry point of the lexer, distributes to {!val: lex_code} or {!val: lex_law} depending of {!val:
-    Surface.Lexer_common.is_code}. *)
+(** Entry point of the lexer, distributes to {!val: lex_code} or {!val:lex_law}
+    depending of the current {!val: Surface.Lexer_common.context}. *)
 let lexer (lexbuf : lexbuf) : token =
   match !L.context with
   | Law -> lex_law lexbuf

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -96,6 +96,6 @@ module type LocalisedLexer = sig
   (** Main lexing function used outside code blocks *)
 
   val lexer : Sedlexing.lexbuf -> Tokens.token
-  (** Entry point of the lexer, distributes to {!val: lex_code} or {!val: lex_law} depending of
-      {!val: Surface.Lexer_common.is_code}. *)
+  (** Entry point of the lexer, distributes to {!val: lex_code} or {!val:lex_law} depending of the
+      current {!val: Surface.Lexer_common.context}. *)
 end

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -32,8 +32,8 @@ val raise_lexer_error : Utils.Pos.t -> string -> 'a
 (** Error-generating helper *)
 
 val token_list_language_agnostic : (string * Tokens.token) list
-(** Associative list matching each punctuation string part of the Catala syntax with its {!module:
-    Surface.Parser} token. Same for all the input languages (English, French, etc.) *)
+(** Associative list matching each punctuation string part of the Catala syntax with its
+    {!Surface.Parser} token. Same for all the input languages (English, French, etc.) *)
 
 val calc_precedence : string -> int
 (** Calculates the precedence according a matched regex of the form : '[#]+' *)
@@ -43,8 +43,8 @@ val get_law_heading : Sedlexing.lexbuf -> Tokens.token
 
 module type LocalisedLexer = sig
   val token_list : (string * Tokens.token) list
-  (** Same as {!val: token_list_language_agnostic}, but with tokens whose string varies with the
-      input language. *)
+  (** Same as {!val: Surface.Lexer_common.token_list_language_agnostic}, but with tokens whose
+      string varies with the input language. *)
 
   val lex_builtin : string -> Ast.builtin_expression option
   (** Simple lexer for builtins *)
@@ -56,6 +56,6 @@ module type LocalisedLexer = sig
   (** Main lexing function used outside code blocks *)
 
   val lexer : Sedlexing.lexbuf -> Tokens.token
-  (** Entry point of the lexer, distributes to {!val: lex_code} or {!val: lex_law} depending of
-      {!val: is_code}. *)
+  (** Entry point of the lexer, distributes to {!val: lex_code} or {!val:lex_law} depending of the
+      current {!val: Surface.Lexer_common.context}. *)
 end

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -12,7 +12,8 @@
    or implied. See the License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Wrapping module around parser and lexer that offers the {!val: parse_source_file} API *)
+(** Wrapping module around parser and lexer that offers the {!: Parser_driver.parse_source_file}
+    API. *)
 
 open Sedlexing
 open Utils

--- a/compiler/surface/parser_driver.mli
+++ b/compiler/surface/parser_driver.mli
@@ -12,7 +12,8 @@
    or implied. See the License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Wrapping module around parser and lexer that offers the {!val: parse_source_file} API *)
+(** Wrapping module around parser and lexer that offers the
+    [Surface.Parser_driver.parse_source_file] API. *)
 
 open Utils
 

--- a/compiler/surface/surface.mld
+++ b/compiler/surface/surface.mld
@@ -1,37 +1,37 @@
 {0 Catala surface representation }
 
-This representation is the first in the compilation chain 
-(see {{: index.html#architecture} Architecture}). Its purpose is to 
+This representation is the first in the compilation chain
+(see {{: index.html#architecture} Architecture}). Its purpose is to
 host the output of the Catala parser, before any transformations have been made.
 
 The module describing the abstract syntax tree is:
 
 {!modules: Surface.Ast}
 
-This representation can also be weaved into literate programming outputs 
+This representation can also be weaved into literate programming outputs
 using the {{:literate.html} literate programming modules}.
 
 {1 Lexing }
 
 Relevant modules:
 
-{!modules: Surface.Lexer Surface.Lexer_fr Surface.Lexer_en}
+{!modules: Surface.Lexer_common Surface.Lexer_fr Surface.Lexer_en}
 
-The lexing in the Catala compiler is done using 
-{{: https://github.com/ocaml-community/sedlex} sedlex}, the modern OCaml lexer 
-that offers full support for UTF-8. This support enables users of non-English 
+The lexing in the Catala compiler is done using
+{{: https://github.com/ocaml-community/sedlex} sedlex}, the modern OCaml lexer
+that offers full support for UTF-8. This support enables users of non-English
 languages to use their favorite diacritics and symbols in their code.
 
-While the parser of Catala is unique, three different lexers can be used to 
+While the parser of Catala is unique, three different lexers can be used to
 produce the parser tokens.
 
-{ul 
-{li {!module: Surface.Lexer} corresponds to a concise and programming-language-like
-    syntax for Catala. Examples of this syntax can be found in the test suite 
+{ul
+{li {!module: Surface.Lexer_common} corresponds to a concise and programming-language-like
+    syntax for Catala. Examples of this syntax can be found in the test suite
     of the compiler.}
-{li {!module: Surface.Lexer_en} is the adaptation of {!module: Surface.Lexer} 
+{li {!module: Surface.Lexer_en} is the adaptation of {!module: Surface.Lexer_common}
     with verbose English keywords matching legal concepts.}
-{li {!module: Surface.Lexer_fr} is the adaptation of {!module: Surface.Lexer} 
+{li {!module: Surface.Lexer_fr} is the adaptation of {!module: Surface.Lexer_common}
     with verbose French keywords matching legal concepts.}
 }
 
@@ -39,7 +39,7 @@ produce the parser tokens.
 
 Relevant modules:
 
-{!modules: Surface.Parser Surface.Parser_driver Surface.Parser_errors} 
+{!modules: Surface.Parser Surface.Parser_driver Surface.Parser_errors}
 
 The Catala compiler uses {{: http://cambium.inria.fr/~fpottier/menhir/} Menhir}
 to perform its parsing. 
@@ -52,13 +52,13 @@ In order to provide decent syntax error messages, the Catala compiler uses the
 novel error handling provided by Menhir and detailed in Section 11 of the 
 {{: http://cambium.inria.fr/~fpottier/menhir/manual.pdf} Menhir manual}. 
 
-A [parser.messages] source file has been manually annotated with custom 
-error message for every potential erroneous state of the parser, and Menhir 
-automatically generated the {!module: Surface.Parser_errors} module containing 
+A [parser.messages] source file has been manually annotated with custom
+error message for every potential erroneous state of the parser, and Menhir
+automatically generated the {!module: Surface.Parser_errors} module containing
 the function linking the erroneous parser states to the custom error message.
 
-To wrap it up, {!module: Surface.Parser_driver} glues all the parsing and 
-lexing together to perform the translation from source code to abstract syntax 
+To wrap it up, {!module: Surface.Parser_driver} glues all the parsing and
+lexing together to perform the translation from source code to abstract syntax
 tree, with meaningful error messages.
 
 {1 Name resolution and translation }
@@ -67,11 +67,11 @@ Relevant modules:
 
 {!modules: Surface.Name_resolution Surface.Desugaring}
 
-The desugaring consists of translating {!module: Surface.Ast} to 
+The desugaring consists of translating {!module: Surface.Ast} to
 {!module: Desugared.Ast} of the {{: desugared.html} desugared representation}.
-The translation is implemented in 
-{!module: Surface.Desugaring}, but it relies on a helper module to perform the 
+The translation is implemented in
+{!module: Surface.Desugaring}, but it relies on a helper module to perform the
 name resolution: {!module: Surface.Name_resolution}. Indeed, in
-{!module: Surface.Ast}, the variables identifiers are just [string], whereas in 
-{!module: Desugared.Ast} they have been turned into well-categorized types 
+{!module: Surface.Ast}, the variables identifiers are just [string], whereas in
+{!module: Desugared.Ast} they have been turned into well-categorized types
 with an unique identifier like {!type: Scopelang.Ast.ScopeName.t}.


### PR DESCRIPTION
> related issue: #166 
> related scopes: `docs`

### Changelog

* Modifies documentation references to remove compilation warnings.

### Note

> "Part of it seems related to the cppo lexer extension.", said _@denismerigoux in  https://github.com/CatalaLang/catala/issues/166#issue-1077051102_

I don't thinks so, indeed, warnings about unlocatable modules such as `Stdlib` appears when upgrading `odoc` to a version `>= 2.0.0` and this even before the refactoring of the lexers.

**Quickfix**: a solution to remove this warnings is to use `odoc.1.5.3`. 