### PR TITLE
[Z3Backend] Add support for enumerations containing argument-less constructors

### DIFF
--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -41,11 +41,11 @@ type context = {
   (* A map from Catala temporary variables, generated when translating a match, to the corresponding
      enum accessor call as a Z3 expression *)
   ctx_z3structs : Sort.sort StructMap.t;
-      (* A map from Catala struct names to the corresponding Z3 sort, from which we can retrieve the
-         constructor and the accessors *)
+  (* A map from Catala struct names to the corresponding Z3 sort, from which we can retrieve the
+     constructor and the accessors *)
   ctx_z3unit : Sort.sort * Expr.expr;
-  (* A pair containing the Z3 encodings of the unit type, encoded as a tuple of 0 elements,
-     and the unit value *)
+      (* A pair containing the Z3 encodings of the unit type, encoded as a tuple of 0 elements, and
+         the unit value *)
 }
 (** The context contains all the required information to encode a VC represented as a Catala term to
     Z3. The fields [ctx_decl] and [ctx_var] are computed before starting the translation to Z3, and
@@ -111,8 +111,8 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
     match ty with
     (* TODO: Print boolean according to current language *)
     | TBool -> Expr.to_string e
-    (* TUnit is only used for the absence of an enum constructor argument.
-       Hence, when pretty-printing, we print nothing to remain closer from Catala sources *)
+    (* TUnit is only used for the absence of an enum constructor argument. Hence, when
+       pretty-printing, we print nothing to remain closer from Catala sources *)
     | TUnit -> ""
     | TInt -> Expr.to_string e
     | TRat -> failwith "[Z3 model]: Pretty-printing of rational literals not supported"
@@ -562,14 +562,13 @@ and translate_expr (ctx : context) (vc : expr Pos.marked) : context * Expr.expr 
           ] )
   | ErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
 
-(** [create_z3unit] creates a Z3 sort and expression corresponding
-    to the unit type and value respectively.
-    Concretely, we represent unit as a tuple with 0 elements **)
+(** [create_z3unit] creates a Z3 sort and expression corresponding to the unit type and value
+    respectively. Concretely, we represent unit as a tuple with 0 elements **)
 let create_z3unit (ctx : Z3.context) : Z3.context * (Sort.sort * Expr.expr) =
   let unit_sort = Tuple.mk_sort ctx (Symbol.mk_string ctx "unit") [] [] in
   let mk_unit = Tuple.get_mk_decl unit_sort in
   let unit_val = Expr.mk_app ctx mk_unit [] in
-  ctx, (unit_sort, unit_val)
+  (ctx, (unit_sort, unit_val))
 
 module Backend = struct
   type backend_context = context
@@ -616,8 +615,6 @@ module Backend = struct
       ctx_z3structs = StructMap.empty;
       ctx_z3unit = z3unit;
     }
-
-
 end
 
 module Io = Io.MakeBackendIO (Backend)

--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -43,6 +43,9 @@ type context = {
   ctx_z3structs : Sort.sort StructMap.t;
       (* A map from Catala struct names to the corresponding Z3 sort, from which we can retrieve the
          constructor and the accessors *)
+  ctx_z3unit : Sort.sort * Expr.expr;
+  (* A pair containing the Z3 encodings of the unit type, encoded as a tuple of 0 elements,
+     and the unit value *)
 }
 (** The context contains all the required information to encode a VC represented as a Catala term to
     Z3. The fields [ctx_decl] and [ctx_var] are computed before starting the translation to Z3, and
@@ -108,7 +111,9 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
     match ty with
     (* TODO: Print boolean according to current language *)
     | TBool -> Expr.to_string e
-    | TUnit -> failwith "[Z3 model]: Pretty-printing of unit literals not supported"
+    (* TUnit is only used for the absence of an enum constructor argument.
+       Hence, when pretty-printing, we print nothing to remain closer from Catala sources *)
+    | TUnit -> ""
     | TInt -> Expr.to_string e
     | TRat -> failwith "[Z3 model]: Pretty-printing of rational literals not supported"
     (* TODO: Print the right money symbol according to language *)
@@ -193,7 +198,7 @@ let print_model (ctx : context) (model : Model.model) : string =
 let translate_typ_lit (ctx : context) (t : typ_lit) : Sort.sort =
   match t with
   | TBool -> Boolean.mk_sort ctx.ctx_z3
-  | TUnit -> failwith "[Z3 encoding] TUnit type not supported"
+  | TUnit -> fst ctx.ctx_z3unit
   | TInt -> Arithmetic.Integer.mk_sort ctx.ctx_z3
   | TRat -> failwith "[Z3 encoding] TRat type not supported"
   | TMoney -> Arithmetic.Integer.mk_sort ctx.ctx_z3
@@ -557,6 +562,15 @@ and translate_expr (ctx : context) (vc : expr Pos.marked) : context * Expr.expr 
           ] )
   | ErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
 
+(** [create_z3unit] creates a Z3 sort and expression corresponding
+    to the unit type and value respectively.
+    Concretely, we represent unit as a tuple with 0 elements **)
+let create_z3unit (ctx : Z3.context) : Z3.context * (Sort.sort * Expr.expr) =
+  let unit_sort = Tuple.mk_sort ctx (Symbol.mk_string ctx "unit") [] [] in
+  let mk_unit = Tuple.get_mk_decl unit_sort in
+  let unit_val = Expr.mk_app ctx mk_unit [] in
+  ctx, (unit_sort, unit_val)
+
 module Backend = struct
   type backend_context = context
 
