### PR TITLE
Add support for rationals in Z3 encoding

### DIFF
--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -115,7 +115,7 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
        pretty-printing, we print nothing to remain closer from Catala sources *)
     | TUnit -> ""
     | TInt -> Expr.to_string e
-    | TRat -> Arithmetic.Real.to_decimal_string e 7
+    | TRat -> Arithmetic.Real.to_decimal_string e !Cli.max_prec_digits
     (* TODO: Print the right money symbol according to language *)
     | TMoney ->
         let z3_str = Expr.to_string e in

--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -407,16 +407,16 @@ let rec translate_op (ctx : context) (op : operator) (args : expr Pos.marked lis
           | And -> (ctx, Boolean.mk_and ctx.ctx_z3 [ e1; e2 ])
           | Or -> (ctx, Boolean.mk_or ctx.ctx_z3 [ e1; e2 ])
           | Xor -> (ctx, Boolean.mk_xor ctx.ctx_z3 e1 e2)
-          | Add KInt | Add KRat -> (ctx, Arithmetic.mk_add ctx.ctx_z3 [ e1; e2 ])
+          | Add KInt | Add KRat | Add KMoney -> (ctx, Arithmetic.mk_add ctx.ctx_z3 [ e1; e2 ])
           | Add _ ->
               failwith "[Z3 encoding] application of non-integer binary operator Add not supported"
-          | Sub KInt | Sub KRat -> (ctx, Arithmetic.mk_sub ctx.ctx_z3 [ e1; e2 ])
+          | Sub KInt | Sub KRat | Sub KMoney -> (ctx, Arithmetic.mk_sub ctx.ctx_z3 [ e1; e2 ])
           | Sub _ ->
               failwith "[Z3 encoding] application of non-integer binary operator Sub not supported"
-          | Mult KInt | Mult KRat -> (ctx, Arithmetic.mk_mul ctx.ctx_z3 [ e1; e2 ])
+          | Mult KInt | Mult KRat | Mult KMoney -> (ctx, Arithmetic.mk_mul ctx.ctx_z3 [ e1; e2 ])
           | Mult _ ->
               failwith "[Z3 encoding] application of non-integer binary operator Mult not supported"
-          | Div KInt | Div KRat -> (ctx, Arithmetic.mk_div ctx.ctx_z3 e1 e2)
+          | Div KInt | Div KRat | Div KMoney -> (ctx, Arithmetic.mk_div ctx.ctx_z3 e1 e2)
           | Div _ ->
               failwith "[Z3 encoding] application of non-integer binary operator Div not supported"
           | Lt KInt | Lt KRat | Lt KMoney | Lt KDate -> (ctx, Arithmetic.mk_lt ctx.ctx_z3 e1 e2)

--- a/compiler/verification/z3backend.ml
+++ b/compiler/verification/z3backend.ml
@@ -329,6 +329,9 @@ let find_or_create_funcdecl (ctx : context) (v : Var.t) : context * FuncDecl.fun
           let ctx = add_funcdecl v fd ctx in
           let ctx = add_z3var name v ctx in
           (ctx, fd)
+      | TAny ->
+          failwith
+            "[Z3 Encoding] A function being applied has type TAny, the type was not fully inferred"
       | _ ->
           failwith
             "[Z3 Encoding] Ill-formed VC, a function application does not have a function type")

--- a/tests/test_proof/bad/output/rationals-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/rationals-empty.catala_en.Proof
@@ -1,0 +1,10 @@
+[ERROR] [A.y] This variable might return an empty error:
+ --> tests/test_proof/bad/rationals-empty.catala_en
+  | 
+6 |   context y content boolean
+  |           ^
+  + Test
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/rationals-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/rationals-overlap.catala_en.Proof
@@ -1,0 +1,10 @@
+[RESULT] [A.y] This variable never returns an empty error
+[ERROR] [A.y] At least two exceptions overlap for this variable:
+ --> tests/test_proof/bad/rationals-overlap.catala_en
+  | 
+6 |   context y content boolean
+  |           ^
+  + Test
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/rationals-empty.catala_en
+++ b/tests/test_proof/bad/rationals-empty.catala_en
@@ -1,0 +1,11 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content decimal
+  context y content boolean
+
+scope A:
+  definition x equals 1.
+  definition y under condition x >. 1./.3. consequence equals true
+```

--- a/tests/test_proof/bad/rationals-overlap.catala_en
+++ b/tests/test_proof/bad/rationals-overlap.catala_en
@@ -1,0 +1,12 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content decimal
+  context y content boolean
+
+scope A:
+  definition x equals 1.
+  definition y under condition x >=. 1./.3. consequence equals true
+  definition y under condition x <=. 1./.3. consequence equals false
+```

--- a/tests/test_proof/good/output/rationals.catala_en.Proof
+++ b/tests/test_proof/good/output/rationals.catala_en.Proof
@@ -1,0 +1,4 @@
+[RESULT] [A.y] This variable never returns an empty error
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/good/rationals.catala_en
+++ b/tests/test_proof/good/rationals.catala_en
@@ -1,0 +1,12 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content decimal
+  context y content boolean
+
+scope A:
+  definition x equals 1.
+  definition y under condition x >. 1./.3. consequence equals true
+  definition y under condition x <=. 1./.3. consequence equals false
+```


### PR DESCRIPTION
This PR extends the current Z3 proof backend with support for rationals, encoded as Z3 reals. It also adds a few unit tests for this support.