### PR TITLE
Fix dune build -p catala @runtest

### DIFF
--- a/build_system/tests/dune
+++ b/build_system/tests/dune
@@ -1,3 +1,4 @@
 (tests
  (names test_clerk_driver)
- (libraries alcotest clerk.driver ninja_utils catala.utils))
+ (libraries alcotest clerk.driver ninja_utils catala.utils)
+ (package clerk))

--- a/catala.opam
+++ b/catala.opam
@@ -3,9 +3,8 @@ opam-version: "2.0"
 version: "0.6.0"
 synopsis:
   "Compiler and library for the literate programming language for tax code specification"
-description: """
-Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information
-"""
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
 maintainer: ["contact@catala-lang.org"]
 authors: [
   "Denis Merigoux"

--- a/clerk.opam
+++ b/clerk.opam
@@ -18,6 +18,7 @@ depends: [
   "ANSITerminal" {>= "0.8.2"}
   "alcotest" {with-test & >= "1.5.0"}
   "catala" {= version}
+  "ninja_utils" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -117,6 +117,8 @@
     :with-test
     (>= 1.5.0)))
   (catala
+   (= :version))
+  (ninja_utils
    (= :version))))
 
 (package

--- a/french_law.opam
+++ b/french_law.opam
@@ -2,9 +2,8 @@
 opam-version: "2.0"
 version: "0.6.0"
 synopsis: "A collection of algorithms and computations defined by French law"
-description: """
-This library contains the implementations of algorithmic portions of French law. The library source code was generated from Catala annotations of the
-   relevant portions of the French law, see https://catala-lang.org"""
+description:
+  "This library contains the implementations of algorithmic portions of French law. The library source code was generated from Catala annotations of the relevant portions of the French law, see https://catala-lang.org"
 maintainer: ["contact@catala-lang.org"]
 authors: ["Denis Merigoux"]
 license: "Apache-2.0"

--- a/ninja_utils.opam
+++ b/ninja_utils.opam
@@ -3,10 +3,8 @@ opam-version: "2.0"
 version: "0.6.0"
 synopsis:
   "A collection of utility functions used to generate Ninja build files"
-description: """
-This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently
-   used by the Catala build system (see
-                                     https://github.com/CatalaLang/catala/tree/master/build_system)"""
+description:
+  "This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)"
 maintainer: ["contact@catala-lang.org"]
 authors: ["Emile Rolley"]
 license: "Apache-2.0"


### PR DESCRIPTION
Fixes the failing build for the `@runtest` dune target used for the opam CI checks.