### PR TITLE
Restore CI by disabling counterexamples printing

### DIFF
--- a/build_system/clerk.ml
+++ b/build_system/clerk.ml
@@ -178,6 +178,13 @@ let test_file (tested_file : string) (catala_exe : string) (catala_opts : string
         let command =
           String.concat " "
             (List.filter (fun s -> s <> "") reproducible_catala_command
+            @ (match expected_output.backend with
+              | Cli.Proof ->
+                  [ "--disable_counterexamples" ]
+                  (* Counterexamples can be different at each call because of the randomness inside
+                     SMT solver, so we can't expect their value to remain constant. Hence we disable
+                     the counterexamples when testing the replication of failed proofs. *)
+              | _ -> [])
             @
             match expected_output.backend with
             | Cli.Interpret | Cli.Proof ->

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -27,13 +27,14 @@ let extensions = [ (".catala_fr", "fr"); (".catala_en", "en"); (".catala_pl", "p
     [driver source_file debug dcalc unstyled wrap_weaved_output backend language max_prec_digits trace optimize scope_to_execute output_file]*)
 let driver (source_file : Pos.input_file) (debug : bool) (unstyled : bool)
     (wrap_weaved_output : bool) (backend : string) (language : string option)
-    (max_prec_digits : int option) (trace : bool) (optimize : bool) (ex_scope : string option)
-    (output_file : string option) : int =
+    (max_prec_digits : int option) (trace : bool) (disable_counterexamples : bool) (optimize : bool)
+    (ex_scope : string option) (output_file : string option) : int =
   try
     Cli.debug_flag := debug;
     Cli.style_flag := not unstyled;
     Cli.trace_flag := trace;
     Cli.optimize_flag := optimize;
+    Cli.disable_counterexamples := disable_counterexamples;
     Cli.debug_print "Reading files...";
     let filename = ref "" in
     (match source_file with FileName f -> filename := f | Contents c -> Cli.contents := c);

--- a/compiler/utils/cli.ml
+++ b/compiler/utils/cli.ml
@@ -34,6 +34,8 @@ let trace_flag = ref false
 
 let optimize_flag = ref false
 
+let disable_counterexamples = ref false
+
 open Cmdliner
 
 let file =
@@ -95,6 +97,15 @@ let max_prec_digits_opt =
     & info [ "p"; "max_digits_printed" ] ~docv:"DIGITS"
         ~doc:"Maximum number of significant digits printed for decimal results (default 20).")
 
+let disable_counterexamples_opt =
+  Arg.(
+    value & flag
+    & info [ "disable_counterexamples" ]
+        ~doc:
+          "Disables the search for counterexamples in proof mode. Useful when you want a \
+           deterministic output from the Catala compiler, since provers can have some randomness \
+           in them.")
+
 let ex_scope =
   Arg.(
     value
@@ -113,7 +124,7 @@ let output =
 let catala_t f =
   Term.(
     const f $ file $ debug $ unstyled $ wrap_weaved_output $ backend $ language
-    $ max_prec_digits_opt $ trace_opt $ optimize $ ex_scope $ output)
+    $ max_prec_digits_opt $ trace_opt $ disable_counterexamples_opt $ optimize $ ex_scope $ output)
 
 let version = "0.5.0"
 

--- a/compiler/utils/cli.mli
+++ b/compiler/utils/cli.mli
@@ -35,6 +35,9 @@ val max_prec_digits : int ref
 
 val trace_flag : bool ref
 
+val disable_counterexamples : bool ref
+(** Disables model-generated counterexamples for proofs that fail. *)
+
 (** {2 CLI terms} *)
 
 val file : string Cmdliner.Term.t
@@ -78,13 +81,13 @@ val catala_t :
   int option ->
   bool ->
   bool ->
+  bool ->
   string option ->
   string option ->
   'a) ->
   'a Cmdliner.Term.t
 (** Main entry point:
-    [catala_t file debug unstyled wrap_weaved_output backend language max_prec_digits_opt trace_opt optimize
-    ex_scope output] *)
+    [catala_t file debug unstyled wrap_weaved_output backend language max_prec_digits_opt trace_opt disable_counterexamples optimize ex_scope output] *)
 
 val version : string
 

--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -168,27 +168,30 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
     variables and Catala variables, and to retrieve type information about the variables that was
     lost during the translation (e.g., by translating a date to an integer) **)
 let print_model (ctx : context) (model : Model.model) : string =
