### PR TITLE
Change dune rule to build tests only for catala

### DIFF
--- a/dune
+++ b/dune
@@ -8,6 +8,7 @@
 
 (rule
  (alias runtest)
+ (package catala)
  (deps
   (source_tree tests))
  (action
@@ -15,6 +16,7 @@
 
 (rule
  (alias runtest)
+ (package catala)
  (deps
   (source_tree examples))
  (action


### PR DESCRIPTION
[30297b27b87ba87ed8dc9ab10787bd1876a0ce6b](https://github.com/CatalaLang/catala/commit/30297b27b87ba87ed8dc9ab10787bd1876a0ce6b) added dune runtests, but those are called too when building clerk or ninja-utils, making a circular dependency between ninja-utils and catala.

this pull request add (package catala) to only run the created runtest when building catala