### PR TITLE
refactor(latex): print warning messages for too long block lines

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ of the Catala programming language development.
 Building and running examples is done via Makefiles. Each example directory
 contains its own Makefile, which includes `Makefile.common.mk`. This common
 Makefiles defines a list of targets that call the Catala compiler with the
-right options. Each of these targers can be called from the root of the
+right options. Each of these targets can be called from the root of the
 repository with:
 
         make -C examples/<directory of example> <name of target>
@@ -44,7 +44,13 @@ file `examples/foo/foo.catala_en`) list.
 When invoking any of these targets, additional options to the Catala compiler
 can be passed using the `CATALA_OPTS` Makefile variable.
 
-> **Remark**: don't forget to run `make pygments` before generating LaTex or PDF files.
+ Important
+
+ : Before trying to generates LaTex or PDF files:
+   1. don't forget to run `make pygments`,
+   2. and you need to have the font
+      [Marianne](https://gouvfr.atlassian.net/wiki/spaces/DB/pages/223019527/Typographie+-+Typography)
+      installed in your machine.
 
 ## Testing examples
 


### PR DESCRIPTION
I found some nitpicks while trying the new latex generation introduced in https://github.com/CatalaLang/catala/commit/ad7fe6a21a6aaaecec0aa6b1d094a6545ee33b95 (very nice by the way).

Now, a warning message will be print for each block line exceeding 80 characters while compiling to the `Latex` backend. And the PR adds some information about the Marianne font in the `examples/README.md`.

## Screenshots

![example-warn-msg](https://user-images.githubusercontent.com/44124798/166160706-6703aa69-05ff-4647-9f55-2c91a3da8834.png)