### PR TITLE
Rationalise the tuple / enum types

### DIFF
--- a/compiler/dcalc/ast.ml
+++ b/compiler/dcalc/ast.ml
@@ -15,7 +15,6 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-open Utils
 open Shared_ast
 
 type lit = dcalc glit

--- a/compiler/dcalc/ast.mli
+++ b/compiler/dcalc/ast.mli
@@ -17,7 +17,6 @@
 
 (** Abstract syntax tree of the default calculus intermediate representation *)
 
-open Utils
 open Shared_ast
 
 type lit = dcalc glit

--- a/compiler/dcalc/interpreter.ml
+++ b/compiler/dcalc/interpreter.ml
@@ -488,15 +488,16 @@ let interpret_program :
  fun (ctx : decl_ctx) (e : 'm Ast.marked_expr) :
      (Uid.MarkedString.info * 'm Ast.marked_expr) list ->
   match evaluate_expr ctx e with
-  | EAbs (_, [((TTuple (taus, Some s_in), _) as targs)]), mark_e -> begin
+  | EAbs (_, [((TStruct s_in, _) as targs)]), mark_e -> begin
     (* At this point, the interpreter seeks to execute the scope but does not
        have a way to retrieve input values from the command line. [taus] contain
-       the types of the scope arguments. For [context] arguments, we cann
-       provide an empty thunked term. But for [input] arguments of another type,
-       we cannot provide anything so we have to fail. *)
+       the types of the scope arguments. For [context] arguments, we can provide
+       an empty thunked term. But for [input] arguments of another type, we
+       cannot provide anything so we have to fail. *)
+    let taus = StructMap.find s_in ctx.ctx_structs in
     let application_term =
       List.map
-        (fun ty ->
+        (fun (_, ty) ->
           match Marked.unmark ty with
           | TArrow ((TLit TUnit, _), ty_in) ->
             Expr.empty_thunked_term

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -126,14 +126,14 @@ let rec translate_typ (tau : typ Marked.pos) : typ Marked.pos =
     begin
       match Marked.unmark tau with
       | TLit l -> TLit l
-      | TTuple (ts, s) -> TTuple (List.map translate_typ ts, s)
-      | TEnum (ts, en) -> TEnum (List.map translate_typ ts, en)
+      | TTuple ts -> TTuple (List.map translate_typ ts)
+      | TStruct s -> TStruct s
+      | TEnum en -> TEnum en
+      | TOption t -> TOption t
       | TAny -> TAny
       | TArray ts -> TArray (translate_typ ts)
       (* catala is not polymorphic *)
-      | TArrow ((TLit TUnit, pos_unit), t2) ->
-        TEnum ([TLit TUnit, pos_unit; translate_typ t2], A.option_enum)
-        (* TAny *)
+      | TArrow ((TLit TUnit, _), t2) -> TOption (translate_typ t2)
       | TArrow (t1, t2) -> TArrow (translate_typ t1, translate_typ t2)
     end
 

--- a/compiler/scalc/compile_from_lambda.ml
+++ b/compiler/scalc/compile_from_lambda.ml
@@ -366,15 +366,7 @@ let translate_program (p : 'm L.program) : A.program =
                      A.func_params =
                        [
                          ( (scope_input_var_id, input_pos),
-                           ( TTuple
-                               ( List.map snd
-                                   (StructMap.find
-                                      scope_def.scope_body
-                                        .scope_body_input_struct
-                                      p.decl_ctx.ctx_structs),
-                                 Some
-                                   scope_def.scope_body.scope_body_input_struct
-                               ),
+                           ( TStruct scope_def.scope_body.scope_body_input_struct,
                              input_pos ) );
                        ];
                      A.func_body = new_scope_body;

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -161,17 +161,17 @@ let rec format_typ (fmt : Format.formatter) (typ : typ Marked.pos) : unit =
   | TLit TDate -> Format.fprintf fmt "Date"
   | TLit TDuration -> Format.fprintf fmt "Duration"
   | TLit TBool -> Format.fprintf fmt "bool"
-  | TTuple (ts, None) ->
+  | TTuple ts ->
     Format.fprintf fmt "Tuple[%a]"
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt ", ")
          (fun fmt t -> Format.fprintf fmt "%a" format_typ_with_parens t))
       ts
-  | TTuple (_, Some s) -> Format.fprintf fmt "%a" format_struct_name s
-  | TEnum ([_; some_typ], e) when EnumName.compare e L.option_enum = 0 ->
+  | TStruct s -> Format.fprintf fmt "%a" format_struct_name s
+  | TOption some_typ ->
     (* We translate the option type with an overloading by Python's [None] *)
     Format.fprintf fmt "Optional[%a]" format_typ some_typ
-  | TEnum (_, e) -> Format.fprintf fmt "%a" format_enum_name e
+  | TEnum e -> Format.fprintf fmt "%a" format_enum_name e
   | TArrow (t1, t2) ->
     Format.fprintf fmt "Callable[[%a], %a]" format_typ_with_parens t1
       format_typ_with_parens t2

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -54,8 +54,10 @@ type marked_typ = typ Marked.pos
 
 and typ =
   | TLit of typ_lit
-  | TTuple of marked_typ list * StructName.t option
-  | TEnum of marked_typ list * EnumName.t
+  | TTuple of marked_typ list
+  | TStruct of StructName.t
+  | TEnum of EnumName.t
+  | TOption of marked_typ
   | TArrow of marked_typ * marked_typ
   | TArray of marked_typ
   | TAny

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -72,13 +72,13 @@ let rec typ (ctx : decl_ctx) (fmt : Format.formatter) (ty : typ) : unit =
   in
   match ty with
   | TLit l -> tlit fmt l
-  | TTuple (ts, None) ->
+  | TTuple ts ->
     Format.fprintf fmt "@[<hov 2>(%a)@]"
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ %a@ " operator "*")
          (fun fmt t -> Format.fprintf fmt "%a" typ t))
       (List.map Marked.unmark ts)
-  | TTuple (_args, Some s) ->
+  | TStruct s ->
     Format.fprintf fmt "@[<hov 2>%a%a%a%a@]" StructName.format_t s punctuation
       "{"
       (Format.pp_print_list
@@ -89,7 +89,7 @@ let rec typ (ctx : decl_ctx) (fmt : Format.formatter) (ty : typ) : unit =
              (Marked.unmark mty)))
       (StructMap.find s ctx.ctx_structs)
       punctuation "}"
-  | TEnum (_, e) ->
+  | TEnum e ->
     Format.fprintf fmt "@[<hov 2>%a%a%a%a@]" EnumName.format_t e punctuation "["
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ %a@ " punctuation "|")
@@ -98,6 +98,9 @@ let rec typ (ctx : decl_ctx) (fmt : Format.formatter) (ty : typ) : unit =
              typ (Marked.unmark mty)))
       (EnumMap.find e ctx.ctx_enums)
       punctuation "]"
+  | TOption t ->
+    Format.fprintf fmt "@[<hov 2>%a@ %a@]" base_type "option" typ
+      (Marked.unmark t)
   | TArrow (t1, t2) ->
     Format.fprintf fmt "@[<hov 2>%a %a@ %a@]" typ_with_parens (Marked.unmark t1)
       operator "→" typ (Marked.unmark t2)


### PR DESCRIPTION
This will allow to unify with types used earlier in the
pipeline (`Scopelang.Ast.typ`).

It seems cleaner! But some areas may warrant a later clean-up, in particular
handling of options and their types in the backends, or possible name conflicts
of structs/enums with built-in types when printing.