### PR TITLE
fix(compiler): fix line num for HTML generation

### DIFF
--- a/compiler/literate/html.ml
+++ b/compiler/literate/html.ml
@@ -141,7 +141,7 @@ let pygmentize_code (c : string Pos.marked) (language : C.backend_lang) : string
       "style=colorful,anchorlinenos=True,lineanchors=\""
       ^ Pos.get_file (Pos.get_position c)
       ^ "\",linenos=table,linenostart="
-      ^ string_of_int (Pos.get_start_line (Pos.get_position c));
+      ^ string_of_int (Pos.get_start_line (Pos.get_position c) - 1);
       "-o";
       temp_file_out;
       temp_file_in;


### PR DESCRIPTION
Fix line numbering for the Html backend.

Catala code block delimiters are removed after the pygmentization and this must be taken into account for the line numbering.

https://github.com/CatalaLang/catala/blob/1f4e869c33dfc1a8f0b7cf892b7a47d340429f30/compiler/literate/html.ml#L154-L162