### PR TITLE
[Z3encoding] Extend support for enumerations

### DIFF
--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -374,7 +374,7 @@ let translate_lit (ctx : context) (l : lit) : Expr.expr =
   | LMoney m ->
       let z3_m = Runtime.integer_to_int (Runtime.money_to_cents m) in
       Arithmetic.Integer.mk_numeral_i ctx.ctx_z3 z3_m
-  | LUnit -> failwith "[Z3 encoding] LUnit literals not supported"
+  | LUnit -> snd ctx.ctx_z3unit
   (* Encoding a date as an integer corresponding to the number of days since Jan
      1, 1900 *)
   | LDate d -> Arithmetic.Integer.mk_numeral_i ctx.ctx_z3 (date_to_int d)

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -698,7 +698,15 @@ and translate_expr (ctx : context) (vc : expr Pos.marked) : context * Expr.expr
       let accessor = List.nth accessors idx in
       let ctx, s = translate_expr ctx s in
       (ctx, Expr.mk_app ctx.ctx_z3 accessor [ s ])
-  | EInj _ -> failwith "[Z3 encoding] EInj unsupported"
+  | EInj (e, idx, en, _tys) ->
+      (* This node corresponds to creating a value for the enumeration [en], by
+         calling the [idx]-th constructor of enum [en], with argument [e] *)
+      let ctx, z3_enum = find_or_create_enum ctx en in
+      let ctx, z3_arg = translate_expr ctx e in
+      let ctrs = Datatype.get_constructors z3_enum in
+      (* This should always succeed if the expression is well-typed in dcalc *)
+      let ctr = List.nth ctrs idx in
+      (ctx, Expr.mk_app ctx.ctx_z3 ctr [ z3_arg ])
   | EMatch (arg, arms, enum) ->
       let ctx, z3_enum = find_or_create_enum ctx enum in
       let ctx, z3_arg = translate_expr ctx arg in

--- a/tests/test_proof/bad/enums_inj-empty.catala_en
+++ b/tests/test_proof/bad/enums_inj-empty.catala_en
@@ -1,0 +1,15 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- C1
+  -- C2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals C1
+  definition y under condition x = C1 consequence equals 1
+```

--- a/tests/test_proof/bad/enums_inj-overlap.catala_en
+++ b/tests/test_proof/bad/enums_inj-overlap.catala_en
@@ -1,0 +1,17 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- C1
+  -- C2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals C1
+  definition y under condition x = C1 consequence equals 1
+  definition y under condition x = C2 consequence equals 2
+  definition y under condition x = C2 consequence equals 3
+```

--- a/tests/test_proof/bad/output/enums_inj-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums_inj-empty.catala_en.Proof
@@ -1,0 +1,10 @@
+[ERROR] [A.y] This variable might return an empty error:
+  --> tests/test_proof/bad/enums_inj-empty.catala_en
+   | 
+10 |   context y content integer
+   |           ^
+   + Article
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/bad/output/enums_inj-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums_inj-overlap.catala_en.Proof
@@ -1,0 +1,10 @@
+[RESULT] [A.y] This variable never returns an empty error
+[ERROR] [A.y] At least two exceptions overlap for this variable:
+  --> tests/test_proof/bad/enums_inj-overlap.catala_en
+   | 
+10 |   context y content integer
+   |           ^
+   + Article
+Counterexample generation is disabled so none was generated.
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable

--- a/tests/test_proof/good/enums_inj.catala_en
+++ b/tests/test_proof/good/enums_inj.catala_en
@@ -1,0 +1,16 @@
+## Article
+
+```catala
+declaration enumeration E:
+  -- C1
+  -- C2
+
+declaration scope A:
+  context x content E
+  context y content integer
+
+scope A:
+  definition x equals C1
+  definition y under condition x = C1 consequence equals 1
+  definition y under condition x = C2 consequence equals 2
+```

--- a/tests/test_proof/good/output/enums_inj.catala_en.Proof
+++ b/tests/test_proof/good/output/enums_inj.catala_en.Proof
@@ -1,0 +1,4 @@
+[RESULT] [A.y] This variable never returns an empty error
+[RESULT] [A.y] No two exceptions to ever overlap for this variable
+[RESULT] [A.x] This variable never returns an empty error
+[RESULT] [A.x] No two exceptions to ever overlap for this variable


### PR DESCRIPTION
This PR extends the support for enumerations in the proof platform by supporting the EInj node, used when creating an enum value by doing for instance `Métropole ()`. This support leverages previous work on array, and simply calls the Z3 constructor for the (previously created) Z3 datatype for the named enumeration.
The PR also adds a few unit tests for EInj.

With that, it seems that VCs for all variables in the allocations_familiales example can be handled when using the -O option of the Catala compiler.

Note, this PR builds on top of, and should thus be merged after, #228