-  let decls = Model.get_decls model in
-
-  Format.asprintf "%a"
-    (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "\n")
-       (fun fmt d ->
-         match Model.get_const_interp model d with
-         (* TODO: Better handling of this case *)
-         | None -> failwith "[Z3 model]: A variable does not have an associated Z3 solution"
-         (* Prints "name : value\n" *)
-         | Some e ->
-             if FuncDecl.get_arity d = 0 then
-               (* Constant case *)
-               let symbol_name = Symbol.to_string (FuncDecl.get_name d) in
-               let v = StringMap.find symbol_name ctx.ctx_z3vars in
-               Format.fprintf fmt "%s %s : %s"
-                 (Cli.print_with_style [ ANSITerminal.blue ] "%s" "-->")
-                 (Cli.print_with_style [ ANSITerminal.yellow ] "%s" (Bindlib.name_of v))
-                 (print_z3model_expr ctx (VarMap.find v ctx.ctx_var) e)
-             else failwith "[Z3 model]: Printing of functions is not yet supported"))
-    decls
+  if !Cli.disable_counterexamples then
+    Format.asprintf "%s counterexamples disabled"
+      (Cli.print_with_style [ ANSITerminal.blue ] "%s" "-->")
+  else
+    let decls = Model.get_decls model in
+    Format.asprintf "%a"
+      (Format.pp_print_list
+         ~pp_sep:(fun fmt () -> Format.fprintf fmt "\n")
+         (fun fmt d ->
+           match Model.get_const_interp model d with
+           (* TODO: Better handling of this case *)
+           | None -> failwith "[Z3 model]: A variable does not have an associated Z3 solution"
+           (* Prints "name : value\n" *)
+           | Some e ->
+               if FuncDecl.get_arity d = 0 then
+                 (* Constant case *)
+                 let symbol_name = Symbol.to_string (FuncDecl.get_name d) in
+                 let v = StringMap.find symbol_name ctx.ctx_z3vars in
+                 Format.fprintf fmt "%s %s : %s"
+                   (Cli.print_with_style [ ANSITerminal.blue ] "%s" "-->")
+                   (Cli.print_with_style [ ANSITerminal.yellow ] "%s" (Bindlib.name_of v))
+                   (print_z3model_expr ctx (VarMap.find v ctx.ctx_var) e)
+               else failwith "[Z3 model]: Printing of functions is not yet supported"))
+      decls
 
 (** [translate_typ_lit] returns the Z3 sort corresponding to the Catala literal type [t] **)
 let translate_typ_lit (ctx : context) (t : typ_lit) : Sort.sort =
@@ -587,7 +590,9 @@ module Backend = struct
 
   let make_context (decl_ctx : decl_ctx) (free_vars_typ : typ Pos.marked VarMap.t) : backend_context
       =
