### PR TITLE
Fix logging operator location for default justifications

### DIFF
--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -28,8 +28,7 @@ let extensions =
   [ (".catala_fr", "fr"); (".catala_en", "en"); (".catala_pl", "pl") ]
 
 (** Entry function for the executable. Returns a negative number in case of
-    error. Usage:
-    [driver source_file options]*)
+    error. Usage: [driver source_file options]*)
 let driver source_file (options : Cli.options) : int =
   try
     Cli.set_option_globals options;

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -179,10 +179,14 @@ let driver source_file (options : Cli.options) : int =
             | None -> (Format.std_formatter, fun _ -> ())
           in
           if Option.is_some options.ex_scope then
-            Format.fprintf fmt "%a\n" Scopelang.Print.format_scope
+            Format.fprintf fmt "%a\n"
+              (Scopelang.Print.format_scope ~debug:options.debug)
               ( scope_uid,
                 Scopelang.Ast.ScopeMap.find scope_uid prgm.program_scopes )
-          else Format.fprintf fmt "%a\n" Scopelang.Print.format_program prgm;
+          else
+            Format.fprintf fmt "%a\n"
+              (Scopelang.Print.format_program ~debug:options.debug)
+              prgm;
           at_end ();
           exit 0
         end;

--- a/compiler/scopelang/print.mli
+++ b/compiler/scopelang/print.mli
@@ -19,6 +19,21 @@ open Utils
 val format_var : Format.formatter -> Ast.Var.t -> unit
 val format_location : Format.formatter -> Ast.location -> unit
 val format_typ : Format.formatter -> Ast.typ Pos.marked -> unit
-val format_expr : Format.formatter -> Ast.expr Pos.marked -> unit
-val format_scope : Format.formatter -> Ast.ScopeName.t * Ast.scope_decl -> unit
-val format_program : Format.formatter -> Ast.program -> unit
+
+val format_expr :
+  ?debug:bool (** [true] for debug printing *) ->
+  Format.formatter ->
+  Ast.expr Pos.marked ->
+  unit
+
+val format_scope :
+  ?debug:bool (** [true] for debug printing *) ->
+  Format.formatter ->
+  Ast.ScopeName.t * Ast.scope_decl ->
+  unit
+
+val format_program :
+  ?debug:bool (** [true] for debug printing *) ->
+  Format.formatter ->
+  Ast.program ->
+  unit

--- a/compiler/scopelang/scope_to_dcalc.ml
+++ b/compiler/scopelang/scope_to_dcalc.ml
@@ -290,14 +290,10 @@ let rec translate_expr (ctx : ctx) (e : Ast.expr Pos.marked) :
             Dcalc.Ast.EAbs ((b, pos_binder), List.map (translate_typ ctx) typ))
           binder
     | EDefault (excepts, just, cons) ->
-        let just =
-          tag_with_log_entry (translate_expr ctx just)
-            Dcalc.Ast.PosRecordIfTrueBool []
-        in
         Bindlib.box_apply3
           (fun e j c -> Dcalc.Ast.EDefault (e, j, c))
           (Bindlib.box_list (List.map (translate_expr ctx) excepts))
-          just (translate_expr ctx cons)
+          (translate_expr ctx just) (translate_expr ctx cons)
     | ELocation (ScopeVar a) ->
         let v, _, _ = Ast.ScopeVarMap.find (Pos.unmark a) ctx.scope_vars in
         Bindlib.box_var v


### PR DESCRIPTION
## The problem

Since https://github.com/CatalaLang/catala/pull/159, the encoding for building the default tree from a set of rules + exceptions has changed. This change has broken an invariant used to insert logging calls recording the places where meaningful decisions about the values of variables were taken : every default justification in Scopelang no longer corresponds to a meaningful definition in the source code. This leads to misleading traces with the `-t` option.

## The solution 

The logging calls are now inserted in the Desugared to Scopelang translation. 