### PR TITLE
Add a (very simple) syntax highlighting mode for Emacs

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,1 @@
-(dirs compiler french_law build_system)
+(dirs compiler french_law build_system syntax_highlighting)

--- a/syntax_highlighting/dune
+++ b/syntax_highlighting/dune
@@ -1,0 +1,7 @@
+(dirs emacs)
+
+(install
+ (files
+  (emacs/catala-mode.el as emacs/site-lisp/catala-mode.el))
+ (section share_root)
+ (package catala))

--- a/syntax_highlighting/emacs/catala-mode.el
+++ b/syntax_highlighting/emacs/catala-mode.el
@@ -1,0 +1,85 @@
+(defvar catala-code-mode-hook nil)
+
+(defun catala-set-syntax-table()
+  (let ((st (syntax-table)))
+    (modify-syntax-entry ?_ "w" st)
+    (modify-syntax-entry ?% "_" st)
+
+    (modify-syntax-entry ?- "." st)
+    (modify-syntax-entry ?\; "." st)
+    (modify-syntax-entry ?. "." st)
+    (modify-syntax-entry ?, "." st)
+    (modify-syntax-entry ?: "." st)
+
+    (modify-syntax-entry ?$ "_" st)
+    (modify-syntax-entry ?@ "_" st)
+    (modify-syntax-entry ?€ "_" st)
+    (modify-syntax-entry ?^ "_" st)
+))
+
+(define-generic-mode 'catala-mode-fr
+  '("#")
+  '("contexte" "entrée" "sortie" "interne"
+    "champ d'application" "si et seulement si" "dépend de" "déclaration" "inclus" "collection" "contenu" "optionnel" "structure" "énumération" "contexte" "entrée" "sortie" "interne" "règle" "sous condition" "condition" "donnée" "conséquence" "rempli" "égal à" "assertion" "définition" "état" "étiquette" "exception")
+  '(("\\<\\(selon\\|sous\s+forme\\|fixé\\|par\\|décroissante\\|croissante\\|varie\\|avec\\|on\s+a\\|dans\\|tel\s+que\\|existe\\|pour\\|tout\\|de\\|si\\|alors\\|sinon\\|initial\\)\\>" . font-lock-builtin-face)
+    ("\\<\\(|[0-9]\\+-[0-9]\\+-[0-9]\\+|\\)\\>" . font-lock-constant-face)
+    ("\\<\\(vrai\\|faux\\)\\>" . font-lock-constant-face)
+    ("\\<\\([0-9][0-9 ]*\\(,[0-9]*\\|\\)\\)\\>" . font-lock-constant-face)
+    ("\\(->\\|+.\\|+@\\|+^\\|+€\\|+\\|-.\\|-@\\|-^\\|-€\\|-\\|*.\\|*@\\|*^\\|*€\\|*\\|/.\\|/@\\|/^\\|/€\\|/\\|!\\|>.\\|>=.\\|<=.\\|<.\\|>@\\|>=@\\|<=@\\|<@\\|>€\\|>=€\\|<=€\\|<€\\|>^\\|>=^\\|<=^\\|<^\\|>\\|>=\\|<=\\|<\\|=\\)" . font-lock-keyword-face)
+    ("\\<\\(\\|non\\|ou\s+bien\\|ou\\|et\\|€\\|%\\|an\\|mois\\|jour\\)\\>" . font-lock-keyword-face)
+    ("\\<\\(entier\\|booléen\\|date\\|durée\\|argent\\|texte\\|décimal\\|décret\\|loi\\|nombre\\|somme\\)\\>" . font-lock-type-face)
+    ("\\<[a-zéèàâùîôêœç][a-zéèàâùîôêœçA-ZÉÈÀÂÙÎÔÊŒÇ0-9_']*\\>" . font-lock-variable-name-face)
+    ("\\<[A-ZÉÈÀÂÙÎÔÊŒÇ][a-zéèàâùîôêœçA-ZÉÈÀÂÙÎÔÊŒÇ0-9_']*\\>" . font-lock-function-name-face))
+  '("\\.catala_fr_raw$")
+  '(catala-set-syntax-table)
+  "A basic generic major mode for catala files (fr version)"
+)
+
+(define-generic-mode 'catala-mode-en
+  '("#")
+  '("context" "input" "output" "internal"
+    "scope" "depends on" "declaration" "includes" "collection" "content" "optional" "structure" "enumeration" "context" "input" "output" "internal" "rule" "under condition" "condition" "data" "consequence" "fulfilled" "equals" "assertion" "definition" "state" "label" "exception")
+  '(("\\<\\(match\\|with\s+pattern\\|fixed\\|by\\|decreasing\\|increasing\\|varies\\|with\\|we\s+have\\|in\\|such\s+that\\|exists\\|for\\|all\\|of\\|if\\|then\\|else\\|initial\\)\\>" . font-lock-builtin-face)
+    ("\\<\\(|[0-9]+-[0-9]+-[0-9]+|\\)\\>" . font-lock-constant-face)
+    ("\\<\\(true\\|false\\)\\>" . font-lock-constant-face)
+    ("\\<\\([0-9][0-9,]*\\(\\.[0-9]*\\|\\)\\)\\>" . font-lock-constant-face)
+    ("\\(->\\|+.\\|+@\\|+^\\|+$\\|+\\|-.\\|-@\\|-^\\|-$\\|-\\|*.\\|*@\\|*^\\|*$\\|*\\|/.\\|/@\\|/^\\|/$\\|/\\|!\\|>.\\|>=.\\|<=.\\|<.\\|>@\\|>=@\\|<=@\\|<@\\|>$\\|>=$\\|<=$\\|<$\\|>^\\|>=^\\|<=^\\|<^\\|>\\|>=\\|<=\\|<\\|=\\)" . font-lock-keyword-face)
+    ("\\<\\(not\\|or\\|xor\\|and\\|\\$\\|%\\|year\\|month\\|day\\)\\>" . font-lock-keyword-face)
+    ("\\<\\(integer\\|boolean\\|date\\|duration\\|money\\|text\\|decimal\\|number\\|sum\\)\\>" . font-lock-type-face)
+    ("\\<[a-zéèàâùîôêœç][a-zéèàâùîôêœçA-ZÉÈÀÂÙÎÔÊŒÇ0-9_']*\\>" . font-lock-variable-name-face)
+    ("\\<[A-ZÉÈÀÂÙÎÔÊŒÇ][a-zéèàâùîôêœçA-ZÉÈÀÂÙÎÔÊŒÇ0-9_']*\\>" . font-lock-function-name-face))
+  '("\\.catala_en_raw$")
+  '(catala-set-syntax-table)
+  "A basic generic major mode for catala files (en version)"
+)
+
+(defun catala-code-mode()
+  "Major mode for catala code (inside of ```catala blocks)"
+  (interactive)
+  (let* ((buf (window-buffer (minibuffer-selected-window)))
+         (name (buffer-file-name buf)))
+    (if (and name (string-match-p "\\.catala_fr" name))
+        (catala-mode-fr)
+      (catala-mode-en)))
+  (run-mode-hooks 'catala-code-mode-hook))
+
+(provide 'catala-code-mode)
+
+;;;###autoload
+(define-derived-mode catala-mode markdown-mode "Catala"
+  "Catala major mode based on markdown-mode"
+  (setq-local markdown-fontify-code-blocks-natively t)
+  (setq-local markdown-code-lang-modes
+   '(("catala-metadata" . catala-code-mode)
+     ("catala" . catala-code-mode))))
+
+(provide 'catala-mode)
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.catala_\\(fr\\|en\\|pl\\)" . catala-mode))
+
+;; To use, add the following lines to ~/.emacs (without the leading ';') :
+; (autoload 'catala-mode "catala-mode" "Catala major mode based on markdown-mode." t)
+; (add-to-list 'auto-mode-alist '("\\.catala_\\(fr\\|en\\|pl\\)" . catala-mode))
+;; You may additionally need the following if you don't already have any emacs setup in opam:
+; (add-to-list 'load-path (concat (string-trim (shell-command-to-string "opam var prefix")) "/share/emacs/site-lisp"))

--- a/syntax_highlighting/en/ace/mode-catala_en.js
+++ b/syntax_highlighting/en/ace/mode-catala_en.js
@@ -87,7 +87,7 @@ ace.define(
           },
           {
             token: "constant.numeric",
-            regex: "\\b([0-9]+(,[0.9]*|))\\b",
+            regex: "\\b([0-9]+(,[0-9]*|))\\b",
           },
           {
             token: "punctuation",

--- a/syntax_highlighting/en/atom/grammars/catala_en.cson
+++ b/syntax_highlighting/en/atom/grammars/catala_en.cson
@@ -137,7 +137,7 @@
         'name' : 'constant.catala_en'
       }
       {
-        'match' : '\\b([0-9]+(,[0.9]*|))\\b'
+        'match' : '\\b([0-9]+(,[0-9]*|))\\b'
         'name' : 'constant.numeric.catala_en'
       }
       {

--- a/syntax_highlighting/en/catala_en.iro
+++ b/syntax_highlighting/en/catala_en.iro
@@ -219,7 +219,7 @@ code : context {
 
 
   : pattern {
-    regex \= \b([0-9]+(,[0.9]*|))\b
+    regex \= \b([0-9]+(,[0-9]*|))\b
     styles [] = .literal_numeric ;
   }
 

--- a/syntax_highlighting/en/pygments/catala_en_lexer/lexer.py
+++ b/syntax_highlighting/en/pygments/catala_en_lexer/lexer.py
@@ -33,7 +33,7 @@ class CatalaEnLexer(RegexLexer):
              bygroups(Keyword.Declaration)),
             (u'(\\|[0-9]+\\-[0-9]+\\-[0-9]+\\|)', bygroups(Number.Integer)),
             (u'\\b(true|false)\\b', bygroups(Keyword.Constant)),
-            (u'\\b([0-9]+(,[0.9]*|))\\b', bygroups(Number.Integer)),
+            (u'\\b([0-9]+(,[0-9]*|))\\b', bygroups(Number.Integer)),
             (u'(\\-\\-|\\;|\\.|\\,|\\:|\\(|\\)|\\[|\\]|\\{|\\})',
              bygroups(Operator)),
             (u'(\\-\\>|\\+\\.|\\+\\@|\\+\\^|\\+\\$|\\+|\\-\\.|\\-\\@|\\-\\^|\\-\\$|\\-|\\*\\.|\\*\\@|\\*\\^|\\*\\$|\\*|/\\.|/\\@|/\\^|/\\$|/|\\!|>\\.|>=\\.|<=\\.|<\\.|>\\@|>=\\@|<=\\@|<\\@|>\\$|>=\\$|<=\\$|<\\$|>\\^|>=\\^|<=\\^|<\\^|>|>=|<=|<|=|not|or|xor|and|\\$|%|year|month|day)',

--- a/syntax_highlighting/en/vscode/syntaxes/catalavs.xml
+++ b/syntax_highlighting/en/vscode/syntaxes/catalavs.xml
@@ -218,7 +218,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b([0-9]+(,[0.9]*|))\b</string>
+          <string>\b([0-9]+(,[0-9]*|))\b</string>
           <key>name</key>
           <string>constant.numeric.catala_en</string>
         </dict>

--- a/syntax_highlighting/fr/ace/mode-catala_fr.js
+++ b/syntax_highlighting/fr/ace/mode-catala_fr.js
@@ -87,7 +87,7 @@ ace.define(
           },
           {
             token: "constant.numeric",
-            regex: "\\b([0-9]+(,[0.9]*|))\\b",
+            regex: "\\b([0-9]+(,[0-9]*|))\\b",
           },
           {
             token: "punctuation",

--- a/syntax_highlighting/fr/atom/grammars/catala_fr.cson
+++ b/syntax_highlighting/fr/atom/grammars/catala_fr.cson
@@ -137,7 +137,7 @@
         'name' : 'constant.catala_fr'
       }
       {
-        'match' : '\\b([0-9]+(,[0.9]*|))\\b'
+        'match' : '\\b([0-9]+(,[0-9]*|))\\b'
         'name' : 'constant.numeric.catala_fr'
       }
       {

--- a/syntax_highlighting/fr/catala_fr.iro
+++ b/syntax_highlighting/fr/catala_fr.iro
@@ -219,7 +219,7 @@ code : context {
 
 
   : pattern {
-    regex \= \b([0-9]+(,[0.9]*|))\b
+    regex \= \b([0-9]+(,[0-9]*|))\b
     styles [] = .literal_numeric ;
   }
 

--- a/syntax_highlighting/fr/pygments/catala_fr_lexer/lexer.py
+++ b/syntax_highlighting/fr/pygments/catala_fr_lexer/lexer.py
@@ -34,7 +34,7 @@ class CatalaFrLexer(RegexLexer):
              bygroups(Keyword.Declaration)),
             (u'(\\|[0-9]+\\-[0-9]+\\-[0-9]+\\|)', bygroups(Number.Integer)),
             (u'\\b(vrai|faux)\\b', bygroups(Keyword.Constant)),
-            (u'\\b([0-9]+(,[0.9]*|))\\b', bygroups(Number.Integer)),
+            (u'\\b([0-9]+(,[0-9]*|))\\b', bygroups(Number.Integer)),
             (u'(\\-\\-|\\;|\\.|\\,|\\:|\\(|\\)|\\[|\\]|\\{|\\})',
              bygroups(Operator)),
             (u'(\\-\\>|\\+\\.|\\+\\@|\\+\\^|\\+\u20ac|\\+|\\-\\.|\\-\\@|\\-\\^|\\-\u20ac|\\-|\\*\\.|\\*\\@|\\*\\^|\\*\u20ac|\\*|/\\.|/\\@|/\\^|/\u20ac|/|\\!|>\\.|>=\\.|<=\\.|<\\.|>\\@|>=\\@|<=\\@|<\\@|>\u20ac|>=\u20ac|<=\u20ac|<\u20ac|>\\^|>=\\^|<=\\^|<\\^|>|>=|<=|<|=|non|ou\\s+bien|ou|et|\u20ac|%|an|mois|jour)',

--- a/syntax_highlighting/fr/vscode/syntaxes/catalavs.xml
+++ b/syntax_highlighting/fr/vscode/syntaxes/catalavs.xml
@@ -218,7 +218,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\b([0-9]+(,[0.9]*|))\b</string>
+          <string>\b([0-9]+(,[0-9]*|))\b</string>
           <key>name</key>
           <string>constant.numeric.catala_fr</string>
         </dict>

--- a/syntax_highlighting/pl/atom/grammars/catala_pl.cson
+++ b/syntax_highlighting/pl/atom/grammars/catala_pl.cson
@@ -107,7 +107,7 @@
         'name' : 'constant.catala_pl'
       }
       {
-        'match' : '\\b([0-9]+(,[0.9]*|))\\b'
+        'match' : '\\b([0-9]+(,[0-9]*|))\\b'
         'name' : 'constant.numeric.catala_pl'
       }
       {

--- a/syntax_highlighting/pl/catala_pl.iro
+++ b/syntax_highlighting/pl/catala_pl.iro
@@ -219,7 +219,7 @@ code : context {
 
 
   : pattern {
-    regex \= \b([0-9]+(,[0.9]*|))\b
+    regex \= \b([0-9]+(,[0-9]*|))\b
     styles [] = .literal_numeric ;
   }
 

--- a/syntax_highlighting/pl/pygments/catala_pl_lexer/lexer.py
+++ b/syntax_highlighting/pl/pygments/catala_pl_lexer/lexer.py
@@ -29,7 +29,7 @@ class CatalaPlLexer(RegexLexer):
             (u'\\b(zakres|zalezy\\s+od|deklaracja|kolekcja|typu|opcjonalny|struktura|enumeracja|kontekst|wej\u015bcie|wyj\u015bcie|wewn\u0119trzny|zasada|pod\\s+warunkuem|czas|konsekwencja|spelnione|wynosi|asercja|definicja|stan|etykieta|wyj\u0105tek|cokolwiek)\\b', bygroups(Keyword.Declaration)),
             (u'(\\|[0-9]+\\-[0-9]+\\-[0-9]+\\|)', bygroups(Number.Integer)),
             (u'\\b(prawda|falsz)\\b', bygroups(Keyword.Constant)),
-            (u'\\b([0-9]+(,[0.9]*|))\\b', bygroups(Number.Integer)),
+            (u'\\b([0-9]+(,[0-9]*|))\\b', bygroups(Number.Integer)),
             (u'(\\-\\-|\\;|\\.|\\,|\\:|\\(|\\)|\\[|\\]|\\{|\\})', bygroups(Operator)),
             (u'(\\-\\>|\\+\\.|\\+\\@|\\+\\^|\\+\\$|\\+|\\-\\.|\\-\\@|\\-\\^|\\-\\$|\\-|\\*\\.|\\*\\@|\\*\\^|\\*\\$|\\*|/\\.|/\\@|/\\^|/\\$|/|\\!|>\\.|>=\\.|<=\\.|<\\.|>\\@|>=\\@|<=\\@|<\\@|>\\$|>=\\$|<=\\$|<\\$|>\\^|>=\\^|<=\\^|<\\^|>|>=|<=|<|=|nie|lub|xor|i|\\$|%|rok|miesiac|dzien)', bygroups(Operator)),
             (u'\\b(calkowita|zerojedynkowy|czas|czas trwania|pieniądze|warunek|tekst|dziesi\u0119tny|suma)\\b', bygroups(Keyword.Type)),


### PR DESCRIPTION
Also fixes a typo in the .iro specifications