### PR TITLE
[Z3encoding] Basic support for arrays

### DIFF
--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -28,8 +28,7 @@ let extensions =
   [ (".catala_fr", "fr"); (".catala_en", "en"); (".catala_pl", "pl") ]
 
 (** Entry function for the executable. Returns a negative number in case of
-    error. Usage:
-    [driver source_file options]*)
+    error. Usage: [driver source_file options]*)
 let driver source_file (options : Cli.options) : int =
   try
     Cli.set_option_globals options;

--- a/compiler/verification/io.ml
+++ b/compiler/verification/io.ml
@@ -171,7 +171,7 @@ module MakeBackendIO (B : Backend) = struct
 
     match z3_vc with
     | Success (encoding, backend_ctx) -> (
-        Cli.debug_print "The translation to Z3 is the following:@\n%s"
+        Cli.debug_print "The translation to Z3 is the following:\n%s"
           (B.print_encoding encoding);
         match B.solve_vc_encoding backend_ctx encoding with
         | ProvenTrue -> Cli.result_print "%s" (print_positive_result vc)

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -196,7 +196,9 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
 
       Format.asprintf "%s (%s)" fd_name (print_z3model_expr ctx (snd case) e')
   | TArrow _ -> failwith "[Z3 model]: Pretty-printing of arrows not supported"
-  | TArray _ -> failwith "[Z3 model]: Pretty-printing of arrays not supported"
+  | TArray _ ->
+      (* For now, only the length of arrays are modeled *)
+      Format.asprintf "(length = %s)" (Expr.to_string e)
   | TAny -> failwith "[Z3 model]: Pretty-printing of Any not supported"
 
 (** [print_model] pretty prints a Z3 model, used to exhibit counter examples

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -197,7 +197,7 @@ let rec print_z3model_expr (ctx : context) (ty : typ Pos.marked) (e : Expr.expr)
       Format.asprintf "%s (%s)" fd_name (print_z3model_expr ctx (snd case) e')
   | TArrow _ -> failwith "[Z3 model]: Pretty-printing of arrows not supported"
   | TArray _ ->
-      (* For now, only the length of arrays are modeled *)
+      (* For now, only the length of arrays is modeled *)
       Format.asprintf "(length = %s)" (Expr.to_string e)
   | TAny -> failwith "[Z3 model]: Pretty-printing of Any not supported"
 

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -263,7 +263,10 @@ let rec translate_typ (ctx : context) (t : typ) : context * Sort.sort =
       failwith "[Z3 encoding] TTuple type of unnamed struct not supported"
   | TEnum (_, e) -> find_or_create_enum ctx e
   | TArrow _ -> failwith "[Z3 encoding] TArrow type not supported"
-  | TArray _ -> failwith "[Z3 encoding] TArray type not supported"
+  | TArray _ ->
+      (* For now, we are only encoding the (symbolic) length of an array.
+         Ultimately, the type of an array should also contain its elements *)
+      (ctx, Arithmetic.Integer.mk_sort ctx.ctx_z3)
   | TAny -> failwith "[Z3 encoding] TAny type not supported"
 
 (** [find_or_create_enum] attempts to retrieve the Z3 sort corresponding to the
@@ -594,8 +597,9 @@ let rec translate_op
       (* Omitting the log from the VC *)
       | Log _ -> (ctx, e1)
       | Length ->
-          failwith
-            "[Z3 encoding] application of unary operator Length not supported"
+          (* For now, an array is only its symbolic length. We simply return
+             it *)
+          (ctx, e1)
       | IntToRat ->
           failwith
             "[Z3 encoding] application of unary operator IntToRat not supported"

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -777,11 +777,12 @@ module Backend = struct
   let solve_vc_encoding (ctx : backend_context) (encoding : vc_encoding) :
       solver_result =
     let solver = Z3.Solver.mk_solver ctx.ctx_z3 None in
-    (* Add all the constraints stored in the context *)
-    let encoding =
-      Boolean.mk_and ctx.ctx_z3 (encoding :: ctx.ctx_z3constraints)
-    in
-    Z3.Solver.add solver [ Boolean.mk_not ctx.ctx_z3 encoding ];
+    (* We take the negation of the query to check for possible
+       counterexamples *)
+    let query = Boolean.mk_not ctx.ctx_z3 encoding in
+    (* Add all the hypotheses stored in the context *)
+    let query_and_hyps = query :: ctx.ctx_z3constraints in
+    Z3.Solver.add solver query_and_hyps;
     match Z3.Solver.check solver [] with
     | UNSATISFIABLE -> ProvenTrue
     | SATISFIABLE -> ProvenFalse (Z3.Solver.get_model solver)

--- a/tests/test_proof/bad/array_length-empty.catala_en
+++ b/tests/test_proof/bad/array_length-empty.catala_en
@@ -1,0 +1,11 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content collection integer
+  context y content boolean
+
+scope A:
+  definition x equals [0; 5]
+  definition y under condition (number of x) > 0 consequence equals true
+```

--- a/tests/test_proof/bad/array_length-overlap.catala_en
+++ b/tests/test_proof/bad/array_length-overlap.catala_en
@@ -1,0 +1,12 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content collection integer
+  context y content boolean
+
+scope A:
+  definition x equals [0; 5]
+  definition y under condition (number of x) >= 0 consequence equals true
+  definition y under condition (number of x) = 1 consequence equals false
+```

--- a/tests/test_proof/bad/output/array_length-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/array_length-empty.catala_en.Proof
@@ -1,0 +1,10 @@
+[ERROR] [A.y] This variable might return an empty error:
+ --> tests/test_proof/bad/array_length-empty.catala_en
+  | 
+6 |   context y content boolean
+  |           ^
+  + Test
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/array_length-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/array_length-overlap.catala_en.Proof
@@ -1,0 +1,10 @@
+[RESULT] [A.y] This variable never returns an empty error
+[ERROR] [A.y] At least two exceptions overlap for this variable:
+ --> tests/test_proof/bad/array_length-overlap.catala_en
+  | 
+6 |   context y content boolean
+  |           ^
+  + Test
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/good/array_length.catala_en
+++ b/tests/test_proof/good/array_length.catala_en
@@ -1,0 +1,12 @@
+## Test
+
+```catala
+declaration scope A:
+  context x content collection integer
+  context y content boolean
+
+scope A:
+  definition x equals [0; 5]
+  definition y under condition (number of x) > 0 consequence equals true
+  definition y under condition (number of x) = 0 consequence equals false
+```

--- a/tests/test_proof/good/output/array_length.catala_en.Proof
+++ b/tests/test_proof/good/output/array_length.catala_en.Proof
@@ -1,0 +1,4 @@
+[RESULT] [A.y] This variable never returns an empty error
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable


### PR DESCRIPTION
This PR adds a basic support for arrays in the proof platform.
At the moment, it only models the (symbolic) length of arrays, and does not consider its contents. This is apparently sufficient to reason about the current version of the "allocations_familiales".

The changes are the following:
* Model arrays as a symbolic integer in Z3, corresponding to their length
* Add support for the length operator
* Extend the Z3 backend context with a `ctx_z3constraints` field, which stores a list of hypotheses regarding the symbolic variables. These hypotheses are added to the Z3 query in the `solve_vc_encoding` function.
* When creating a new symbolic array, log that its length is positive as a context hypothesis
* Add support for pretty-printing array counterexamples
* Add three unit tests for array verification (both positive and negative)