### PR TITLE
Refactor: add wrappers for file formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ catala.html: $(COMPILER_DIR)/utils/cli.ml
 	| tac | sed "1,20d" | tac > $@
 
 #> website-assets				: Builds all the assets necessary for the Catala website
-website-assets: doc literate_examples grammar.html catala.html build_french_law_library_js
+website-assets: doc js_build literate_examples grammar.html catala.html build_french_law_library_js
 
 ##########################################
 # Misceallenous

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -767,12 +767,10 @@ let driver
       return_ok
     else
       try
-        let out = open_out ninja_output in
-        Cli.debug_print "writing %s..." ninja_output;
-        Nj.format
-          (Format.formatter_of_out_channel out)
-          (add_root_test_build ninja ctx.all_file_names ctx.all_test_builds);
-        close_out out;
+        File.with_formatter_of_file ninja_output (fun fmt ->
+            Cli.debug_print "writing %s..." ninja_output;
+            Nj.format fmt
+              (add_root_test_build ninja ctx.all_file_names ctx.all_test_builds));
         let ninja_cmd = "ninja " ^ ninja_flags ^ " test -f " ^ ninja_output in
         Cli.debug_print "executing '%s'..." ninja_cmd;
         Sys.command ninja_cmd
@@ -790,9 +788,9 @@ let driver
       if 0 <> res then return_err else return_ok
     | None ->
       Cli.error_print "Please provide a scope to run with the -s option";
-      1)
+      return_err)
   | _ ->
     Cli.error_print "The command \"%s\" is unknown to clerk." command;
-    1
+    return_err
 
 let main () = exit (Cmdliner.Cmd.eval' (Cmdliner.Cmd.v info (clerk_t driver)))

--- a/compiler/utils/file.ml
+++ b/compiler/utils/file.ml
@@ -1,0 +1,37 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
+   Emile Rolley <emile.rolley@tuta.io>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+let with_formatter_of_out_channel oc f =
+  let fmt = Format.formatter_of_out_channel oc in
+  match f fmt with
+  | exception e ->
+    let bt = Printexc.get_raw_backtrace () in
+    Format.pp_print_flush fmt ();
+    Printexc.raise_with_backtrace e bt
+  | res ->
+    Format.pp_print_flush fmt ();
+    res
+
+let with_formatter_of_file filename f =
+  let oc = open_out filename in
+  let res = with_formatter_of_out_channel oc f in
+  close_out oc;
+  res
+
+let with_formatter_of_opt_file filename_opt f =
+  match filename_opt with
+  | None -> f Format.std_formatter
+  | Some filename -> with_formatter_of_file filename f

--- a/compiler/utils/file.mli
+++ b/compiler/utils/file.mli
@@ -1,0 +1,34 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
+   Emile Rolley <emile.rolley@tuta.io>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+(** Utility functions used for file manipulation. *)
+
+(** {2 Formatter wrappers} *)
+
+val with_formatter_of_out_channel :
+  out_channel -> (Format.formatter -> 'a) -> 'a
+(** [with_formatter_of_out_channel oc f] creates an flushes the formatter used
+    in [f] from the given out_channel [oc]. *)
+
+val with_formatter_of_file : string -> (Format.formatter -> 'a) -> 'a
+(** [with_formatter_of_file filename f] manages the formatter created from the
+    file [filename] used in [f] -- i.e. closes the corresponding out_channel and
+    flushes the formatter. *)
+
+val with_formatter_of_opt_file : string option -> (Format.formatter -> 'a) -> 'a
+(** [with_formatter_of_opt_file filename_opt f] manages the formatter created
+    from the file [filename_opt] if there is some (see
+    {!with_formatter_of_file}), otherwise, uses the [Format.std_formatter]. *)

--- a/compiler/utils/utils.mld
+++ b/compiler/utils/utils.mld
@@ -24,9 +24,7 @@ Related modules:
 
 {!modules: Utils.Pos}
 
-
 {1 Error messages}
-
 
 Error handling is critical in a compiler. The Catala compiler uses an architecture
 of error messages inspired by the Rust compiler, where error messages all
@@ -38,3 +36,9 @@ Hence, all error thrown by the compiler should use {!module: Utils.Errors}
 Related modules:
 
 {!modules: Utils.Errors}
+
+{1 File utilities}
+
+Related modules:
+
+{!modules: Utils.File}


### PR DESCRIPTION
Quick refactoring using wrappers around file formatters.

## Changelog

* Adds the missing `js_build` for the `website-assets` Makefile rule.
* Adds new files: `compiler/utils/file.ml*`.
* Refactors call of `Format.formatter_of_out_channel oc` with `Utils.File.with_...` functions.