@@ -590,6 +604,7 @@ module Backend = struct
       (if !Cli.disable_counterexamples then [] else [ ("model", "true") ]) @ [ ("proof", "false") ]
     in
     let z3_ctx = mk_context cfg in
+    let z3_ctx, z3unit = create_z3unit z3_ctx in
     {
       ctx_z3 = z3_ctx;
       ctx_decl = decl_ctx;
@@ -599,7 +614,10 @@ module Backend = struct
       ctx_z3datatypes = EnumMap.empty;
       ctx_z3matchsubsts = VarMap.empty;
       ctx_z3structs = StructMap.empty;
+      ctx_z3unit = z3unit;
     }
+
+
 end
 
 module Io = Io.MakeBackendIO (Backend)

--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -178,20 +178,22 @@ let print_model (ctx : context) (model : Model.model) : string =
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "\n")
        (fun fmt d ->
-         match Model.get_const_interp model d with
-         (* TODO: Better handling of this case *)
-         | None -> failwith "[Z3 model]: A variable does not have an associated Z3 solution"
-         (* Prints "name : value\n" *)
-         | Some e ->
-             if FuncDecl.get_arity d = 0 then
-               (* Constant case *)
+         if FuncDecl.get_arity d = 0 then begin
+           (* Constant case *)
+           match Model.get_const_interp model d with
+           (* TODO: Better handling of this case *)
+           | None -> failwith "[Z3 model]: A variable does not have an associated Z3 solution"
+           (* Print "name : value\n" *)
+           | Some e ->
                let symbol_name = Symbol.to_string (FuncDecl.get_name d) in
                let v = StringMap.find symbol_name ctx.ctx_z3vars in
+               Cli.error_print "testbis\n";
                Format.fprintf fmt "%s %s : %s"
                  (Cli.print_with_style [ ANSITerminal.blue ] "%s" "-->")
                  (Cli.print_with_style [ ANSITerminal.yellow ] "%s" (Bindlib.name_of v))
                  (print_z3model_expr ctx (VarMap.find v ctx.ctx_var) e)
-             else failwith "[Z3 model]: Printing of functions is not yet supported"))
+         end
+         else failwith "[Z3 model]: Printing of functions is not yet supported"))
     decls
 
 (** [translate_typ_lit] returns the Z3 sort corresponding to the Catala literal type [t] **)

--- a/tests/test_proof/bad/enums_unit-empty.catala_en
+++ b/tests/test_proof/bad/enums_unit-empty.catala_en
@@ -1,0 +1,20 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- Case1 content integer
+  -- Case2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals Case1 content 2
+  definition y under condition match x with pattern
+    -- Case1 of i : i > 0
+    -- Case2 : false consequence equals 2
+  definition y under condition match x with pattern
+    -- Case1 of i : false
+    -- Case2 : true consequence equals 2
+```

--- a/tests/test_proof/bad/enums_unit-overlap.catala_en
+++ b/tests/test_proof/bad/enums_unit-overlap.catala_en
@@ -1,0 +1,20 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- Case1 content integer
+  -- Case2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals Case1 content 2
+  definition y under condition match x with pattern
+    -- Case1 of i : true
+    -- Case2 : true consequence equals 2
+  definition y under condition match x with pattern
+    -- Case1 of i : false
+    -- Case2 : true consequence equals 2
+```

--- a/tests/test_proof/bad/output/enums_unit-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums_unit-empty.catala_en.Proof
@@ -1,0 +1,10 @@
+[ERROR] [A.y] This variable might return an empty error:
+  --> tests/test_proof/bad/enums_unit-empty.catala_en
+   | 
+10 |   context y content integer
+   |           ^
+   + Article
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/enums_unit-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums_unit-overlap.catala_en.Proof
@@ -1,0 +1,10 @@
+[RESULT] [A.y] This variable never returns an empty error
+[ERROR] [A.y] At least two exceptions overlap for this variable:
+  --> tests/test_proof/bad/enums_unit-overlap.catala_en
+   | 
+10 |   context y content integer
+   |           ^
+   + Article
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/good/enums_unit.catala_en
+++ b/tests/test_proof/good/enums_unit.catala_en
@@ -1,0 +1,20 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- Case1 content integer
+  -- Case2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals Case1 content 2
+  definition y under condition match x with pattern
+    -- Case1 of i : true
+    -- Case2 : false consequence equals 2
+  definition y under condition match x with pattern
+    -- Case1 of i : false
+    -- Case2 : true consequence equals 2
+```

--- a/tests/test_proof/good/output/enums_unit.catala_en.Proof
+++ b/tests/test_proof/good/output/enums_unit.catala_en.Proof
@@ -1,0 +1,4 @@
+[RESULT] [A.y] This variable never returns an empty error
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable


### PR DESCRIPTION
This PR adds Z3 encoding support for elements of type TUnit, which are generated as arguments of enumeration constructors that do not have any argument in Catala.
Values of type unit are encoded to Z3 as a tuple with 0 elements.
The unit value and type are generated once and for all when initializing the global context for simplicity, since it should be the same everywhere.
Simple unit tests for absence of errors, presence of an empty error and presence of an exception overlap were also added to tests/test_proof