-    let cfg = [ ("model", "true"); ("proof", "false") ] in
+    let cfg =
+      (if !Cli.disable_counterexamples then [] else [ ("model", "true") ]) @ [ ("proof", "false") ]
+    in
     let z3_ctx = mk_context cfg in
     {
       ctx_z3 = z3_ctx;

--- a/tests/test_proof/bad/output/dates_get_year-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/dates_get_year-empty.catala_en.Proof
@@ -5,7 +5,7 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 2020-07-07
+--> counterexamples disabled
 [RESULT] [A.y] No two exceptions to ever overlap for this variable
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/dates_get_year-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/dates_get_year-overlap.catala_en.Proof
@@ -6,6 +6,6 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 2020-01-01
+--> counterexamples disabled
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/dates_simple-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/dates_simple-empty.catala_en.Proof
@@ -5,7 +5,7 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 1900-01-01
+--> counterexamples disabled
 [RESULT] [A.y] No two exceptions to ever overlap for this variable
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/dates_simple-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/dates_simple-overlap.catala_en.Proof
@@ -6,6 +6,6 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 2010-01-01
+--> counterexamples disabled
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/enums-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums-empty.catala_en.Proof
@@ -5,7 +5,7 @@
    |           ^
    + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> y : B (C (false))
+--> counterexamples disabled
 [RESULT] [A.x] No two exceptions to ever overlap for this variable
 [RESULT] [A.y] This variable never returns an empty error
 [RESULT] [A.y] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/enums-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums-overlap.catala_en.Proof
@@ -6,6 +6,6 @@
    |           ^
    + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> y : A (2)
+--> counterexamples disabled
 [RESULT] [A.y] This variable never returns an empty error
 [RESULT] [A.y] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/money-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/money-empty.catala_en.Proof
@@ -5,7 +5,7 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 0.00 $
+--> counterexamples disabled
 [RESULT] [A.y] No two exceptions to ever overlap for this variable
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/money-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/money-overlap.catala_en.Proof
@@ -6,6 +6,6 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 1000.00 $
+--> counterexamples disabled
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/no_vars-conflict.catala_en.Proof
+++ b/tests/test_proof/bad/output/no_vars-conflict.catala_en.Proof
@@ -6,6 +6,6 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 0
+--> counterexamples disabled
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/no_vars-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/no_vars-empty.catala_en.Proof
@@ -5,7 +5,7 @@
   |           ^
   + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x : 1
+--> counterexamples disabled
 [RESULT] [A.y] No two exceptions to ever overlap for this variable
 [RESULT] [A.x] This variable never returns an empty error
 [RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/prolala_motivating_example.catala_en.Proof
+++ b/tests/test_proof/bad/output/prolala_motivating_example.catala_en.Proof
@@ -6,8 +6,7 @@
    + ProLaLa 2022 Super Cash Bonus
    +-+ Amount
 The solver generated the following counterexample to explain the faulty behavior:
---> eligibility.is_eligible : false
---> number_of_advisors : 4
+--> counterexamples disabled
 [RESULT] [Amount.amount] No two exceptions to ever overlap for this variable
 [RESULT] [Amount.correct_amount] This variable never returns an empty error
 [RESULT] [Amount.correct_amount] No two exceptions to ever overlap for this variable
@@ -27,8 +26,7 @@ The solver generated the following counterexample to explain the faulty behavior
    + ProLaLa 2022 Super Cash Bonus
    +-+ Eligibility
 The solver generated the following counterexample to explain the faulty behavior:
---> is_student : false
---> is_professor : false
+--> counterexamples disabled
 [ERROR] [Eligibility.is_eligible] At least two exceptions overlap for this variable:
   --> tests/test_proof/bad/prolala_motivating_example.catala_en
    | 
@@ -37,8 +35,7 @@ The solver generated the following counterexample to explain the faulty behavior
    + ProLaLa 2022 Super Cash Bonus
    +-+ Eligibility
 The solver generated the following counterexample to explain the faulty behavior:
---> is_student : true
---> is_professor : true
+--> counterexamples disabled
 [RESULT] [Eligibility.is_eligible_correct] This variable never returns an empty error
 [RESULT] [Eligibility.is_eligible_correct] No two exceptions to ever overlap for this variable
 [RESULT] [Eligibility.is_professor] This variable never returns an empty error

--- a/tests/test_proof/bad/output/sat_solving.catala_en.Proof
+++ b/tests/test_proof/bad/output/sat_solving.catala_en.Proof
@@ -5,15 +5,7 @@
    |           ^^^
    + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> x6 : false
---> x8 : false
---> x5 : false
---> x2 : true
---> x1 : true
---> x9 : false
---> x3 : true
---> x7 : true
---> x4 : true
+--> counterexamples disabled
 [RESULT] [A.x10] No two exceptions to ever overlap for this variable
 [RESULT] [A.x9] This variable never returns an empty error
 [RESULT] [A.x9] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/structs-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/structs-empty.catala_en.Proof
@@ -5,7 +5,7 @@
    |           ^
    + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> y : S { -- a : 0 -- b : T { -- c : false -- d : 2 } }
+--> counterexamples disabled
 [RESULT] [A.x] No two exceptions to ever overlap for this variable
 [RESULT] [A.y] This variable never returns an empty error
 [RESULT] [A.y] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/structs-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/structs-overlap.catala_en.Proof
@@ -6,6 +6,6 @@
    |           ^
    + Test
 The solver generated the following counterexample to explain the faulty behavior:
---> y : S { -- a : 3 -- b : T { -- c : true -- d : 2 } }
+--> counterexamples disabled
 [RESULT] [A.y] This variable never returns an empty error
 [RESULT] [A.y] No two exceptions to ever overlap for this variable


### PR DESCRIPTION
Recently, the CI failed because Z3 returned different counterexamples from the ones that were enshrined in the expected stdout output. We cannot afford to have the CI failing because of Z3's randomness, so I added an option in the Catala compiler to disable Z3's models and avoid printing the values for the test suite.

Here was an example of failing CI: https://github.com/CatalaLang/catala/runs/4952713428?check_suite_focus=true#step:6:611