### PR TITLE
Rename lots of types

### DIFF
--- a/compiler/dcalc/ast.ml
+++ b/compiler/dcalc/ast.ml
@@ -22,4 +22,4 @@ type lit = dcalc glit
 type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
 and 'm expr = (dcalc, 'm mark) gexpr
 
-type 'm program = 'm naked_expr Shared_ast.program
+type 'm program = 'm expr Shared_ast.program

--- a/compiler/dcalc/ast.ml
+++ b/compiler/dcalc/ast.ml
@@ -19,7 +19,7 @@ open Shared_ast
 
 type lit = dcalc glit
 
-type 'm expr = (dcalc, 'm mark) gexpr
-and 'm marked_expr = (dcalc, 'm mark) marked_gexpr
+type 'm expr = (dcalc, 'm mark) naked_gexpr
+and 'm marked_expr = (dcalc, 'm mark) gexpr
 
 type 'm program = 'm expr Shared_ast.program

--- a/compiler/dcalc/ast.ml
+++ b/compiler/dcalc/ast.ml
@@ -19,7 +19,7 @@ open Shared_ast
 
 type lit = dcalc glit
 
-type 'm expr = (dcalc, 'm mark) naked_gexpr
-and 'm marked_expr = (dcalc, 'm mark) gexpr
+type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
+and 'm expr = (dcalc, 'm mark) gexpr
 
-type 'm program = 'm expr Shared_ast.program
+type 'm program = 'm naked_expr Shared_ast.program

--- a/compiler/dcalc/ast.mli
+++ b/compiler/dcalc/ast.mli
@@ -20,8 +20,5 @@
 open Shared_ast
 
 type lit = dcalc glit
-
-type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
-and 'm expr = (dcalc, 'm mark) gexpr
-
-type 'm program = 'm naked_expr Shared_ast.program
+type 'm expr = (dcalc, 'm mark) gexpr
+type 'm program = 'm expr Shared_ast.program

--- a/compiler/dcalc/ast.mli
+++ b/compiler/dcalc/ast.mli
@@ -21,7 +21,7 @@ open Shared_ast
 
 type lit = dcalc glit
 
-type 'm expr = (dcalc, 'm mark) naked_gexpr
-and 'm marked_expr = (dcalc, 'm mark) gexpr
+type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
+and 'm expr = (dcalc, 'm mark) gexpr
 
-type 'm program = 'm expr Shared_ast.program
+type 'm program = 'm naked_expr Shared_ast.program

--- a/compiler/dcalc/ast.mli
+++ b/compiler/dcalc/ast.mli
@@ -21,7 +21,7 @@ open Shared_ast
 
 type lit = dcalc glit
 
-type 'm expr = (dcalc, 'm mark) gexpr
-and 'm marked_expr = (dcalc, 'm mark) marked_gexpr
+type 'm expr = (dcalc, 'm mark) naked_gexpr
+and 'm marked_expr = (dcalc, 'm mark) gexpr
 
 type 'm program = 'm expr Shared_ast.program

--- a/compiler/dcalc/interpreter.mli
+++ b/compiler/dcalc/interpreter.mli
@@ -23,9 +23,7 @@ val evaluate_expr : decl_ctx -> 'm Ast.expr -> 'm Ast.expr
 (** Evaluates an expression according to the semantics of the default calculus. *)
 
 val interpret_program :
-  decl_ctx ->
-  'm Ast.expr ->
-  (Uid.MarkedString.info * 'm Ast.expr) list
+  decl_ctx -> 'm Ast.expr -> (Uid.MarkedString.info * 'm Ast.expr) list
 (** Interprets a program. This function expects an expression typed as a
     function whose argument are all thunked. The function is executed by
     providing for each argument a thunked empty default. Returns a list of all

--- a/compiler/dcalc/interpreter.mli
+++ b/compiler/dcalc/interpreter.mli
@@ -19,13 +19,13 @@
 open Utils
 open Shared_ast
 
-val evaluate_expr : decl_ctx -> 'm Ast.marked_expr -> 'm Ast.marked_expr
+val evaluate_expr : decl_ctx -> 'm Ast.expr -> 'm Ast.expr
 (** Evaluates an expression according to the semantics of the default calculus. *)
 
 val interpret_program :
   decl_ctx ->
-  'm Ast.marked_expr ->
-  (Uid.MarkedString.info * 'm Ast.marked_expr) list
+  'm Ast.expr ->
+  (Uid.MarkedString.info * 'm Ast.expr) list
 (** Interprets a program. This function expects an expression typed as a
     function whose argument are all thunked. The function is executed by
     providing for each argument a thunked empty default. Returns a list of all

--- a/compiler/dcalc/optimizations.ml
+++ b/compiler/dcalc/optimizations.ml
@@ -19,7 +19,7 @@ open Shared_ast
 open Ast
 
 type partial_evaluation_ctx = {
-  var_values : (typed naked_expr, typed expr) Var.Map.t;
+  var_values : (typed expr, typed expr) Var.Map.t;
   decl_ctx : decl_ctx;
 }
 
@@ -190,8 +190,8 @@ let optimize_expr (decl_ctx : decl_ctx) (e : 'm expr) =
 let rec scope_lets_map
     (t : 'a -> 'm expr -> 'm expr Bindlib.box)
     (ctx : 'a)
-    (scope_body_expr : 'm naked_expr scope_body_expr) :
-    'm naked_expr scope_body_expr Bindlib.box =
+    (scope_body_expr : 'm expr scope_body_expr) :
+    'm expr scope_body_expr Bindlib.box =
   match scope_body_expr with
   | Result e -> Bindlib.box_apply (fun e' -> Result e') (t ctx e)
   | ScopeLet scope_let ->
@@ -212,7 +212,7 @@ let rec scope_lets_map
 let rec scopes_map
     (t : 'a -> 'm expr -> 'm expr Bindlib.box)
     (ctx : 'a)
-    (scopes : 'm naked_expr scopes) : 'm naked_expr scopes Bindlib.box =
+    (scopes : 'm expr scopes) : 'm expr scopes Bindlib.box =
   match scopes with
   | Nil -> Bindlib.box Nil
   | ScopeDef scope_def ->

--- a/compiler/dcalc/optimizations.mli
+++ b/compiler/dcalc/optimizations.mli
@@ -20,5 +20,5 @@
 open Shared_ast
 open Ast
 
-val optimize_expr : decl_ctx -> 'm marked_expr -> 'm marked_expr Bindlib.box
+val optimize_expr : decl_ctx -> 'm expr -> 'm expr Bindlib.box
 val optimize_program : 'm program -> untyped program

--- a/compiler/dcalc/typing.ml
+++ b/compiler/dcalc/typing.ml
@@ -120,7 +120,7 @@ type mark = { pos : Pos.t; uf : unionfind_typ }
 (** Raises an error if unification cannot be performed *)
 let rec unify
     (ctx : A.decl_ctx)
-    (e : ('a, 'm A.mark) A.marked_gexpr) (* used for error context *)
+    (e : ('a, 'm A.mark) A.gexpr) (* used for error context *)
     (t1 : typ Marked.pos UnionFind.elem)
     (t2 : typ Marked.pos UnionFind.elem) : unit =
   let unify = unify ctx in
@@ -307,11 +307,11 @@ let box_ty e = Bindlib.unbox (Bindlib.box_apply ty e)
 let rec typecheck_expr_bottom_up
     (ctx : A.decl_ctx)
     (env : 'm Ast.expr env)
-    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.marked_gexpr Bindlib.box =
+    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
   (* Cli.debug_format "Looking for type of %a" (Expr.format ~debug:true ctx)
      e; *)
   let pos_e = A.Expr.pos e in
-  let mark (e : (A.dcalc, mark) A.gexpr) uf =
+  let mark (e : (A.dcalc, mark) A.naked_gexpr) uf =
     Marked.mark { uf; pos = pos_e } e
   in
   let unionfind_make ?(pos = e) t = UnionFind.make (add_pos pos t) in
@@ -471,12 +471,12 @@ and typecheck_expr_top_down
     (ctx : A.decl_ctx)
     (env : 'm Ast.expr env)
     (tau : typ Marked.pos UnionFind.elem)
-    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.marked_gexpr Bindlib.box =
+    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
   (* Cli.debug_format "Propagating type %a for expr %a" (format_typ ctx) tau
      (Expr.format ctx) e; *)
   let pos_e = A.Expr.pos e in
   let mark e = Marked.mark { uf = tau; pos = pos_e } e in
-  let unify_and_mark (e' : (A.dcalc, mark) A.gexpr) tau' =
+  let unify_and_mark (e' : (A.dcalc, mark) A.naked_gexpr) tau' =
     (* This try...with was added because of
        [tests/test_bool/bad/bad_assert.catala_en] but we shouldn't need it.
        TODO: debug why it is needed here. *)

--- a/compiler/dcalc/typing.ml
+++ b/compiler/dcalc/typing.ml
@@ -33,8 +33,8 @@ module Any =
     ()
 
 type unionfind_typ = naked_typ Marked.pos UnionFind.elem
-(** We do not reuse {!type: Dcalc.Ast.naked_typ} because we have to include a new
-    [TAny] variant. Indeed, error terms can have any type and this has to be
+(** We do not reuse {!type: Dcalc.Ast.naked_typ} because we have to include a
+    new [TAny] variant. Indeed, error terms can have any type and this has to be
     captured by the type sytem. *)
 
 and naked_typ =
@@ -84,9 +84,7 @@ let rec format_typ
     (fmt : Format.formatter)
     (naked_typ : unionfind_typ) : unit =
   let format_typ = format_typ ctx in
-  let format_typ_with_parens
-      (fmt : Format.formatter)
-      (t : unionfind_typ) =
+  let format_typ_with_parens (fmt : Format.formatter) (t : unionfind_typ) =
     if typ_needs_parens t then Format.fprintf fmt "(%a)" format_typ t
     else Format.fprintf fmt "%a" format_typ t
   in
@@ -109,11 +107,7 @@ let rec format_typ
   | TArray t1 -> Format.fprintf fmt "@[%a@ array@]" format_typ t1
   | TAny d -> Format.fprintf fmt "any[%d]" (Any.hash d)
 
-exception
-  Type_error of
-    A.any_marked_expr
-    * unionfind_typ
-    * unionfind_typ
+exception Type_error of A.any_marked_expr * unionfind_typ * unionfind_typ
 
 type mark = { pos : Pos.t; uf : unionfind_typ }
 
@@ -306,7 +300,7 @@ let box_ty e = Bindlib.unbox (Bindlib.box_apply ty e)
 (** Infers the most permissive type from an expression *)
 let rec typecheck_expr_bottom_up
     (ctx : A.decl_ctx)
-    (env : 'm Ast.naked_expr env)
+    (env : 'm Ast.expr env)
     (e : 'm Ast.expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
   (* Cli.debug_format "Looking for type of %a" (Expr.format ~debug:true ctx)
      e; *)
@@ -469,10 +463,10 @@ let rec typecheck_expr_bottom_up
 (** Checks whether the expression can be typed with the provided type *)
 and typecheck_expr_top_down
     (ctx : A.decl_ctx)
-    (env : 'm Ast.naked_expr env)
+    (env : 'm Ast.expr env)
     (tau : unionfind_typ)
     (e : 'm Ast.expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
-  (* Cli.debug_format "Propagating type %a for naked_expr %a" (format_typ ctx) tau
+  (* Cli.debug_format "Propagating type %a for expr %a" (format_typ ctx) tau
      (Expr.format ctx) e; *)
   let pos_e = A.Expr.pos e in
   let mark e = Marked.mark { uf = tau; pos = pos_e } e in
@@ -667,10 +661,7 @@ let infer_type (type m) ctx (e : m Ast.expr) =
   | A.Untyped _ -> A.Expr.ty (Bindlib.unbox (infer_types ctx e))
 
 (** Typechecks an expression given an expected type *)
-let check_type
-    (ctx : A.decl_ctx)
-    (e : 'm Ast.expr)
-    (tau : A.typ) =
+let check_type (ctx : A.decl_ctx) (e : 'm Ast.expr) (tau : A.typ) =
   (* todo: consider using the already inferred type if ['m] = [typed] *)
   ignore
   @@ wrap ctx (typecheck_expr_top_down ctx A.Var.Map.empty (ast_to_typ tau)) e

--- a/compiler/dcalc/typing.ml
+++ b/compiler/dcalc/typing.ml
@@ -306,8 +306,8 @@ let box_ty e = Bindlib.unbox (Bindlib.box_apply ty e)
 (** Infers the most permissive type from an expression *)
 let rec typecheck_expr_bottom_up
     (ctx : A.decl_ctx)
-    (env : 'm Ast.expr env)
-    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
+    (env : 'm Ast.naked_expr env)
+    (e : 'm Ast.expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
   (* Cli.debug_format "Looking for type of %a" (Expr.format ~debug:true ctx)
      e; *)
   let pos_e = A.Expr.pos e in
@@ -469,10 +469,10 @@ let rec typecheck_expr_bottom_up
 (** Checks whether the expression can be typed with the provided type *)
 and typecheck_expr_top_down
     (ctx : A.decl_ctx)
-    (env : 'm Ast.expr env)
+    (env : 'm Ast.naked_expr env)
     (tau : typ Marked.pos UnionFind.elem)
-    (e : 'm Ast.marked_expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
-  (* Cli.debug_format "Propagating type %a for expr %a" (format_typ ctx) tau
+    (e : 'm Ast.expr) : (A.dcalc, mark) A.gexpr Bindlib.box =
+  (* Cli.debug_format "Propagating type %a for naked_expr %a" (format_typ ctx) tau
      (Expr.format ctx) e; *)
   let pos_e = A.Expr.pos e in
   let mark e = Marked.mark { uf = tau; pos = pos_e } e in
@@ -655,13 +655,13 @@ let wrap ctx f e =
 let get_ty_mark { uf; pos } = A.Typed { ty = typ_to_ast uf; pos }
 
 (* Infer the type of an expression *)
-let infer_types (ctx : A.decl_ctx) (e : 'm Ast.marked_expr) :
-    A.typed Ast.marked_expr Bindlib.box =
+let infer_types (ctx : A.decl_ctx) (e : 'm Ast.expr) :
+    A.typed Ast.expr Bindlib.box =
   A.Expr.map_marks ~f:get_ty_mark
   @@ Bindlib.unbox
   @@ wrap ctx (typecheck_expr_bottom_up ctx A.Var.Map.empty) e
 
-let infer_type (type m) ctx (e : m Ast.marked_expr) =
+let infer_type (type m) ctx (e : m Ast.expr) =
   match Marked.get_mark e with
   | A.Typed { ty; _ } -> ty
   | A.Untyped _ -> A.Expr.ty (Bindlib.unbox (infer_types ctx e))
@@ -669,7 +669,7 @@ let infer_type (type m) ctx (e : m Ast.marked_expr) =
 (** Typechecks an expression given an expected type *)
 let check_type
     (ctx : A.decl_ctx)
-    (e : 'm Ast.marked_expr)
+    (e : 'm Ast.expr)
     (tau : A.typ Marked.pos) =
   (* todo: consider using the already inferred type if ['m] = [typed] *)
   ignore

--- a/compiler/dcalc/typing.mli
+++ b/compiler/dcalc/typing.mli
@@ -19,8 +19,7 @@
 
 open Shared_ast
 
-val infer_types :
-  decl_ctx -> untyped Ast.expr -> typed Ast.expr Bindlib.box
+val infer_types : decl_ctx -> untyped Ast.expr -> typed Ast.expr Bindlib.box
 (** Infers types everywhere on the given expression, and adds (or replaces) type
     annotations on each node *)
 

--- a/compiler/dcalc/typing.mli
+++ b/compiler/dcalc/typing.mli
@@ -24,9 +24,9 @@ val infer_types :
 (** Infers types everywhere on the given expression, and adds (or replaces) type
     annotations on each node *)
 
-val infer_type : decl_ctx -> 'm Ast.expr -> typ Utils.Marked.pos
+val infer_type : decl_ctx -> 'm Ast.expr -> typ
 (** Gets the outer type of the given expression, using either the existing
     annotations or inference *)
 
-val check_type : decl_ctx -> 'm Ast.expr -> typ Utils.Marked.pos -> unit
+val check_type : decl_ctx -> 'm Ast.expr -> typ -> unit
 val infer_types_program : untyped Ast.program -> typed Ast.program

--- a/compiler/dcalc/typing.mli
+++ b/compiler/dcalc/typing.mli
@@ -20,13 +20,13 @@
 open Shared_ast
 
 val infer_types :
-  decl_ctx -> untyped Ast.marked_expr -> typed Ast.marked_expr Bindlib.box
+  decl_ctx -> untyped Ast.expr -> typed Ast.expr Bindlib.box
 (** Infers types everywhere on the given expression, and adds (or replaces) type
     annotations on each node *)
 
-val infer_type : decl_ctx -> 'm Ast.marked_expr -> typ Utils.Marked.pos
+val infer_type : decl_ctx -> 'm Ast.expr -> typ Utils.Marked.pos
 (** Gets the outer type of the given expression, using either the existing
     annotations or inference *)
 
-val check_type : decl_ctx -> 'm Ast.marked_expr -> typ Utils.Marked.pos -> unit
+val check_type : decl_ctx -> 'm Ast.expr -> typ Utils.Marked.pos -> unit
 val infer_types_program : untyped Ast.program -> typed Ast.program

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -94,11 +94,11 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
-type expr = (desugared, Pos.t) naked_gexpr
-type marked_expr = expr Marked.pos
+type naked_expr = (desugared, Pos.t) naked_gexpr
+type expr = naked_expr Marked.pos
 
 module ExprMap = Map.Make (struct
-  type t = marked_expr
+  type t = expr
 
   let compare = Expr.compare
 end)
@@ -112,9 +112,9 @@ type label_situation = ExplicitlyLabeled of LabelName.t Marked.pos | Unlabeled
 
 type rule = {
   rule_id : RuleName.t;
-  rule_just : marked_expr Bindlib.box;
-  rule_cons : marked_expr Bindlib.box;
-  rule_parameter : (expr Var.t * marked_typ) option;
+  rule_just : expr Bindlib.box;
+  rule_cons : expr Bindlib.box;
+  rule_parameter : (naked_expr Var.t * marked_typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }
@@ -181,7 +181,7 @@ let always_false_rule (pos : Pos.t) (have_parameter : marked_typ option) : rule
     rule_label = Unlabeled;
   }
 
-type assertion = marked_expr Bindlib.box
+type assertion = expr Bindlib.box
 type variation_typ = Increasing | Decreasing
 type reference_typ = Decree | Law
 
@@ -212,7 +212,7 @@ type program = {
   program_ctx : decl_ctx;
 }
 
-let rec locations_used (e : marked_expr) : LocationSet.t =
+let rec locations_used (e : expr) : LocationSet.t =
   match Marked.unmark e with
   | ELocation l -> LocationSet.singleton (l, Marked.get_mark e)
   | EVar _ | ELit _ | EOp _ -> LocationSet.empty

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -94,8 +94,7 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
-type naked_expr = (desugared, Pos.t) naked_gexpr
-type expr = naked_expr Marked.pos
+type expr = (desugared, Pos.t) gexpr
 
 module ExprMap = Map.Make (struct
   type t = expr
@@ -114,7 +113,7 @@ type rule = {
   rule_id : RuleName.t;
   rule_just : expr Bindlib.box;
   rule_cons : expr Bindlib.box;
-  rule_parameter : (naked_expr Var.t * typ) option;
+  rule_parameter : (expr Var.t * typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }
@@ -167,8 +166,7 @@ let empty_rule (pos : Pos.t) (have_parameter : typ option) : rule =
     rule_label = Unlabeled;
   }
 
-let always_false_rule (pos : Pos.t) (have_parameter : typ option) : rule
-    =
+let always_false_rule (pos : Pos.t) (have_parameter : typ option) : rule =
   {
     rule_just = Bindlib.box (ELit (LBool true), pos);
     rule_cons = Bindlib.box (ELit (LBool false), pos);

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -94,7 +94,7 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
-type expr = (desugared, Pos.t) gexpr
+type expr = (desugared, Pos.t) naked_gexpr
 type marked_expr = expr Marked.pos
 
 module ExprMap = Map.Make (struct

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -114,7 +114,7 @@ type rule = {
   rule_id : RuleName.t;
   rule_just : expr Bindlib.box;
   rule_cons : expr Bindlib.box;
-  rule_parameter : (naked_expr Var.t * marked_typ) option;
+  rule_parameter : (naked_expr Var.t * typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }
@@ -154,7 +154,7 @@ module Rule = struct
     | Some _, None -> 1
 end
 
-let empty_rule (pos : Pos.t) (have_parameter : marked_typ option) : rule =
+let empty_rule (pos : Pos.t) (have_parameter : typ option) : rule =
   {
     rule_just = Bindlib.box (ELit (LBool false), pos);
     rule_cons = Bindlib.box (ELit LEmptyError, pos);
@@ -167,7 +167,7 @@ let empty_rule (pos : Pos.t) (have_parameter : marked_typ option) : rule =
     rule_label = Unlabeled;
   }
 
-let always_false_rule (pos : Pos.t) (have_parameter : marked_typ option) : rule
+let always_false_rule (pos : Pos.t) (have_parameter : typ option) : rule
     =
   {
     rule_just = Bindlib.box (ELit (LBool true), pos);
@@ -191,7 +191,7 @@ type meta_assertion =
 
 type scope_def = {
   scope_def_rules : rule RuleMap.t;
-  scope_def_typ : marked_typ;
+  scope_def_typ : typ;
   scope_def_is_condition : bool;
   scope_def_io : Scopelang.Ast.io;
 }

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -49,15 +49,15 @@ module ScopeDefSet : Set.S with type elt = ScopeDef.t
 
 (** {2 Expressions} *)
 
-type expr = (desugared, Pos.t) naked_gexpr
+type naked_expr = (desugared, Pos.t) naked_gexpr
 (** See {!type:Shared_ast.naked_gexpr} for the complete definition *)
 
-and marked_expr = expr Marked.pos
+and expr = naked_expr Marked.pos
 
 type location = desugared glocation
 
 module LocationSet : Set.S with type elt = location Marked.pos
-module ExprMap : Map.S with type key = marked_expr
+module ExprMap : Map.S with type key = expr
 
 (** {2 Rules and scopes}*)
 
@@ -70,9 +70,9 @@ type label_situation = ExplicitlyLabeled of LabelName.t Marked.pos | Unlabeled
 
 type rule = {
   rule_id : RuleName.t;
-  rule_just : marked_expr Bindlib.box;
-  rule_cons : marked_expr Bindlib.box;
-  rule_parameter : (expr Var.t * marked_typ) option;
+  rule_just : expr Bindlib.box;
+  rule_cons : expr Bindlib.box;
+  rule_parameter : (naked_expr Var.t * marked_typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }
@@ -82,7 +82,7 @@ module Rule : Set.OrderedType with type t = rule
 val empty_rule : Pos.t -> typ Marked.pos option -> rule
 val always_false_rule : Pos.t -> typ Marked.pos option -> rule
 
-type assertion = expr Marked.pos Bindlib.box
+type assertion = naked_expr Marked.pos Bindlib.box
 type variation_typ = Increasing | Decreasing
 type reference_typ = Decree | Law
 
@@ -115,5 +115,5 @@ type program = {
 
 (** {1 Helpers} *)
 
-val locations_used : expr Marked.pos -> LocationSet.t
+val locations_used : naked_expr Marked.pos -> LocationSet.t
 val free_variables : rule RuleMap.t -> Pos.t ScopeDefMap.t

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -72,17 +72,17 @@ type rule = {
   rule_id : RuleName.t;
   rule_just : expr Bindlib.box;
   rule_cons : expr Bindlib.box;
-  rule_parameter : (naked_expr Var.t * marked_typ) option;
+  rule_parameter : (naked_expr Var.t * typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }
 
 module Rule : Set.OrderedType with type t = rule
 
-val empty_rule : Pos.t -> typ Marked.pos option -> rule
-val always_false_rule : Pos.t -> typ Marked.pos option -> rule
+val empty_rule : Pos.t -> typ option -> rule
+val always_false_rule : Pos.t -> typ option -> rule
 
-type assertion = naked_expr Marked.pos Bindlib.box
+type assertion = expr Bindlib.box
 type variation_typ = Increasing | Decreasing
 type reference_typ = Decree | Law
 
@@ -92,7 +92,7 @@ type meta_assertion =
 
 type scope_def = {
   scope_def_rules : rule RuleMap.t;
-  scope_def_typ : typ Marked.pos;
+  scope_def_typ : typ;
   scope_def_is_condition : bool;
   scope_def_io : Scopelang.Ast.io;
 }
@@ -115,5 +115,5 @@ type program = {
 
 (** {1 Helpers} *)
 
-val locations_used : naked_expr Marked.pos -> LocationSet.t
+val locations_used : expr -> LocationSet.t
 val free_variables : rule RuleMap.t -> Pos.t ScopeDefMap.t

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -49,10 +49,8 @@ module ScopeDefSet : Set.S with type elt = ScopeDef.t
 
 (** {2 Expressions} *)
 
-type naked_expr = (desugared, Pos.t) naked_gexpr
+type expr = (desugared, Pos.t) gexpr
 (** See {!type:Shared_ast.naked_gexpr} for the complete definition *)
-
-and expr = naked_expr Marked.pos
 
 type location = desugared glocation
 
@@ -72,7 +70,7 @@ type rule = {
   rule_id : RuleName.t;
   rule_just : expr Bindlib.box;
   rule_cons : expr Bindlib.box;
-  rule_parameter : (naked_expr Var.t * typ) option;
+  rule_parameter : (expr Var.t * typ) option;
   rule_exception : exception_situation;
   rule_label : label_situation;
 }

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -49,8 +49,8 @@ module ScopeDefSet : Set.S with type elt = ScopeDef.t
 
 (** {2 Expressions} *)
 
-type expr = (desugared, Pos.t) gexpr
-(** See {!type:Shared_ast.gexpr} for the complete definition *)
+type expr = (desugared, Pos.t) naked_gexpr
+(** See {!type:Shared_ast.naked_gexpr} for the complete definition *)
 
 and marked_expr = expr Marked.pos
 

--- a/compiler/desugared/desugared_to_scope.ml
+++ b/compiler/desugared/desugared_to_scope.ml
@@ -27,14 +27,13 @@ type target_scope_vars =
 
 type ctx = {
   scope_var_mapping : target_scope_vars ScopeVarMap.t;
-  var_mapping : (Ast.naked_expr, Scopelang.Ast.naked_expr Var.t) Var.Map.t;
+  var_mapping : (Ast.expr, Scopelang.Ast.expr Var.t) Var.Map.t;
 }
 
 let tag_with_log_entry
     (e : Scopelang.Ast.expr)
     (l : log_entry)
-    (markings : Utils.Uid.MarkedString.info list) :
-    Scopelang.Ast.expr =
+    (markings : Utils.Uid.MarkedString.info list) : Scopelang.Ast.expr =
   ( EApp ((EOp (Unop (Log (l, markings))), Marked.get_mark e), [e]),
     Marked.get_mark e )
 
@@ -186,7 +185,7 @@ let rec rule_tree_to_expr
     ~(toplevel : bool)
     (ctx : ctx)
     (def_pos : Pos.t)
-    (is_func : Ast.naked_expr Var.t option)
+    (is_func : Ast.expr Var.t option)
     (tree : rule_tree) : Scopelang.Ast.expr Bindlib.box =
   let exceptions, base_rules =
     match tree with Leaf r -> [], r | Node (exceptions, r) -> exceptions, r
@@ -194,9 +193,8 @@ let rec rule_tree_to_expr
   (* because each rule has its own variable parameter and we want to convert the
      whole rule tree into a function, we need to perform some alpha-renaming of
      all the expressions *)
-  let substitute_parameter
-      (e : Ast.expr Bindlib.box)
-      (rule : Ast.rule) : Ast.expr Bindlib.box =
+  let substitute_parameter (e : Ast.expr Bindlib.box) (rule : Ast.rule) :
+      Ast.expr Bindlib.box =
     match is_func, rule.Ast.rule_parameter with
     | Some new_param, Some (old_param, _) ->
       let binder = Bindlib.bind_var old_param e in
@@ -286,8 +284,7 @@ let rec rule_tree_to_expr
          that the result returned by the function is not empty *)
       let default =
         Bindlib.box_apply
-          (fun (default : Scopelang.Ast.naked_expr * Pos.t) ->
-            ErrorOnEmpty default, def_pos)
+          (fun (default : Scopelang.Ast.expr) -> ErrorOnEmpty default, def_pos)
           default
       in
       Expr.make_abs

--- a/compiler/lcalc/ast.ml
+++ b/compiler/lcalc/ast.ml
@@ -28,7 +28,7 @@ let option_enum : EnumName.t = EnumName.fresh ("eoption", Pos.no_pos)
 let none_constr : EnumConstructor.t = EnumConstructor.fresh ("ENone", Pos.no_pos)
 let some_constr : EnumConstructor.t = EnumConstructor.fresh ("ESome", Pos.no_pos)
 
-let option_enum_config : (EnumConstructor.t * typ Marked.pos) list =
+let option_enum_config : (EnumConstructor.t * typ) list =
   [none_constr, (TLit TUnit, Pos.no_pos); some_constr, (TAny, Pos.no_pos)]
 
 (* FIXME: proper typing in all the constructors below *)

--- a/compiler/lcalc/ast.ml
+++ b/compiler/lcalc/ast.ml
@@ -19,8 +19,8 @@ include Shared_ast
 
 type lit = lcalc glit
 
-type 'm expr = (lcalc, 'm mark) gexpr
-and 'm marked_expr = (lcalc, 'm mark) marked_gexpr
+type 'm expr = (lcalc, 'm mark) naked_gexpr
+and 'm marked_expr = (lcalc, 'm mark) gexpr
 
 type 'm program = 'm expr Shared_ast.program
 

--- a/compiler/lcalc/ast.ml
+++ b/compiler/lcalc/ast.ml
@@ -19,10 +19,10 @@ include Shared_ast
 
 type lit = lcalc glit
 
-type 'm expr = (lcalc, 'm mark) naked_gexpr
-and 'm marked_expr = (lcalc, 'm mark) gexpr
+type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
+and 'm expr = (lcalc, 'm mark) gexpr
 
-type 'm program = 'm expr Shared_ast.program
+type 'm program = 'm naked_expr Shared_ast.program
 
 let option_enum : EnumName.t = EnumName.fresh ("eoption", Pos.no_pos)
 let none_constr : EnumConstructor.t = EnumConstructor.fresh ("ENone", Pos.no_pos)

--- a/compiler/lcalc/ast.ml
+++ b/compiler/lcalc/ast.ml
@@ -18,11 +18,8 @@ open Utils
 include Shared_ast
 
 type lit = lcalc glit
-
-type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
-and 'm expr = (lcalc, 'm mark) gexpr
-
-type 'm program = 'm naked_expr Shared_ast.program
+type 'm expr = (lcalc, 'm mark) gexpr
+type 'm program = 'm expr Shared_ast.program
 
 let option_enum : EnumName.t = EnumName.fresh ("eoption", Pos.no_pos)
 let none_constr : EnumConstructor.t = EnumConstructor.fresh ("ENone", Pos.no_pos)

--- a/compiler/lcalc/ast.mli
+++ b/compiler/lcalc/ast.mli
@@ -14,7 +14,6 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-open Utils
 open Shared_ast
 
 (** Abstract syntax tree for the lambda calculus *)
@@ -33,7 +32,7 @@ type 'm program = 'm naked_expr Shared_ast.program
 val option_enum : EnumName.t
 val none_constr : EnumConstructor.t
 val some_constr : EnumConstructor.t
-val option_enum_config : (EnumConstructor.t * typ Marked.pos) list
+val option_enum_config : (EnumConstructor.t * typ) list
 val make_none : 'm mark -> 'm expr Bindlib.box
 val make_some : 'm expr Bindlib.box -> 'm expr Bindlib.box
 
@@ -46,7 +45,7 @@ val make_matchopt_with_abs_arms :
 val make_matchopt :
   'm mark ->
   'm naked_expr Var.t ->
-  typ Marked.pos ->
+  typ ->
   'm expr Bindlib.box ->
   'm expr Bindlib.box ->
   'm expr Bindlib.box ->

--- a/compiler/lcalc/ast.mli
+++ b/compiler/lcalc/ast.mli
@@ -21,11 +21,8 @@ open Shared_ast
 (** {1 Abstract syntax tree} *)
 
 type lit = lcalc glit
-
-type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
-and 'm expr = (lcalc, 'm mark) gexpr
-
-type 'm program = 'm naked_expr Shared_ast.program
+type 'm expr = (lcalc, 'm mark) gexpr
+type 'm program = 'm expr Shared_ast.program
 
 (** {1 Language terms construction}*)
 
@@ -44,7 +41,7 @@ val make_matchopt_with_abs_arms :
 
 val make_matchopt :
   'm mark ->
-  'm naked_expr Var.t ->
+  'm expr Var.t ->
   typ ->
   'm expr Bindlib.box ->
   'm expr Bindlib.box ->
@@ -55,5 +52,5 @@ val make_matchopt :
 
 (** {1 Special symbols} *)
 
-val handle_default : untyped naked_expr Var.t
-val handle_default_opt : untyped naked_expr Var.t
+val handle_default : untyped expr Var.t
+val handle_default_opt : untyped expr Var.t

--- a/compiler/lcalc/ast.mli
+++ b/compiler/lcalc/ast.mli
@@ -23,8 +23,8 @@ open Shared_ast
 
 type lit = lcalc glit
 
-type 'm expr = (lcalc, 'm mark) gexpr
-and 'm marked_expr = (lcalc, 'm mark) marked_gexpr
+type 'm expr = (lcalc, 'm mark) naked_gexpr
+and 'm marked_expr = (lcalc, 'm mark) gexpr
 
 type 'm program = 'm expr Shared_ast.program
 

--- a/compiler/lcalc/ast.mli
+++ b/compiler/lcalc/ast.mli
@@ -23,10 +23,10 @@ open Shared_ast
 
 type lit = lcalc glit
 
-type 'm expr = (lcalc, 'm mark) naked_gexpr
-and 'm marked_expr = (lcalc, 'm mark) gexpr
+type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
+and 'm expr = (lcalc, 'm mark) gexpr
 
-type 'm program = 'm expr Shared_ast.program
+type 'm program = 'm naked_expr Shared_ast.program
 
 (** {1 Language terms construction}*)
 
@@ -34,27 +34,27 @@ val option_enum : EnumName.t
 val none_constr : EnumConstructor.t
 val some_constr : EnumConstructor.t
 val option_enum_config : (EnumConstructor.t * typ Marked.pos) list
-val make_none : 'm mark -> 'm marked_expr Bindlib.box
-val make_some : 'm marked_expr Bindlib.box -> 'm marked_expr Bindlib.box
+val make_none : 'm mark -> 'm expr Bindlib.box
+val make_some : 'm expr Bindlib.box -> 'm expr Bindlib.box
 
 val make_matchopt_with_abs_arms :
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box
 
 val make_matchopt :
   'm mark ->
-  'm expr Var.t ->
+  'm naked_expr Var.t ->
   typ Marked.pos ->
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box ->
-  'm marked_expr Bindlib.box
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box ->
+  'm expr Bindlib.box
 (** [e' = make_matchopt'' pos v e e_none e_some] Builds the term corresponding
     to [match e with | None -> fun () -> e_none |Some -> fun v -> e_some]. *)
 
 (** {1 Special symbols} *)
 
-val handle_default : untyped expr Var.t
-val handle_default_opt : untyped expr Var.t
+val handle_default : untyped naked_expr Var.t
+val handle_default_opt : untyped naked_expr Var.t

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -22,13 +22,13 @@ module D = Dcalc.Ast
 (** TODO: This version is not yet debugged and ought to be specialized when
     Lcalc has more structure. *)
 
-type 'm ctx = { name_context : string; globally_bound_vars : 'm expr Var.Set.t }
+type 'm ctx = { name_context : string; globally_bound_vars : 'm naked_expr Var.Set.t }
 
 (** Returns the expression with closed closures and the set of free variables
     inside this new expression. Implementation guided by
     http://gallium.inria.fr/~fpottier/mpri/cours04.pdf#page=9. *)
-let closure_conversion_expr (type m) (ctx : m ctx) (e : m marked_expr) :
-    m marked_expr Bindlib.box =
+let closure_conversion_expr (type m) (ctx : m ctx) (e : m expr) :
+    m expr Bindlib.box =
   let rec aux e =
     match Marked.unmark e with
     | EVar v ->

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -22,7 +22,7 @@ module D = Dcalc.Ast
 (** TODO: This version is not yet debugged and ought to be specialized when
     Lcalc has more structure. *)
 
-type 'm ctx = { name_context : string; globally_bound_vars : 'm naked_expr Var.Set.t }
+type 'm ctx = { name_context : string; globally_bound_vars : 'm expr Var.Set.t }
 
 (** Returns the expression with closed closures and the set of free variables
     inside this new expression. Implementation guided by

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -19,7 +19,7 @@ open Shared_ast
 module D = Dcalc.Ast
 module A = Ast
 
-type 'm ctx = ('m D.naked_expr, 'm A.naked_expr Var.t) Var.Map.t
+type 'm ctx = ('m D.expr, 'm A.expr Var.t) Var.Map.t
 (** This environment contains a mapping between the variables in Dcalc and their
     correspondance in Lcalc. *)
 
@@ -51,8 +51,7 @@ let rec translate_default
   in
   exceptions
 
-and translate_expr (ctx : 'm ctx) (e : 'm D.expr) :
-    'm A.expr Bindlib.box =
+and translate_expr (ctx : 'm ctx) (e : 'm D.expr) : 'm A.expr Bindlib.box =
   match Marked.unmark e with
   | EVar v -> Expr.make_var (Var.Map.find v ctx, Marked.get_mark e)
   | ETuple (args, s) ->
@@ -112,8 +111,8 @@ and translate_expr (ctx : 'm ctx) (e : 'm D.expr) :
 let rec translate_scope_lets
     (decl_ctx : decl_ctx)
     (ctx : 'm ctx)
-    (scope_lets : 'm D.naked_expr scope_body_expr) :
-    'm A.naked_expr scope_body_expr Bindlib.box =
+    (scope_lets : 'm D.expr scope_body_expr) :
+    'm A.expr scope_body_expr Bindlib.box =
   match scope_lets with
   | Result e -> Bindlib.box_apply (fun e -> Result e) (translate_expr ctx e)
   | ScopeLet scope_let ->
@@ -140,7 +139,7 @@ let rec translate_scope_lets
 let rec translate_scopes
     (decl_ctx : decl_ctx)
     (ctx : 'm ctx)
-    (scopes : 'm D.naked_expr scopes) : 'm A.naked_expr scopes Bindlib.box =
+    (scopes : 'm D.expr scopes) : 'm A.expr scopes Bindlib.box =
   match scopes with
   | Nil -> Bindlib.box Nil
   | ScopeDef scope_def ->
@@ -159,7 +158,7 @@ let rec translate_scopes
     let new_scope_body_expr =
       Bindlib.bind_var new_scope_input_var new_scope_body_expr
     in
-    let new_scope : 'm A.naked_expr scope_body Bindlib.box =
+    let new_scope : 'm A.expr scope_body Bindlib.box =
       Bindlib.box_apply
         (fun new_scope_body_expr ->
           {

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -19,21 +19,21 @@ open Shared_ast
 module D = Dcalc.Ast
 module A = Ast
 
-type 'm ctx = ('m D.expr, 'm A.expr Var.t) Var.Map.t
+type 'm ctx = ('m D.naked_expr, 'm A.naked_expr Var.t) Var.Map.t
 (** This environment contains a mapping between the variables in Dcalc and their
     correspondance in Lcalc. *)
 
-let thunk_expr (e : 'm A.marked_expr Bindlib.box) (mark : 'm mark) :
-    'm A.marked_expr Bindlib.box =
+let thunk_expr (e : 'm A.expr Bindlib.box) (mark : 'm mark) :
+    'm A.expr Bindlib.box =
   let dummy_var = Var.make "_" in
   Expr.make_abs [| dummy_var |] e [TAny, Expr.mark_pos mark] mark
 
 let rec translate_default
     (ctx : 'm ctx)
-    (exceptions : 'm D.marked_expr list)
-    (just : 'm D.marked_expr)
-    (cons : 'm D.marked_expr)
-    (mark_default : 'm mark) : 'm A.marked_expr Bindlib.box =
+    (exceptions : 'm D.expr list)
+    (just : 'm D.expr)
+    (cons : 'm D.expr)
+    (mark_default : 'm mark) : 'm A.expr Bindlib.box =
   let exceptions =
     List.map
       (fun except -> thunk_expr (translate_expr ctx except) mark_default)
@@ -51,8 +51,8 @@ let rec translate_default
   in
   exceptions
 
-and translate_expr (ctx : 'm ctx) (e : 'm D.marked_expr) :
-    'm A.marked_expr Bindlib.box =
+and translate_expr (ctx : 'm ctx) (e : 'm D.expr) :
+    'm A.expr Bindlib.box =
   match Marked.unmark e with
   | EVar v -> Expr.make_var (Var.Map.find v ctx, Marked.get_mark e)
   | ETuple (args, s) ->
@@ -112,8 +112,8 @@ and translate_expr (ctx : 'm ctx) (e : 'm D.marked_expr) :
 let rec translate_scope_lets
     (decl_ctx : decl_ctx)
     (ctx : 'm ctx)
-    (scope_lets : 'm D.expr scope_body_expr) :
-    'm A.expr scope_body_expr Bindlib.box =
+    (scope_lets : 'm D.naked_expr scope_body_expr) :
+    'm A.naked_expr scope_body_expr Bindlib.box =
   match scope_lets with
   | Result e -> Bindlib.box_apply (fun e -> Result e) (translate_expr ctx e)
   | ScopeLet scope_let ->
@@ -140,7 +140,7 @@ let rec translate_scope_lets
 let rec translate_scopes
     (decl_ctx : decl_ctx)
     (ctx : 'm ctx)
-    (scopes : 'm D.expr scopes) : 'm A.expr scopes Bindlib.box =
+    (scopes : 'm D.naked_expr scopes) : 'm A.naked_expr scopes Bindlib.box =
   match scopes with
   | Nil -> Bindlib.box Nil
   | ScopeDef scope_def ->
@@ -159,7 +159,7 @@ let rec translate_scopes
     let new_scope_body_expr =
       Bindlib.bind_var new_scope_input_var new_scope_body_expr
     in
-    let new_scope : 'm A.expr scope_body Bindlib.box =
+    let new_scope : 'm A.naked_expr scope_body Bindlib.box =
       Bindlib.box_apply
         (fun new_scope_body_expr ->
           {

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -120,7 +120,7 @@ let add_var
     Since positions where there is thunked expressions is exactly where we will
     put option expressions. Hence, the transformation simply reduce [unit -> 'a]
     into ['a option] recursivly. There is no polymorphism inside catala. *)
-let rec translate_typ (tau : typ Marked.pos) : typ Marked.pos =
+let rec translate_typ (tau : typ) : typ =
   (Fun.flip Marked.same_mark_as)
     tau
     begin

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -42,12 +42,12 @@ module A = Ast
 
 open Shared_ast
 
-type 'm hoists = ('m A.naked_expr, 'm D.expr) Var.Map.t
-(** Hoists definition. It represent bindings between [A.Var.t] and [D.naked_expr]. *)
+type 'm hoists = ('m A.expr, 'm D.expr) Var.Map.t
+(** Hoists definition. It represent bindings between [A.Var.t] and [D.expr]. *)
 
 type 'm info = {
-  naked_expr : 'm A.expr Bindlib.box;
-  var : 'm A.naked_expr Bindlib.var;
+  expr : 'm A.expr Bindlib.box;
+  var : 'm A.expr Var.t;
   is_pure : bool;
 }
 (** Information about each encontered Dcalc variable is stored inside a context
@@ -61,14 +61,14 @@ let pp_info (fmt : Format.formatter) (info : 'm info) =
 
 type 'm ctx = {
   decl_ctx : decl_ctx;
-  vars : ('m D.naked_expr, 'm info) Var.Map.t;
+  vars : ('m D.expr, 'm info) Var.Map.t;
       (** information context about variables in the current scope *)
 }
 
 let _pp_ctx (fmt : Format.formatter) (ctx : 'm ctx) =
   let pp_binding
       (fmt : Format.formatter)
-      ((v, info) : 'm D.naked_expr Var.t * 'm info) =
+      ((v, info) : 'm D.expr Var.t * 'm info) =
     Format.fprintf fmt "%a: %a" Print.var v pp_info info
   in
 
@@ -82,7 +82,7 @@ let _pp_ctx (fmt : Format.formatter) (ctx : 'm ctx) =
 
 (** [find ~info n ctx] is a warpper to ocaml's Map.find that handle errors in a
     slightly better way. *)
-let find ?(info : string = "none") (n : 'm D.naked_expr Var.t) (ctx : 'm ctx) :
+let find ?(info : string = "none") (n : 'm D.expr Var.t) (ctx : 'm ctx) :
     'm info =
   (* let _ = Format.asprintf "Searching for variable %a inside context %a"
      Print.var n pp_ctx ctx |> Cli.debug_print in *)
@@ -99,11 +99,11 @@ let find ?(info : string = "none") (n : 'm D.naked_expr Var.t) (ctx : 'm ctx) :
     debuging purposes as it printing each of the Dcalc/Lcalc variable pairs. *)
 let add_var
     (mark : 'm mark)
-    (var : 'm D.naked_expr Var.t)
+    (var : 'm D.expr Var.t)
     (is_pure : bool)
     (ctx : 'm ctx) : 'm ctx =
   let new_var = Var.make (Bindlib.name_of var) in
-  let naked_expr = Expr.make_var (new_var, mark) in
+  let expr = Expr.make_var (new_var, mark) in
 
   (* Cli.debug_print @@ Format.asprintf "D.%a |-> A.%a" Print.var var Print.var
      new_var; *)
@@ -111,7 +111,7 @@ let add_var
     ctx with
     vars =
       Var.Map.update var
-        (fun _ -> Some { naked_expr; var = new_var; is_pure })
+        (fun _ -> Some { expr; var = new_var; is_pure })
         ctx.vars;
   }
 
@@ -172,7 +172,7 @@ let rec translate_and_hoist (ctx : 'm ctx) (e : 'm D.expr) :
       (* Cli.debug_print @@ Format.asprintf "Found an unpure variable %a,
          created a variable %a to replace it" Print.var v Print.var v'; *)
       Expr.make_var (v', pos), Var.Map.singleton v' e
-    else (find ~info:"should never happend" v ctx).naked_expr, Var.Map.empty
+    else (find ~info:"should never happend" v ctx).expr, Var.Map.empty
   | EApp ((EVar v, p), [(ELit LUnit, _)]) ->
     if not (find ~info:"search for a variable" v ctx).is_pure then
       let v' = Var.make (Bindlib.name_of v) in
@@ -288,8 +288,8 @@ let rec translate_and_hoist (ctx : 'm ctx) (e : 'm D.expr) :
     Expr.earray es' pos, disjoint_union_maps (Expr.pos e) hoists
   | EOp op -> Bindlib.box (EOp op, pos), Var.Map.empty
 
-and translate_expr ?(append_esome = true) (ctx : 'm ctx) (e : 'm D.expr)
-    : 'm A.expr Bindlib.box =
+and translate_expr ?(append_esome = true) (ctx : 'm ctx) (e : 'm D.expr) :
+    'm A.expr Bindlib.box =
   let e', hoists = translate_and_hoist ctx e in
   let hoists = Var.Map.bindings hoists in
 
@@ -306,7 +306,7 @@ and translate_expr ?(append_esome = true) (ctx : 'm ctx) (e : 'm D.expr)
         match hoist with
         (* Here we have to handle only the cases appearing in hoists, as defined
            the [translate_and_hoist] function. *)
-        | EVar v -> (find ~info:"should never happend" v ctx).naked_expr
+        | EVar v -> (find ~info:"should never happend" v ctx).expr
         | EDefault (excep, just, cons) ->
           let excep' = List.map (translate_expr ctx) excep in
           let just' = translate_expr ctx just in
@@ -356,8 +356,8 @@ and translate_expr ?(append_esome = true) (ctx : 'm ctx) (e : 'm D.expr)
         (TAny, Expr.mark_pos mark_hoist)
         c' (A.make_none mark_hoist) acc)
 
-let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_expr) :
-    'm A.naked_expr scope_body_expr Bindlib.box =
+let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.expr scope_body_expr) :
+    'm A.expr scope_body_expr Bindlib.box =
   match lets with
   | Result e ->
     Bindlib.box_apply
@@ -373,7 +373,7 @@ let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_ex
       } ->
     (* special case : the subscope variable is thunked (context i/o). We remove
        this thunking. *)
-    let _, naked_expr = Bindlib.unmbind binder in
+    let _, expr = Bindlib.unmbind binder in
 
     let var_is_pure = true in
     let var, next = Bindlib.unbind next in
@@ -392,13 +392,13 @@ let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_ex
             scope_let_next = new_next;
             scope_let_pos = pos;
           })
-      (translate_expr ctx ~append_esome:false naked_expr)
+      (translate_expr ctx ~append_esome:false expr)
       (Bindlib.bind_var new_var new_next)
   | ScopeLet
       {
         scope_let_kind = SubScopeVarDefinition;
         scope_let_typ = typ;
-        scope_let_expr = (ErrorOnEmpty _, emark) as naked_expr;
+        scope_let_expr = (ErrorOnEmpty _, emark) as expr;
         scope_let_next = next;
         scope_let_pos = pos;
       } ->
@@ -419,25 +419,25 @@ let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_ex
             scope_let_next = new_next;
             scope_let_pos = pos;
           })
-      (translate_expr ctx ~append_esome:false naked_expr)
+      (translate_expr ctx ~append_esome:false expr)
       (Bindlib.bind_var new_var (translate_scope_let ctx' next))
   | ScopeLet
       {
         scope_let_kind = SubScopeVarDefinition;
         scope_let_pos = pos;
-        scope_let_expr = naked_expr;
+        scope_let_expr = expr;
         _;
       } ->
     Errors.raise_spanned_error pos
       "Internal Error: found an SubScopeVarDefinition that does not satisfy \
        the invariants when translating Dcalc to Lcalc without exceptions: \
        @[<hov 2>%a@]"
-      (Expr.format ctx.decl_ctx) naked_expr
+      (Expr.format ctx.decl_ctx) expr
   | ScopeLet
       {
         scope_let_kind = kind;
         scope_let_typ = typ;
-        scope_let_expr = naked_expr;
+        scope_let_expr = expr;
         scope_let_next = next;
         scope_let_pos = pos;
       } ->
@@ -458,7 +458,7 @@ let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_ex
     let var, next = Bindlib.unbind next in
     (* Cli.debug_print @@ Format.asprintf "unbinding %a" Print.var var; *)
     let vmark =
-      Expr.map_mark (fun _ -> pos) (fun _ -> typ) (Marked.get_mark naked_expr)
+      Expr.map_mark (fun _ -> pos) (fun _ -> typ) (Marked.get_mark expr)
     in
     let ctx' = add_var vmark var var_is_pure ctx in
     let new_var = (find ~info:"variable that was just created" var ctx').var in
@@ -472,13 +472,13 @@ let rec translate_scope_let (ctx : 'm ctx) (lets : 'm D.naked_expr scope_body_ex
             scope_let_next = new_next;
             scope_let_pos = pos;
           })
-      (translate_expr ctx ~append_esome:false naked_expr)
+      (translate_expr ctx ~append_esome:false expr)
       (Bindlib.bind_var new_var (translate_scope_let ctx' next))
 
 let translate_scope_body
     (scope_pos : Pos.t)
     (ctx : 'm ctx)
-    (body : 'm D.naked_expr scope_body) : 'm A.naked_expr scope_body Bindlib.box =
+    (body : 'm D.expr scope_body) : 'm A.expr scope_body Bindlib.box =
   match body with
   | {
    scope_body_expr = result;
@@ -504,8 +504,8 @@ let translate_scope_body
         })
       (Bindlib.bind_var v' (translate_scope_let ctx' lets))
 
-let rec translate_scopes (ctx : 'm ctx) (scopes : 'm D.naked_expr scopes) :
-    'm A.naked_expr scopes Bindlib.box =
+let rec translate_scopes (ctx : 'm ctx) (scopes : 'm D.expr scopes) :
+    'm A.expr scopes Bindlib.box =
   match scopes with
   | Nil -> Bindlib.box Nil
   | ScopeDef { scope_name; scope_body; scope_next } ->

--- a/compiler/lcalc/optimizations.ml
+++ b/compiler/lcalc/optimizations.ml
@@ -22,9 +22,9 @@ let ( let+ ) x f = Bindlib.box_apply f x
 let ( and+ ) x y = Bindlib.box_pair x y
 
 let visitor_map
-    (t : 'a -> 'm marked_expr -> 'm marked_expr Bindlib.box)
+    (t : 'a -> 'm expr -> 'm expr Bindlib.box)
     (ctx : 'a)
-    (e : 'm marked_expr) : 'm marked_expr Bindlib.box =
+    (e : 'm expr) : 'm expr Bindlib.box =
   (* calls [t ctx] on every direct childs of [e], then rebuild an abstract
      syntax tree modified. Used in other transformations. *)
   let default_mark e' = Marked.same_mark_as e' e in
@@ -68,7 +68,7 @@ let visitor_map
     default_mark @@ ECatch (e1, exn, e2)
   | ERaise _ | ELit _ | EOp _ -> Bindlib.box e
 
-let rec iota_expr (_ : unit) (e : 'm marked_expr) : 'm marked_expr Bindlib.box =
+let rec iota_expr (_ : unit) (e : 'm expr) : 'm expr Bindlib.box =
   let default_mark e' = Marked.mark (Marked.get_mark e) e' in
   match Marked.unmark e with
   | EMatch ((EInj (e1, i, n', _ts), _), cases, n) when EnumName.compare n n' = 0
@@ -87,7 +87,7 @@ let rec iota_expr (_ : unit) (e : 'm marked_expr) : 'm marked_expr Bindlib.box =
     visitor_map iota_expr () e'
   | _ -> visitor_map iota_expr () e
 
-let rec beta_expr (_ : unit) (e : 'm marked_expr) : 'm marked_expr Bindlib.box =
+let rec beta_expr (_ : unit) (e : 'm expr) : 'm expr Bindlib.box =
   let default_mark e' = Marked.same_mark_as e' e in
   match Marked.unmark e with
   | EApp (e1, args) -> (
@@ -116,8 +116,8 @@ let _beta_optimizations (p : 'm program) : 'm program =
   in
   { p with scopes = Bindlib.unbox new_scopes }
 
-let rec peephole_expr (_ : unit) (e : 'm marked_expr) :
-    'm marked_expr Bindlib.box =
+let rec peephole_expr (_ : unit) (e : 'm expr) :
+    'm expr Bindlib.box =
   let default_mark e' = Marked.mark (Marked.get_mark e) e' in
 
   match Marked.unmark e with

--- a/compiler/lcalc/optimizations.ml
+++ b/compiler/lcalc/optimizations.ml
@@ -95,7 +95,6 @@ let rec beta_expr (_ : unit) (e : 'm expr) : 'm expr Bindlib.box =
     and+ args = List.map (beta_expr ()) args |> Bindlib.box_list in
     match Marked.unmark e1 with
     | EAbs (binder, _ts) ->
-      let (_ : (_, _) Bindlib.mbinder) = binder in
       Bindlib.msubst binder (List.map fst args |> Array.of_list)
     | _ -> default_mark @@ EApp (e1, args))
   | _ -> visitor_map beta_expr () e
@@ -116,8 +115,7 @@ let _beta_optimizations (p : 'm program) : 'm program =
   in
   { p with scopes = Bindlib.unbox new_scopes }
 
-let rec peephole_expr (_ : unit) (e : 'm expr) :
-    'm expr Bindlib.box =
+let rec peephole_expr (_ : unit) (e : 'm expr) : 'm expr Bindlib.box =
   let default_mark e' = Marked.mark (Marked.get_mark e) e' in
 
   match Marked.unmark e with

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -21,7 +21,7 @@ open String_common
 module D = Dcalc.Ast
 
 let find_struct (s : StructName.t) (ctx : decl_ctx) :
-    (StructFieldName.t * typ Marked.pos) list =
+    (StructFieldName.t * typ) list =
   try StructMap.find s ctx.ctx_structs
   with Not_found ->
     let s_name, pos = StructName.get_info s in
@@ -30,7 +30,7 @@ let find_struct (s : StructName.t) (ctx : decl_ctx) :
       s_name
 
 let find_enum (en : EnumName.t) (ctx : decl_ctx) :
-    (EnumConstructor.t * typ Marked.pos) list =
+    (EnumConstructor.t * typ) list =
   try EnumMap.find en ctx.ctx_enums
   with Not_found ->
     let en_name, pos = EnumName.get_info en in
@@ -183,7 +183,7 @@ let format_enum_cons_name (fmt : Format.formatter) (v : EnumConstructor.t) :
     (avoid_keywords
        (to_ascii (Format.asprintf "%a" EnumConstructor.format_t v)))
 
-let rec typ_embedding_name (fmt : Format.formatter) (ty : typ Marked.pos) : unit
+let rec typ_embedding_name (fmt : Format.formatter) (ty : typ) : unit
     =
   match Marked.unmark ty with
   | TLit TUnit -> Format.fprintf fmt "embed_unit"
@@ -198,11 +198,11 @@ let rec typ_embedding_name (fmt : Format.formatter) (ty : typ Marked.pos) : unit
   | TArray ty -> Format.fprintf fmt "embed_array (%a)" typ_embedding_name ty
   | _ -> Format.fprintf fmt "unembeddable"
 
-let typ_needs_parens (e : typ Marked.pos) : bool =
+let typ_needs_parens (e : typ) : bool =
   match Marked.unmark e with TArrow _ | TArray _ -> true | _ -> false
 
-let rec format_typ (fmt : Format.formatter) (typ : typ Marked.pos) : unit =
-  let format_typ_with_parens (fmt : Format.formatter) (t : typ Marked.pos) =
+let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
+  let format_typ_with_parens (fmt : Format.formatter) (t : typ) =
     if typ_needs_parens t then Format.fprintf fmt "(%a)" format_typ t
     else Format.fprintf fmt "%a" format_typ t
   in
@@ -450,7 +450,7 @@ let rec format_expr
 let format_struct_embedding
     (fmt : Format.formatter)
     ((struct_name, struct_fields) :
-      StructName.t * (StructFieldName.t * typ Marked.pos) list) =
+      StructName.t * (StructFieldName.t * typ) list) =
   if List.length struct_fields = 0 then
     Format.fprintf fmt "let embed_%a (_: %a.t) : runtime_value = Unit@\n@\n"
       format_struct_name struct_name format_to_module_name (`Sname struct_name)
@@ -473,7 +473,7 @@ let format_struct_embedding
 let format_enum_embedding
     (fmt : Format.formatter)
     ((enum_name, enum_cases) :
-      EnumName.t * (EnumConstructor.t * typ Marked.pos) list) =
+      EnumName.t * (EnumConstructor.t * typ) list) =
   if List.length enum_cases = 0 then
     Format.fprintf fmt "let embed_%a (_: %a.t) : runtime_value = Unit@\n@\n"
       format_to_module_name (`Ename enum_name) format_enum_name enum_name

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -183,8 +183,7 @@ let format_enum_cons_name (fmt : Format.formatter) (v : EnumConstructor.t) :
     (avoid_keywords
        (to_ascii (Format.asprintf "%a" EnumConstructor.format_t v)))
 
-let rec typ_embedding_name (fmt : Format.formatter) (ty : typ) : unit
-    =
+let rec typ_embedding_name (fmt : Format.formatter) (ty : typ) : unit =
   match Marked.unmark ty with
   | TLit TUnit -> Format.fprintf fmt "embed_unit"
   | TLit TBool -> Format.fprintf fmt "embed_bool"
@@ -271,10 +270,8 @@ let format_exception (fmt : Format.formatter) (exc : except Marked.pos) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
 
-let rec format_expr
-    (ctx : decl_ctx)
-    (fmt : Format.formatter)
-    (e : 'm expr) : unit =
+let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
+    unit =
   let format_expr = format_expr ctx in
   let format_with_parens (fmt : Format.formatter) (e : 'm expr) =
     if needs_parens e then Format.fprintf fmt "(%a)" format_expr e
@@ -472,8 +469,7 @@ let format_struct_embedding
 
 let format_enum_embedding
     (fmt : Format.formatter)
-    ((enum_name, enum_cases) :
-      EnumName.t * (EnumConstructor.t * typ) list) =
+    ((enum_name, enum_cases) : EnumName.t * (EnumConstructor.t * typ) list) =
   if List.length enum_cases = 0 then
     Format.fprintf fmt "let embed_%a (_: %a.t) : runtime_value = Unit@\n@\n"
       format_to_module_name (`Ename enum_name) format_enum_name enum_name
@@ -556,7 +552,7 @@ let format_ctx
 let rec format_scope_body_expr
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (scope_lets : 'm Ast.naked_expr scope_body_expr) : unit =
+    (scope_lets : 'm Ast.expr scope_body_expr) : unit =
   match scope_lets with
   | Result e -> format_expr ctx fmt e
   | ScopeLet scope_let ->
@@ -572,7 +568,7 @@ let rec format_scope_body_expr
 let rec format_scopes
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (scopes : 'm Ast.naked_expr scopes) : unit =
+    (scopes : 'm Ast.expr scopes) : unit =
   match scopes with
   | Nil -> ()
   | ScopeDef scope_def ->

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -242,7 +242,7 @@ let format_var (fmt : Format.formatter) (v : 'm Var.t) : unit =
     Cli.debug_print "lowercase_name: %s " lowercase_name;
     Format.fprintf fmt "%s_" lowercase_name)
 
-let needs_parens (e : 'm marked_expr) : bool =
+let needs_parens (e : 'm expr) : bool =
   match Marked.unmark e with
   | EApp ((EAbs (_, _), _), _)
   | ELit (LBool _ | LUnit)
@@ -274,9 +274,9 @@ let format_exception (fmt : Format.formatter) (exc : except Marked.pos) : unit =
 let rec format_expr
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (e : 'm marked_expr) : unit =
+    (e : 'm expr) : unit =
   let format_expr = format_expr ctx in
-  let format_with_parens (fmt : Format.formatter) (e : 'm marked_expr) =
+  let format_with_parens (fmt : Format.formatter) (e : 'm expr) =
     if needs_parens e then Format.fprintf fmt "(%a)" format_expr e
     else Format.fprintf fmt "%a" format_expr e
   in
@@ -556,7 +556,7 @@ let format_ctx
 let rec format_scope_body_expr
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (scope_lets : 'm Ast.expr scope_body_expr) : unit =
+    (scope_lets : 'm Ast.naked_expr scope_body_expr) : unit =
   match scope_lets with
   | Result e -> format_expr ctx fmt e
   | ScopeLet scope_let ->
@@ -572,7 +572,7 @@ let rec format_scope_body_expr
 let rec format_scopes
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (scopes : 'm Ast.expr scopes) : unit =
+    (scopes : 'm Ast.naked_expr scopes) : unit =
   match scopes with
   | Nil -> ()
   | ScopeDef scope_def ->

--- a/compiler/lcalc/to_ocaml.mli
+++ b/compiler/lcalc/to_ocaml.mli
@@ -29,7 +29,7 @@ val find_enum :
   EnumName.t -> decl_ctx -> (EnumConstructor.t * typ Marked.pos) list
 
 val typ_needs_parens : typ Marked.pos -> bool
-val needs_parens : 'm marked_expr -> bool
+val needs_parens : 'm expr -> bool
 val format_enum_name : Format.formatter -> EnumName.t -> unit
 val format_enum_cons_name : Format.formatter -> EnumConstructor.t -> unit
 val format_struct_name : Format.formatter -> StructName.t -> unit

--- a/compiler/lcalc/to_ocaml.mli
+++ b/compiler/lcalc/to_ocaml.mli
@@ -23,12 +23,12 @@ open Ast
 val avoid_keywords : string -> string
 
 val find_struct :
-  StructName.t -> decl_ctx -> (StructFieldName.t * typ Marked.pos) list
+  StructName.t -> decl_ctx -> (StructFieldName.t * typ) list
 
 val find_enum :
-  EnumName.t -> decl_ctx -> (EnumConstructor.t * typ Marked.pos) list
+  EnumName.t -> decl_ctx -> (EnumConstructor.t * typ) list
 
-val typ_needs_parens : typ Marked.pos -> bool
+val typ_needs_parens : typ -> bool
 val needs_parens : 'm expr -> bool
 val format_enum_name : Format.formatter -> EnumName.t -> unit
 val format_enum_cons_name : Format.formatter -> EnumConstructor.t -> unit

--- a/compiler/lcalc/to_ocaml.mli
+++ b/compiler/lcalc/to_ocaml.mli
@@ -21,13 +21,8 @@ open Ast
 (** Formats a lambda calculus program into a valid OCaml program *)
 
 val avoid_keywords : string -> string
-
-val find_struct :
-  StructName.t -> decl_ctx -> (StructFieldName.t * typ) list
-
-val find_enum :
-  EnumName.t -> decl_ctx -> (EnumConstructor.t * typ) list
-
+val find_struct : StructName.t -> decl_ctx -> (StructFieldName.t * typ) list
+val find_enum : EnumName.t -> decl_ctx -> (EnumConstructor.t * typ) list
 val typ_needs_parens : typ -> bool
 val needs_parens : 'm expr -> bool
 val format_enum_name : Format.formatter -> EnumName.t -> unit

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -328,10 +328,10 @@ module To_jsoo = struct
           Format.fprintf fmt "%a@\n" format_enum_decl (e, find_enum e ctx))
       (type_ordering @ scope_structs)
 
-  let fmt_input_struct_name fmt (scope_def : 'a expr scope_def) =
+  let fmt_input_struct_name fmt (scope_def : 'a naked_expr scope_def) =
     format_struct_name fmt scope_def.scope_body.scope_body_input_struct
 
-  let fmt_output_struct_name fmt (scope_def : 'a expr scope_def) =
+  let fmt_output_struct_name fmt (scope_def : 'a naked_expr scope_def) =
     format_struct_name fmt scope_def.scope_body.scope_body_output_struct
 
   let rec format_scopes_to_fun

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -328,10 +328,10 @@ module To_jsoo = struct
           Format.fprintf fmt "%a@\n" format_enum_decl (e, find_enum e ctx))
       (type_ordering @ scope_structs)
 
-  let fmt_input_struct_name fmt (scope_def : 'a naked_expr scope_def) =
+  let fmt_input_struct_name fmt (scope_def : 'a expr scope_def) =
     format_struct_name fmt scope_def.scope_body.scope_body_input_struct
 
-  let fmt_output_struct_name fmt (scope_def : 'a naked_expr scope_def) =
+  let fmt_output_struct_name fmt (scope_def : 'a expr scope_def) =
     format_struct_name fmt scope_def.scope_body.scope_body_output_struct
 
   let rec format_scopes_to_fun

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -60,8 +60,8 @@ module To_jsoo = struct
       | TBool -> "bool Js.t"
       | TDate -> "Js.js_string Js.t")
 
-  let rec format_typ (fmt : Format.formatter) (typ : typ Marked.pos) : unit =
-    let format_typ_with_parens (fmt : Format.formatter) (t : typ Marked.pos) =
+  let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
+    let format_typ_with_parens (fmt : Format.formatter) (t : typ) =
       if typ_needs_parens t then Format.fprintf fmt "(%a)" format_typ t
       else Format.fprintf fmt "%a" format_typ t
     in
@@ -137,7 +137,7 @@ module To_jsoo = struct
       (type_ordering : Scopelang.Dependency.TVertex.t list)
       (fmt : Format.formatter)
       (ctx : decl_ctx) : unit =
-    let format_prop_or_meth fmt (struct_field_type : typ Marked.pos) =
+    let format_prop_or_meth fmt (struct_field_type : typ) =
       match Marked.unmark struct_field_type with
       | TArrow _ -> Format.fprintf fmt "Js.meth"
       | _ -> Format.fprintf fmt "Js.readonly_prop"
@@ -224,7 +224,7 @@ module To_jsoo = struct
     in
     let format_enum_decl
         fmt
-        (enum_name, (enum_cons : (EnumConstructor.t * typ Marked.pos) list)) =
+        (enum_name, (enum_cons : (EnumConstructor.t * typ) list)) =
       let fmt_enum_name fmt _ = format_enum_name fmt enum_name in
       let fmt_module_enum_name fmt _ =
         To_ocaml.format_to_module_name fmt (`Ename enum_name)

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -49,7 +49,7 @@ module To_json = struct
     Format.fprintf fmt "%s" s
 
   let rec find_scope_def (target_name : string) :
-      'm naked_expr scopes -> 'm naked_expr scope_def option = function
+      'm expr scopes -> 'm expr scope_def option = function
     | Nil -> None
     | ScopeDef scope_def ->
       let name = Format.asprintf "%a" ScopeName.format_t scope_def.scope_name in
@@ -111,8 +111,7 @@ module To_json = struct
     in
     let rec collect_required_type_defs_from_scope_input
         (input_struct : StructName.t) : typ list =
-      let rec collect (acc : typ list) (t : typ) : typ list
-          =
+      let rec collect (acc : typ list) (t : typ) : typ list =
         match Marked.unmark t with
         | TStruct s ->
           (* Scope's input is a struct. *)

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -69,7 +69,7 @@ module To_json = struct
     | TDate -> Format.fprintf fmt "\"type\": \"string\",@\n\"format\": \"date\""
     | TDuration -> failwith "TODO: tlit duration"
 
-  let rec fmt_type fmt (typ : marked_typ) =
+  let rec fmt_type fmt (typ : typ) =
     match Marked.unmark typ with
     | TLit tlit -> fmt_tlit fmt tlit
     | TStruct sname ->
@@ -110,8 +110,8 @@ module To_json = struct
       | _ -> failwith "unreachable: only structs and enums are collected."
     in
     let rec collect_required_type_defs_from_scope_input
-        (input_struct : StructName.t) : marked_typ list =
-      let rec collect (acc : marked_typ list) (t : marked_typ) : marked_typ list
+        (input_struct : StructName.t) : typ list =
+      let rec collect (acc : typ list) (t : typ) : typ list
           =
         match Marked.unmark t with
         | TStruct s ->

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -49,7 +49,7 @@ module To_json = struct
     Format.fprintf fmt "%s" s
 
   let rec find_scope_def (target_name : string) :
-      'm expr scopes -> 'm expr scope_def option = function
+      'm naked_expr scopes -> 'm naked_expr scope_def option = function
     | Nil -> None
     | ScopeDef scope_def ->
       let name = Format.asprintf "%a" ScopeName.format_t scope_def.scope_name in

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -25,32 +25,32 @@ let dead_value = LocalName.fresh ("dead_value", Pos.no_pos)
 let handle_default = TopLevelName.fresh ("handle_default", Pos.no_pos)
 let handle_default_opt = TopLevelName.fresh ("handle_default_opt", Pos.no_pos)
 
-type expr =
+type naked_expr =
   | EVar of LocalName.t
   | EFunc of TopLevelName.t
-  | EStruct of expr Marked.pos list * StructName.t
-  | EStructFieldAccess of expr Marked.pos * StructFieldName.t * StructName.t
-  | EInj of expr Marked.pos * EnumConstructor.t * EnumName.t
-  | EArray of expr Marked.pos list
+  | EStruct of naked_expr Marked.pos list * StructName.t
+  | EStructFieldAccess of naked_expr Marked.pos * StructFieldName.t * StructName.t
+  | EInj of naked_expr Marked.pos * EnumConstructor.t * EnumName.t
+  | EArray of naked_expr Marked.pos list
   | ELit of L.lit
-  | EApp of expr Marked.pos * expr Marked.pos list
+  | EApp of naked_expr Marked.pos * naked_expr Marked.pos list
   | EOp of operator
 
 type stmt =
   | SInnerFuncDef of LocalName.t Marked.pos * func
   | SLocalDecl of LocalName.t Marked.pos * typ Marked.pos
-  | SLocalDef of LocalName.t Marked.pos * expr Marked.pos
+  | SLocalDef of LocalName.t Marked.pos * naked_expr Marked.pos
   | STryExcept of block * except * block
   | SRaise of except
-  | SIfThenElse of expr Marked.pos * block * block
+  | SIfThenElse of naked_expr Marked.pos * block * block
   | SSwitch of
-      expr Marked.pos
+      naked_expr Marked.pos
       * EnumName.t
       * (block (* Statements corresponding to arm closure body*)
         * (* Variable instantiated with enum payload *) LocalName.t)
         list  (** Each block corresponds to one case of the enum *)
-  | SReturn of expr
-  | SAssert of expr
+  | SReturn of naked_expr
+  | SAssert of naked_expr
 
 and block = stmt Marked.pos list
 

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -25,26 +25,27 @@ let dead_value = LocalName.fresh ("dead_value", Pos.no_pos)
 let handle_default = TopLevelName.fresh ("handle_default", Pos.no_pos)
 let handle_default_opt = TopLevelName.fresh ("handle_default_opt", Pos.no_pos)
 
-type naked_expr =
+type expr = naked_expr Marked.pos
+and naked_expr =
   | EVar of LocalName.t
   | EFunc of TopLevelName.t
-  | EStruct of naked_expr Marked.pos list * StructName.t
-  | EStructFieldAccess of naked_expr Marked.pos * StructFieldName.t * StructName.t
-  | EInj of naked_expr Marked.pos * EnumConstructor.t * EnumName.t
-  | EArray of naked_expr Marked.pos list
+  | EStruct of expr list * StructName.t
+  | EStructFieldAccess of expr * StructFieldName.t * StructName.t
+  | EInj of expr * EnumConstructor.t * EnumName.t
+  | EArray of expr list
   | ELit of L.lit
-  | EApp of naked_expr Marked.pos * naked_expr Marked.pos list
+  | EApp of expr * expr list
   | EOp of operator
 
 type stmt =
   | SInnerFuncDef of LocalName.t Marked.pos * func
-  | SLocalDecl of LocalName.t Marked.pos * typ Marked.pos
-  | SLocalDef of LocalName.t Marked.pos * naked_expr Marked.pos
+  | SLocalDecl of LocalName.t Marked.pos * typ
+  | SLocalDef of LocalName.t Marked.pos * expr
   | STryExcept of block * except * block
   | SRaise of except
-  | SIfThenElse of naked_expr Marked.pos * block * block
+  | SIfThenElse of expr * block * block
   | SSwitch of
-      naked_expr Marked.pos
+      expr
       * EnumName.t
       * (block (* Statements corresponding to arm closure body*)
         * (* Variable instantiated with enum payload *) LocalName.t)
@@ -55,7 +56,7 @@ type stmt =
 and block = stmt Marked.pos list
 
 and func = {
-  func_params : (LocalName.t Marked.pos * typ Marked.pos) list;
+  func_params : (LocalName.t Marked.pos * typ) list;
   func_body : block;
 }
 

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -26,6 +26,7 @@ let handle_default = TopLevelName.fresh ("handle_default", Pos.no_pos)
 let handle_default_opt = TopLevelName.fresh ("handle_default_opt", Pos.no_pos)
 
 type expr = naked_expr Marked.pos
+
 and naked_expr =
   | EVar of LocalName.t
   | EFunc of TopLevelName.t

--- a/compiler/scalc/compile_from_lambda.ml
+++ b/compiler/scalc/compile_from_lambda.ml
@@ -21,17 +21,16 @@ module L = Lcalc.Ast
 module D = Dcalc.Ast
 
 type 'm ctxt = {
-  func_dict : ('m L.naked_expr, A.TopLevelName.t) Var.Map.t;
+  func_dict : ('m L.expr, A.TopLevelName.t) Var.Map.t;
   decl_ctx : decl_ctx;
-  var_dict : ('m L.naked_expr, A.LocalName.t) Var.Map.t;
+  var_dict : ('m L.expr, A.LocalName.t) Var.Map.t;
   inside_definition_of : A.LocalName.t option;
   context_name : string;
 }
 
 (* Expressions can spill out side effect, hence this function also returns a
    list of statements to be prepended before the expression is evaluated *)
-let rec translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
-    A.block * A.expr =
+let rec translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) : A.block * A.expr =
   match Marked.unmark expr with
   | EVar v ->
     let local_var =
@@ -115,8 +114,7 @@ let rec translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
       :: tmp_stmts,
       (A.EVar tmp_var, Expr.pos expr) )
 
-and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) :
-    A.block =
+and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
   match Marked.unmark block_expr with
   | EAssert e ->
     (* Assertions are always encapsulated in a unit-typed let binding *)
@@ -273,9 +271,9 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) :
 let rec translate_scope_body_expr
     (scope_name : ScopeName.t)
     (decl_ctx : decl_ctx)
-    (var_dict : ('m L.naked_expr, A.LocalName.t) Var.Map.t)
-    (func_dict : ('m L.naked_expr, A.TopLevelName.t) Var.Map.t)
-    (scope_expr : 'm L.naked_expr scope_body_expr) : A.block =
+    (var_dict : ('m L.expr, A.LocalName.t) Var.Map.t)
+    (func_dict : ('m L.expr, A.TopLevelName.t) Var.Map.t)
+    (scope_expr : 'm L.expr scope_body_expr) : A.block =
   match scope_expr with
   | Result e ->
     let block, new_e =

--- a/compiler/scalc/compile_from_lambda.ml
+++ b/compiler/scalc/compile_from_lambda.ml
@@ -30,15 +30,15 @@ type 'm ctxt = {
 
 (* Expressions can spill out side effect, hence this function also returns a
    list of statements to be prepended before the expression is evaluated *)
-let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
-    A.block * A.naked_expr Marked.pos =
-  match Marked.unmark naked_expr with
+let rec translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
+    A.block * A.expr =
+  match Marked.unmark expr with
   | EVar v ->
     let local_var =
       try A.EVar (Var.Map.find v ctxt.var_dict)
       with Not_found -> A.EFunc (Var.Map.find v ctxt.func_dict)
     in
-    [], (local_var, Expr.pos naked_expr)
+    [], (local_var, Expr.pos expr)
   | ETuple (args, Some s_name) ->
     let args_stmts, new_args =
       List.fold_left
@@ -49,14 +49,14 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
     in
     let new_args = List.rev new_args in
     let args_stmts = List.rev args_stmts in
-    args_stmts, (A.EStruct (new_args, s_name), Expr.pos naked_expr)
+    args_stmts, (A.EStruct (new_args, s_name), Expr.pos expr)
   | ETuple (_, None) -> failwith "Non-struct tuples cannot be compiled to scalc"
   | ETupleAccess (e1, num_field, Some s_name, _) ->
     let e1_stmts, new_e1 = translate_expr ctxt e1 in
     let field_name =
       fst (List.nth (StructMap.find s_name ctxt.decl_ctx.ctx_structs) num_field)
     in
-    e1_stmts, (A.EStructFieldAccess (new_e1, field_name, s_name), Expr.pos naked_expr)
+    e1_stmts, (A.EStructFieldAccess (new_e1, field_name, s_name), Expr.pos expr)
   | ETupleAccess (_, _, None, _) ->
     failwith "Non-struct tuples cannot be compiled to scalc"
   | EInj (e1, num_cons, e_name, _) ->
@@ -64,7 +64,7 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
     let cons_name =
       fst (List.nth (EnumMap.find e_name ctxt.decl_ctx.ctx_enums) num_cons)
     in
-    e1_stmts, (A.EInj (new_e1, cons_name, e_name), Expr.pos naked_expr)
+    e1_stmts, (A.EInj (new_e1, cons_name, e_name), Expr.pos expr)
   | EApp (f, args) ->
     let f_stmts, new_f = translate_expr ctxt f in
     let args_stmts, new_args =
@@ -75,7 +75,7 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
         ([], []) args
     in
     let new_args = List.rev new_args in
-    f_stmts @ args_stmts, (A.EApp (new_f, new_args), Expr.pos naked_expr)
+    f_stmts @ args_stmts, (A.EApp (new_f, new_args), Expr.pos expr)
   | EArray args ->
     let args_stmts, new_args =
       List.fold_left
@@ -85,9 +85,9 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
         ([], []) args
     in
     let new_args = List.rev new_args in
-    args_stmts, (A.EArray new_args, Expr.pos naked_expr)
-  | EOp op -> [], (A.EOp op, Expr.pos naked_expr)
-  | ELit l -> [], (A.ELit l, Expr.pos naked_expr)
+    args_stmts, (A.EArray new_args, Expr.pos expr)
+  | EOp op -> [], (A.EOp op, Expr.pos expr)
+  | ELit l -> [], (A.ELit l, Expr.pos expr)
   | _ ->
     let tmp_var =
       A.LocalName.fresh
@@ -100,7 +100,7 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
             let v = Marked.unmark (A.LocalName.get_info v) in
             let tmp_rex = Re.Pcre.regexp "^temp_" in
             if Re.Pcre.pmatch ~rex:tmp_rex v then v else "temp_" ^ v),
-          Expr.pos naked_expr )
+          Expr.pos expr )
     in
     let ctxt =
       {
@@ -109,11 +109,11 @@ let rec translate_expr (ctxt : 'm ctxt) (naked_expr : 'm L.expr) :
         context_name = Marked.unmark (A.LocalName.get_info tmp_var);
       }
     in
-    let tmp_stmts = translate_statements ctxt naked_expr in
-    ( ( A.SLocalDecl ((tmp_var, Expr.pos naked_expr), (TAny, Expr.pos naked_expr)),
-        Expr.pos naked_expr )
+    let tmp_stmts = translate_statements ctxt expr in
+    ( ( A.SLocalDecl ((tmp_var, Expr.pos expr), (TAny, Expr.pos expr)),
+        Expr.pos expr )
       :: tmp_stmts,
-      (A.EVar tmp_var, Expr.pos naked_expr) )
+      (A.EVar tmp_var, Expr.pos expr) )
 
 and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) :
     A.block =

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -18,7 +18,7 @@ open Utils
 open Shared_ast
 open Ast
 
-let needs_parens (_e : naked_expr Marked.pos) : bool = false
+let needs_parens (_e : expr) : bool = false
 
 let format_local_name (fmt : Format.formatter) (v : LocalName.t) : unit =
   Format.fprintf fmt "%a_%s" LocalName.format_t v
@@ -28,9 +28,9 @@ let rec format_expr
     (decl_ctx : decl_ctx)
     ?(debug : bool = false)
     (fmt : Format.formatter)
-    (e : naked_expr Marked.pos) : unit =
+    (e : expr) : unit =
   let format_expr = format_expr decl_ctx ~debug in
-  let format_with_parens (fmt : Format.formatter) (e : naked_expr Marked.pos) =
+  let format_with_parens (fmt : Format.formatter) (e : expr) =
     if needs_parens e then
       Format.fprintf fmt "%a%a%a" Print.punctuation "(" format_expr e
         Print.punctuation ")"

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -18,7 +18,7 @@ open Utils
 open Shared_ast
 open Ast
 
-let needs_parens (_e : expr Marked.pos) : bool = false
+let needs_parens (_e : naked_expr Marked.pos) : bool = false
 
 let format_local_name (fmt : Format.formatter) (v : LocalName.t) : unit =
   Format.fprintf fmt "%a_%s" LocalName.format_t v
@@ -28,9 +28,9 @@ let rec format_expr
     (decl_ctx : decl_ctx)
     ?(debug : bool = false)
     (fmt : Format.formatter)
-    (e : expr Marked.pos) : unit =
+    (e : naked_expr Marked.pos) : unit =
   let format_expr = format_expr decl_ctx ~debug in
-  let format_with_parens (fmt : Format.formatter) (e : expr Marked.pos) =
+  let format_with_parens (fmt : Format.formatter) (e : naked_expr Marked.pos) =
     if needs_parens e then
       Format.fprintf fmt "%a%a%a" Print.punctuation "(" format_expr e
         Print.punctuation ")"
@@ -115,11 +115,11 @@ let rec format_statement
     Format.fprintf fmt "@[<hov 2>%a %a %a@ %a@]" Print.keyword "decl"
       LocalName.format_t (Marked.unmark name) Print.punctuation ":"
       (Print.typ decl_ctx) typ
-  | SLocalDef (name, expr) ->
+  | SLocalDef (name, naked_expr) ->
     Format.fprintf fmt "@[<hov 2>%a %a@ %a@]" LocalName.format_t
       (Marked.unmark name) Print.punctuation "="
       (format_expr decl_ctx ~debug)
-      expr
+      naked_expr
   | STryExcept (b_try, except, b_with) ->
     Format.fprintf fmt "@[<v 2>%a%a@ %a@]@\n@[<v 2>%a %a%a@ %a@]" Print.keyword
       "try" Print.punctuation ":"
@@ -143,10 +143,10 @@ let rec format_statement
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "return"
       (format_expr decl_ctx ~debug)
       (ret, Marked.get_mark stmt)
-  | SAssert expr ->
+  | SAssert naked_expr ->
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "assert"
       (format_expr decl_ctx ~debug)
-      (expr, Marked.get_mark stmt)
+      (naked_expr, Marked.get_mark stmt)
   | SSwitch (e_switch, enum, arms) ->
     Format.fprintf fmt "@[<v 0>%a @[<hov 2>%a@]%a@]%a" Print.keyword "switch"
       (format_expr decl_ctx ~debug)

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -115,11 +115,11 @@ let rec format_statement
     Format.fprintf fmt "@[<hov 2>%a %a %a@ %a@]" Print.keyword "decl"
       LocalName.format_t (Marked.unmark name) Print.punctuation ":"
       (Print.typ decl_ctx) typ
-  | SLocalDef (name, naked_expr) ->
+  | SLocalDef (name, expr) ->
     Format.fprintf fmt "@[<hov 2>%a %a@ %a@]" LocalName.format_t
       (Marked.unmark name) Print.punctuation "="
       (format_expr decl_ctx ~debug)
-      naked_expr
+      expr
   | STryExcept (b_try, except, b_with) ->
     Format.fprintf fmt "@[<v 2>%a%a@ %a@]@\n@[<v 2>%a %a%a@ %a@]" Print.keyword
       "try" Print.punctuation ":"
@@ -143,10 +143,10 @@ let rec format_statement
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "return"
       (format_expr decl_ctx ~debug)
       (ret, Marked.get_mark stmt)
-  | SAssert naked_expr ->
+  | SAssert expr ->
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "assert"
       (format_expr decl_ctx ~debug)
-      (naked_expr, Marked.get_mark stmt)
+      (expr, Marked.get_mark stmt)
   | SSwitch (e_switch, enum, arms) ->
     Format.fprintf fmt "@[<v 0>%a @[<hov 2>%a@]%a@]%a" Print.keyword "switch"
       (format_expr decl_ctx ~debug)

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -259,10 +259,8 @@ let format_exception (fmt : Format.formatter) (exc : except Marked.pos) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
 
-let rec format_expression
-    (ctx : decl_ctx)
-    (fmt : Format.formatter)
-    (e : expr) : unit =
+let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :
+    unit =
   match Marked.unmark e with
   | EVar v -> format_var fmt v
   | EFunc f -> format_toplevel_name fmt f

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -232,7 +232,7 @@ let format_toplevel_name (fmt : Format.formatter) (v : TopLevelName.t) : unit =
   let v_str = Marked.unmark (TopLevelName.get_info v) in
   format_name_cleaned fmt v_str
 
-let needs_parens (e : expr Marked.pos) : bool =
+let needs_parens (e : naked_expr Marked.pos) : bool =
   match Marked.unmark e with
   | ELit (LBool _ | LUnit) | EVar _ | EOp _ -> false
   | _ -> true
@@ -262,7 +262,7 @@ let format_exception (fmt : Format.formatter) (exc : except Marked.pos) : unit =
 let rec format_expression
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (e : expr Marked.pos) : unit =
+    (e : naked_expr Marked.pos) : unit =
   match Marked.unmark e with
   | EVar v -> format_var fmt v
   | EFunc f -> format_toplevel_name fmt f

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -144,12 +144,12 @@ let format_enum_cons_name (fmt : Format.formatter) (v : EnumConstructor.t) :
     (avoid_keywords
        (to_ascii (Format.asprintf "%a" EnumConstructor.format_t v)))
 
-let typ_needs_parens (e : typ Marked.pos) : bool =
+let typ_needs_parens (e : typ) : bool =
   match Marked.unmark e with TArrow _ | TArray _ -> true | _ -> false
 
-let rec format_typ (fmt : Format.formatter) (typ : typ Marked.pos) : unit =
+let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
   let format_typ = format_typ in
-  let format_typ_with_parens (fmt : Format.formatter) (t : typ Marked.pos) =
+  let format_typ_with_parens (fmt : Format.formatter) (t : typ) =
     if typ_needs_parens t then Format.fprintf fmt "(%a)" format_typ t
     else Format.fprintf fmt "%a" format_typ t
   in
@@ -232,7 +232,7 @@ let format_toplevel_name (fmt : Format.formatter) (v : TopLevelName.t) : unit =
   let v_str = Marked.unmark (TopLevelName.get_info v) in
   format_name_cleaned fmt v_str
 
-let needs_parens (e : naked_expr Marked.pos) : bool =
+let needs_parens (e : expr) : bool =
   match Marked.unmark e with
   | ELit (LBool _ | LUnit) | EVar _ | EOp _ -> false
   | _ -> true
@@ -262,7 +262,7 @@ let format_exception (fmt : Format.formatter) (exc : except Marked.pos) : unit =
 let rec format_expression
     (ctx : decl_ctx)
     (fmt : Format.formatter)
-    (e : naked_expr Marked.pos) : unit =
+    (e : expr) : unit =
   match Marked.unmark e with
   | EVar v -> format_var fmt v
   | EFunc f -> format_toplevel_name fmt f

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -36,7 +36,7 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
-type expr = (scopelang, Pos.t) gexpr
+type expr = (scopelang, Pos.t) naked_gexpr
 type marked_expr = expr Marked.pos
 
 module ExprMap = Map.Make (struct

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -37,7 +37,6 @@ Set.Make (struct
 end)
 
 type expr = (scopelang, Pos.t) gexpr
-type naked_expr = (scopelang, Pos.t) naked_gexpr
 
 module ExprMap = Map.Make (struct
   type t = expr

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -36,16 +36,16 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
-type expr = (scopelang, Pos.t) naked_gexpr
-type marked_expr = expr Marked.pos
+type naked_expr = (scopelang, Pos.t) naked_gexpr
+type expr = naked_expr Marked.pos
 
 module ExprMap = Map.Make (struct
-  type t = marked_expr
+  type t = expr
 
   let compare = Expr.compare
 end)
 
-let rec locations_used (e : expr Marked.pos) : LocationSet.t =
+let rec locations_used (e : naked_expr Marked.pos) : LocationSet.t =
   match Marked.unmark e with
   | ELocation l -> LocationSet.singleton (l, Marked.get_mark e)
   | EVar _ | ELit _ | EOp _ -> LocationSet.empty
@@ -84,8 +84,8 @@ type io_input = NoInput | OnlyInput | Reentrant
 type io = { io_output : bool Marked.pos; io_input : io_input Marked.pos }
 
 type rule =
-  | Definition of location Marked.pos * marked_typ * io * expr Marked.pos
-  | Assertion of expr Marked.pos
+  | Definition of location Marked.pos * marked_typ * io * naked_expr Marked.pos
+  | Assertion of naked_expr Marked.pos
   | Call of ScopeName.t * SubScopeName.t
 
 type scope_decl = {

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -36,8 +36,8 @@ Set.Make (struct
   let compare = Expr.compare_location
 end)
 
+type expr = (scopelang, Pos.t) gexpr
 type naked_expr = (scopelang, Pos.t) naked_gexpr
-type expr = naked_expr Marked.pos
 
 module ExprMap = Map.Make (struct
   type t = expr
@@ -45,7 +45,7 @@ module ExprMap = Map.Make (struct
   let compare = Expr.compare
 end)
 
-let rec locations_used (e : naked_expr Marked.pos) : LocationSet.t =
+let rec locations_used (e : expr) : LocationSet.t =
   match Marked.unmark e with
   | ELocation l -> LocationSet.singleton (l, Marked.get_mark e)
   | EVar _ | ELit _ | EOp _ -> LocationSet.empty
@@ -84,13 +84,13 @@ type io_input = NoInput | OnlyInput | Reentrant
 type io = { io_output : bool Marked.pos; io_input : io_input Marked.pos }
 
 type rule =
-  | Definition of location Marked.pos * marked_typ * io * naked_expr Marked.pos
-  | Assertion of naked_expr Marked.pos
+  | Definition of location Marked.pos * typ * io * expr
+  | Assertion of expr
   | Call of ScopeName.t * SubScopeName.t
 
 type scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (marked_typ * io) ScopeVarMap.t;
+  scope_sig : (typ * io) ScopeVarMap.t;
   scope_decl_rules : rule list;
 }
 

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -41,7 +41,6 @@ module LocationSet : Set.S with type elt = location Marked.pos
 
 (** {1 Abstract syntax tree} *)
 
-type naked_expr = (scopelang, Pos.t) naked_gexpr
 type expr = (scopelang, Pos.t) gexpr
 
 module ExprMap : Map.S with type key = expr

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -41,8 +41,8 @@ module LocationSet : Set.S with type elt = location Marked.pos
 
 (** {1 Abstract syntax tree} *)
 
-type expr = (scopelang, Pos.t) gexpr
-type marked_expr = (scopelang, Pos.t) marked_gexpr
+type expr = (scopelang, Pos.t) naked_gexpr
+type marked_expr = (scopelang, Pos.t) gexpr
 
 module ExprMap : Map.S with type key = marked_expr
 

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -70,13 +70,13 @@ type io = {
 (** Characterization of the input/output status of a scope variable. *)
 
 type rule =
-  | Definition of location Marked.pos * marked_typ * io * naked_expr Marked.pos
-  | Assertion of naked_expr Marked.pos
+  | Definition of location Marked.pos * typ * io * expr
+  | Assertion of expr
   | Call of ScopeName.t * SubScopeName.t
 
 type scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (marked_typ * io) ScopeVarMap.t;
+  scope_sig : (typ * io) ScopeVarMap.t;
   scope_decl_rules : rule list;
 }
 

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -41,12 +41,12 @@ module LocationSet : Set.S with type elt = location Marked.pos
 
 (** {1 Abstract syntax tree} *)
 
-type expr = (scopelang, Pos.t) naked_gexpr
-type marked_expr = (scopelang, Pos.t) gexpr
+type naked_expr = (scopelang, Pos.t) naked_gexpr
+type expr = (scopelang, Pos.t) gexpr
 
-module ExprMap : Map.S with type key = marked_expr
+module ExprMap : Map.S with type key = expr
 
-val locations_used : marked_expr -> LocationSet.t
+val locations_used : expr -> LocationSet.t
 
 (** This type characterizes the three levels of visibility for a given scope
     variable with regards to the scope's input and possible redefinitions inside
@@ -70,8 +70,8 @@ type io = {
 (** Characterization of the input/output status of a scope variable. *)
 
 type rule =
-  | Definition of location Marked.pos * marked_typ * io * expr Marked.pos
-  | Assertion of expr Marked.pos
+  | Definition of location Marked.pos * marked_typ * io * naked_expr Marked.pos
+  | Assertion of naked_expr Marked.pos
   | Call of ScopeName.t * SubScopeName.t
 
 type scope_decl = {

--- a/compiler/scopelang/dependency.ml
+++ b/compiler/scopelang/dependency.ml
@@ -164,7 +164,7 @@ module TTopologicalTraversal = Graph.Topological.Make (TDependencies)
 module TSCC = Graph.Components.Make (TDependencies)
 (** Tarjan's stongly connected components algorithm, provided by OCamlGraph *)
 
-let rec get_structs_or_enums_in_type (t : typ Marked.pos) : TVertexSet.t =
+let rec get_structs_or_enums_in_type (t : typ) : TVertexSet.t =
   match Marked.unmark t with
   | TStruct s -> TVertexSet.singleton (TVertex.Struct s)
   | TEnum e -> TVertexSet.singleton (TVertex.Enum e)

--- a/compiler/scopelang/dependency.mli
+++ b/compiler/scopelang/dependency.mli
@@ -49,6 +49,6 @@ module TVertexSet : Set.S with type elt = TVertex.t
 module TDependencies :
   Graph.Sig.P with type V.t = TVertex.t and type E.label = Pos.t
 
-val get_structs_or_enums_in_type : typ Marked.pos -> TVertexSet.t
+val get_structs_or_enums_in_type : typ -> TVertexSet.t
 val build_type_graph : struct_ctx -> enum_ctx -> TDependencies.t
 val check_type_cycles : struct_ctx -> enum_ctx -> TVertex.t list

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -76,7 +76,7 @@ let scope ?(debug = false) ctx fmt (name, decl) =
              (Print.typ ctx) typ Print.punctuation "="
              (fun fmt e ->
                match Marked.unmark loc with
-               | SubScopeVar _ -> Print.expr ctx fmt e
+               | SubScopeVar _ -> Print.naked_expr ctx fmt e
                | ScopelangScopeVar v -> (
                  match
                    Marked.unmark
@@ -85,12 +85,12 @@ let scope ?(debug = false) ctx fmt (name, decl) =
                  with
                  | Reentrant ->
                    Format.fprintf fmt "%a@ %a" Print.operator
-                     "reentrant or by default" (Print.expr ~debug ctx) e
-                 | _ -> Format.fprintf fmt "%a" (Print.expr ~debug ctx) e))
+                     "reentrant or by default" (Print.naked_expr ~debug ctx) e
+                 | _ -> Format.fprintf fmt "%a" (Print.naked_expr ~debug ctx) e))
              e
          | Assertion e ->
            Format.fprintf fmt "%a %a" Print.keyword "assert"
-             (Print.expr ~debug ctx) e
+             (Print.naked_expr ~debug ctx) e
          | Call (scope_name, subscope_name) ->
            Format.fprintf fmt "%a %a%a%a%a" Print.keyword "call"
              ScopeName.format_t scope_name Print.punctuation "["

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -21,7 +21,7 @@ open Ast
 let struc
     ctx
     (fmt : Format.formatter)
-    ((name, fields) : StructName.t * (StructFieldName.t * typ Marked.pos) list)
+    ((name, fields) : StructName.t * (StructFieldName.t * typ) list)
     : unit =
   Format.fprintf fmt "%a %a %a %a@\n@[<hov 2>  %a@]@\n%a" Print.keyword "type"
     StructName.format_t name Print.punctuation "=" Print.punctuation "{"
@@ -35,7 +35,7 @@ let struc
 let enum
     ctx
     (fmt : Format.formatter)
-    ((name, cases) : EnumName.t * (EnumConstructor.t * typ Marked.pos) list) :
+    ((name, cases) : EnumName.t * (EnumConstructor.t * typ) list) :
     unit =
   Format.fprintf fmt "%a %a %a @\n@[<hov 2>  %a@]" Print.keyword "type"
     EnumName.format_t name Print.punctuation "="

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -21,8 +21,7 @@ open Ast
 let struc
     ctx
     (fmt : Format.formatter)
-    ((name, fields) : StructName.t * (StructFieldName.t * typ) list)
-    : unit =
+    ((name, fields) : StructName.t * (StructFieldName.t * typ) list) : unit =
   Format.fprintf fmt "%a %a %a %a@\n@[<hov 2>  %a@]@\n%a" Print.keyword "type"
     StructName.format_t name Print.punctuation "=" Print.punctuation "{"
     (Format.pp_print_list
@@ -35,8 +34,7 @@ let struc
 let enum
     ctx
     (fmt : Format.formatter)
-    ((name, cases) : EnumName.t * (EnumConstructor.t * typ) list) :
-    unit =
+    ((name, cases) : EnumName.t * (EnumConstructor.t * typ) list) : unit =
   Format.fprintf fmt "%a %a %a @\n@[<hov 2>  %a@]" Print.keyword "type"
     EnumName.format_t name Print.punctuation "="
     (Format.pp_print_list
@@ -76,7 +74,7 @@ let scope ?(debug = false) ctx fmt (name, decl) =
              (Print.typ ctx) typ Print.punctuation "="
              (fun fmt e ->
                match Marked.unmark loc with
-               | SubScopeVar _ -> Print.naked_expr ctx fmt e
+               | SubScopeVar _ -> Print.expr ctx fmt e
                | ScopelangScopeVar v -> (
                  match
                    Marked.unmark
@@ -85,12 +83,12 @@ let scope ?(debug = false) ctx fmt (name, decl) =
                  with
                  | Reentrant ->
                    Format.fprintf fmt "%a@ %a" Print.operator
-                     "reentrant or by default" (Print.naked_expr ~debug ctx) e
-                 | _ -> Format.fprintf fmt "%a" (Print.naked_expr ~debug ctx) e))
+                     "reentrant or by default" (Print.expr ~debug ctx) e
+                 | _ -> Format.fprintf fmt "%a" (Print.expr ~debug ctx) e))
              e
          | Assertion e ->
            Format.fprintf fmt "%a %a" Print.keyword "assert"
-             (Print.naked_expr ~debug ctx) e
+             (Print.expr ~debug ctx) e
          | Call (scope_name, subscope_name) ->
            Format.fprintf fmt "%a %a%a%a%a" Print.keyword "call"
              ScopeName.format_t scope_name Print.punctuation "["

--- a/compiler/scopelang/scope_to_dcalc.ml
+++ b/compiler/scopelang/scope_to_dcalc.ml
@@ -25,9 +25,9 @@ type scope_var_ctx = {
 
 type scope_sig_ctx = {
   scope_sig_local_vars : scope_var_ctx list;  (** List of scope variables *)
-  scope_sig_scope_var : untyped Dcalc.Ast.naked_expr Var.t;
+  scope_sig_scope_var : untyped Dcalc.Ast.expr Var.t;
       (** Var representing the scope *)
-  scope_sig_input_var : untyped Dcalc.Ast.naked_expr Var.t;
+  scope_sig_input_var : untyped Dcalc.Ast.expr Var.t;
       (** Var representing the scope input inside the scope func *)
   scope_sig_input_struct : StructName.t;  (** Scope input *)
   scope_sig_output_struct : StructName.t;  (** Scope output *)
@@ -40,11 +40,12 @@ type ctx = {
   enums : enum_ctx;
   scope_name : ScopeName.t;
   scopes_parameters : scope_sigs_ctx;
-  scope_vars : (untyped Dcalc.Ast.naked_expr Var.t * naked_typ * Ast.io) ScopeVarMap.t;
+  scope_vars :
+    (untyped Dcalc.Ast.expr Var.t * naked_typ * Ast.io) ScopeVarMap.t;
   subscope_vars :
-    (untyped Dcalc.Ast.naked_expr Var.t * naked_typ * Ast.io) ScopeVarMap.t
+    (untyped Dcalc.Ast.expr Var.t * naked_typ * Ast.io) ScopeVarMap.t
     Ast.SubScopeMap.t;
-  local_vars : (Ast.naked_expr, untyped Dcalc.Ast.naked_expr Var.t) Var.Map.t;
+  local_vars : (Ast.expr, untyped Dcalc.Ast.expr Var.t) Var.Map.t;
 }
 
 let empty_ctx
@@ -101,8 +102,7 @@ let tag_with_log_entry
 
    NOTE: the choice of the exception that will be triggered and show in the
    trace is arbitrary (but deterministic). *)
-let collapse_similar_outcomes (excepts : Ast.expr list) :
-    Ast.expr list =
+let collapse_similar_outcomes (excepts : Ast.expr list) : Ast.expr list =
   let cons_map =
     List.fold_left
       (fun map -> function
@@ -135,8 +135,7 @@ let collapse_similar_outcomes (excepts : Ast.expr list) :
 
 let rec translate_expr (ctx : ctx) (e : Ast.expr) :
     untyped Dcalc.Ast.expr Bindlib.box =
-  Bindlib.box_apply (fun (x : untyped Dcalc.Ast.naked_expr) ->
-      Marked.mark (pos_mark_as e) x)
+  Bindlib.box_apply (fun x -> Marked.mark (pos_mark_as e) x)
   @@
   match Marked.unmark e with
   | EVar v -> Bindlib.box_var (Var.Map.find v ctx.local_vars)
@@ -357,8 +356,8 @@ let translate_rule
     (ctx : ctx)
     (rule : Ast.rule)
     ((sigma_name, pos_sigma) : Utils.Uid.MarkedString.info) :
-    (untyped Dcalc.Ast.naked_expr scope_body_expr Bindlib.box ->
-    untyped Dcalc.Ast.naked_expr scope_body_expr Bindlib.box)
+    (untyped Dcalc.Ast.expr scope_body_expr Bindlib.box ->
+    untyped Dcalc.Ast.expr scope_body_expr Bindlib.box)
     * ctx =
   match rule with
   | Definition ((ScopelangScopeVar a, var_def_pos), tau, a_io, e) ->
@@ -636,7 +635,7 @@ let translate_rules
     (rules : Ast.rule list)
     ((sigma_name, pos_sigma) : Utils.Uid.MarkedString.info)
     (sigma_return_struct_name : StructName.t) :
-    untyped Dcalc.Ast.naked_expr scope_body_expr Bindlib.box * ctx =
+    untyped Dcalc.Ast.expr scope_body_expr Bindlib.box * ctx =
   let scope_lets, new_ctx =
     List.fold_left
       (fun (scope_lets, ctx) rule ->
@@ -673,7 +672,7 @@ let translate_scope_decl
     (sctx : scope_sigs_ctx)
     (scope_name : ScopeName.t)
     (sigma : Ast.scope_decl) :
-    untyped Dcalc.Ast.naked_expr scope_body Bindlib.box * struct_ctx =
+    untyped Dcalc.Ast.expr scope_body Bindlib.box * struct_ctx =
   let sigma_info = ScopeName.get_info sigma.scope_decl_name in
   let scope_sig = Ast.ScopeMap.find sigma.scope_decl_name sctx in
   let scope_variables = scope_sig.scope_sig_local_vars in
@@ -850,7 +849,7 @@ let translate_program (prgm : Ast.program) :
   in
   (* the resulting expression is the list of definitions of all the scopes,
      ending with the top-level scope. *)
-  let (scopes, decl_ctx) : untyped Dcalc.Ast.naked_expr scopes Bindlib.box * _ =
+  let (scopes, decl_ctx) : untyped Dcalc.Ast.expr scopes Bindlib.box * _ =
     List.fold_right
       (fun scope_name (scopes, decl_ctx) ->
         let scope = Ast.ScopeMap.find scope_name prgm.program_scopes in

--- a/compiler/scopelang/scope_to_dcalc.ml
+++ b/compiler/scopelang/scope_to_dcalc.ml
@@ -19,7 +19,7 @@ open Shared_ast
 
 type scope_var_ctx = {
   scope_var_name : ScopeVar.t;
-  scope_var_typ : typ;
+  scope_var_typ : naked_typ;
   scope_var_io : Ast.io;
 }
 
@@ -40,9 +40,9 @@ type ctx = {
   enums : enum_ctx;
   scope_name : ScopeName.t;
   scopes_parameters : scope_sigs_ctx;
-  scope_vars : (untyped Dcalc.Ast.naked_expr Var.t * typ * Ast.io) ScopeVarMap.t;
+  scope_vars : (untyped Dcalc.Ast.naked_expr Var.t * naked_typ * Ast.io) ScopeVarMap.t;
   subscope_vars :
-    (untyped Dcalc.Ast.naked_expr Var.t * typ * Ast.io) ScopeVarMap.t
+    (untyped Dcalc.Ast.naked_expr Var.t * naked_typ * Ast.io) ScopeVarMap.t
     Ast.SubScopeMap.t;
   local_vars : (Ast.naked_expr, untyped Dcalc.Ast.naked_expr Var.t) Var.Map.t;
 }
@@ -101,8 +101,8 @@ let tag_with_log_entry
 
    NOTE: the choice of the exception that will be triggered and show in the
    trace is arbitrary (but deterministic). *)
-let collapse_similar_outcomes (excepts : Ast.naked_expr Marked.pos list) :
-    Ast.naked_expr Marked.pos list =
+let collapse_similar_outcomes (excepts : Ast.expr list) :
+    Ast.expr list =
   let cons_map =
     List.fold_left
       (fun map -> function
@@ -133,7 +133,7 @@ let collapse_similar_outcomes (excepts : Ast.naked_expr Marked.pos list) :
   in
   excepts
 
-let rec translate_expr (ctx : ctx) (e : Ast.naked_expr Marked.pos) :
+let rec translate_expr (ctx : ctx) (e : Ast.expr) :
     untyped Dcalc.Ast.expr Bindlib.box =
   Bindlib.box_apply (fun (x : untyped Dcalc.Ast.naked_expr) ->
       Marked.mark (pos_mark_as e) x)

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -174,90 +174,90 @@ type 'a glocation =
       ScopeName.t * SubScopeName.t Marked.pos * ScopeVar.t Marked.pos
       -> [< desugared | scopelang ] glocation
 
-type ('a, 't) marked_gexpr = (('a, 't) gexpr, 't) Marked.t
+type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
 (** General expressions: groups all expression cases of the different ASTs, and
     uses a GADT to eliminate irrelevant cases for each one. The ['t] annotations
     are also totally unconstrained at this point. The dcalc exprs, for example,
-    are then defined with [type expr = dcalc gexpr] plus the annotations.
+    are then defined with [type expr = dcalc naked_gexpr] plus the annotations.
 
     A few tips on using this GADT:
 
     - To write a function that handles cases from different ASTs, explicit the
-      type variables: [fun (type a) (x: a gexpr) -> ...]
+      type variables: [fun (type a) (x: a naked_gexpr) -> ...]
     - For recursive functions, you may need to additionally explicit the
-      generalisation of the variable: [let rec f: type a . a gexpr -> ...] *)
+      generalisation of the variable: [let rec f: type a . a naked_gexpr -> ...] *)
 
 (** The expressions use the {{:https://lepigre.fr/ocaml-bindlib/} Bindlib}
     library, based on higher-order abstract syntax *)
-and ('a, 't) gexpr =
+and ('a, 't) naked_gexpr =
   (* Constructors common to all ASTs *)
-  | ELit : 'a glit -> ('a any, 't) gexpr
+  | ELit : 'a glit -> ('a any, 't) naked_gexpr
   | EApp :
-      ('a, 't) marked_gexpr * ('a, 't) marked_gexpr list
-      -> ('a any, 't) gexpr
-  | EOp : operator -> ('a any, 't) gexpr
-  | EArray : ('a, 't) marked_gexpr list -> ('a any, 't) gexpr
+      ('a, 't) gexpr * ('a, 't) gexpr list
+      -> ('a any, 't) naked_gexpr
+  | EOp : operator -> ('a any, 't) naked_gexpr
+  | EArray : ('a, 't) gexpr list -> ('a any, 't) naked_gexpr
   (* All but statement calculus *)
   | EVar :
-      ('a, 't) gexpr Bindlib.var
-      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) naked_gexpr Bindlib.var
+      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) naked_gexpr
   | EAbs :
-      (('a, 't) gexpr, ('a, 't) marked_gexpr) Bindlib.mbinder * marked_typ list
-      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) gexpr
+      (('a, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder * marked_typ list
+      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) naked_gexpr
   | EIfThenElse :
-      ('a, 't) marked_gexpr * ('a, 't) marked_gexpr * ('a, 't) marked_gexpr
-      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr * ('a, 't) gexpr * ('a, 't) gexpr
+      -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) naked_gexpr
   (* Early stages *)
-  | ELocation : 'a glocation -> (([< desugared | scopelang ] as 'a), 't) gexpr
+  | ELocation : 'a glocation -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EStruct :
-      StructName.t * ('a, 't) marked_gexpr StructFieldMap.t
-      -> (([< desugared | scopelang ] as 'a), 't) gexpr
+      StructName.t * ('a, 't) gexpr StructFieldMap.t
+      -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EStructAccess :
-      ('a, 't) marked_gexpr * StructFieldName.t * StructName.t
-      -> (([< desugared | scopelang ] as 'a), 't) gexpr
+      ('a, 't) gexpr * StructFieldName.t * StructName.t
+      -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EEnumInj :
-      ('a, 't) marked_gexpr * EnumConstructor.t * EnumName.t
-      -> (([< desugared | scopelang ] as 'a), 't) gexpr
+      ('a, 't) gexpr * EnumConstructor.t * EnumName.t
+      -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EMatchS :
-      ('a, 't) marked_gexpr
+      ('a, 't) gexpr
       * EnumName.t
-      * ('a, 't) marked_gexpr EnumConstructorMap.t
-      -> (([< desugared | scopelang ] as 'a), 't) gexpr
+      * ('a, 't) gexpr EnumConstructorMap.t
+      -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   (* Lambda-like *)
   | ETuple :
-      ('a, 't) marked_gexpr list * StructName.t option
-      -> (([< dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr list * StructName.t option
+      -> (([< dcalc | lcalc ] as 'a), 't) naked_gexpr
   | ETupleAccess :
-      ('a, 't) marked_gexpr * int * StructName.t option * marked_typ list
-      -> (([< dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr * int * StructName.t option * marked_typ list
+      -> (([< dcalc | lcalc ] as 'a), 't) naked_gexpr
   | EInj :
-      ('a, 't) marked_gexpr * int * EnumName.t * marked_typ list
-      -> (([< dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr * int * EnumName.t * marked_typ list
+      -> (([< dcalc | lcalc ] as 'a), 't) naked_gexpr
   | EMatch :
-      ('a, 't) marked_gexpr * ('a, 't) marked_gexpr list * EnumName.t
-      -> (([< dcalc | lcalc ] as 'a), 't) gexpr
-  | EAssert : ('a, 't) marked_gexpr -> (([< dcalc | lcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr * ('a, 't) gexpr list * EnumName.t
+      -> (([< dcalc | lcalc ] as 'a), 't) naked_gexpr
+  | EAssert : ('a, 't) gexpr -> (([< dcalc | lcalc ] as 'a), 't) naked_gexpr
   (* Default terms *)
   | EDefault :
-      ('a, 't) marked_gexpr list * ('a, 't) marked_gexpr * ('a, 't) marked_gexpr
-      -> (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr list * ('a, 't) gexpr * ('a, 't) gexpr
+      -> (([< desugared | scopelang | dcalc ] as 'a), 't) naked_gexpr
   | ErrorOnEmpty :
-      ('a, 't) marked_gexpr
-      -> (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr
+      ('a, 't) gexpr
+      -> (([< desugared | scopelang | dcalc ] as 'a), 't) naked_gexpr
   (* Lambda calculus with exceptions *)
-  | ERaise : except -> ((lcalc as 'a), 't) gexpr
+  | ERaise : except -> ((lcalc as 'a), 't) naked_gexpr
   | ECatch :
-      ('a, 't) marked_gexpr * except * ('a, 't) marked_gexpr
-      -> ((lcalc as 'a), 't) gexpr
+      ('a, 't) gexpr * except * ('a, 't) gexpr
+      -> ((lcalc as 'a), 't) naked_gexpr
 
 (* (\* Statement calculus *\)
- * | ESVar: LocalName.t -> (scalc as 'a, 't) gexpr
- * | ESStruct: ('a, 't) marked_gexpr list * StructName.t -> (scalc as 'a, 't) gexpr
- * | ESStructFieldAccess: ('a, 't) marked_gexpr * StructFieldName.t * StructName.t -> (scalc as 'a, 't) gexpr
- * | ESInj: ('a, 't) marked_gexpr * EnumConstructor.t * EnumName.t -> (scalc as 'a, 't) gexpr
- * | ESFunc: TopLevelName.t -> (scalc as 'a, 't) gexpr *)
+ * | ESVar: LocalName.t -> (scalc as 'a, 't) naked_gexpr
+ * | ESStruct: ('a, 't) gexpr list * StructName.t -> (scalc as 'a, 't) naked_gexpr
+ * | ESStructFieldAccess: ('a, 't) gexpr * StructFieldName.t * StructName.t -> (scalc as 'a, 't) naked_gexpr
+ * | ESInj: ('a, 't) gexpr * EnumConstructor.t * EnumName.t -> (scalc as 'a, 't) naked_gexpr
+ * | ESFunc: TopLevelName.t -> (scalc as 'a, 't) naked_gexpr *)
 
-type 'e anyexpr = 'e constraint 'e = (_ any, _) gexpr
+type 'e anyexpr = 'e constraint 'e = (_ any, _) naked_gexpr
 (** Shorter alias for functions taking any kind of expression *)
 
 (** {2 Markings} *)
@@ -267,25 +267,25 @@ type typed = { pos : Pos.t; ty : marked_typ }
 
 (** The generic type of AST markings. Using a GADT allows functions to be
     polymorphic in the marking, but still do transformations on types when
-    appropriate. Expected to fill the ['t] parameter of [gexpr] and
-    [marked_gexpr] (a ['t] annotation different from this type is used in the
+    appropriate. Expected to fill the ['t] parameter of [naked_gexpr] and
+    [gexpr] (a ['t] annotation different from this type is used in the
     middle of the typing processing, but all visible ASTs should otherwise use
     this. *)
 type _ mark = Untyped : untyped -> untyped mark | Typed : typed -> typed mark
 
-type 'e marked = ('e, 'm mark) Marked.t constraint 'e = ('a, 'm mark) gexpr
-(** [('a, 't) gexpr marked] is equivalent to [('a, 'm mark) marked_gexpr] but
+type 'e marked = ('e, 'm mark) Marked.t constraint 'e = ('a, 'm mark) naked_gexpr
+(** [('a, 't) naked_gexpr marked] is equivalent to [('a, 'm mark) gexpr] but
     often more convenient to write since we generally use the type of
-    expressions ['e = (_, _ mark) gexpr] as type parameter. *)
+    expressions ['e = (_, _ mark) naked_gexpr] as type parameter. *)
 
 (** Useful for errors and printing, for example *)
 type any_marked_expr =
-  | AnyExpr : (_ any, _ mark) marked_gexpr -> any_marked_expr
+  | AnyExpr : (_ any, _ mark) gexpr -> any_marked_expr
 
 (** {2 Higher-level program structure} *)
 
 (** Constructs scopes and programs on top of expressions. The ['e] type
-    parameter throughout is expected to match instances of the [gexpr] type
+    parameter throughout is expected to match instances of the [naked_gexpr] type
     defined above. Markings are constrained to the [mark] GADT defined above.
     Note that this structure is at the moment only relevant for [dcalc] and
     [lcalc], as [scopelang] has its own scope structure, as the name implies. *)
@@ -310,7 +310,7 @@ type 'e scope_let = {
   scope_let_next : ('e, 'e scope_body_expr) Bindlib.binder;
   scope_let_pos : Pos.t;
 }
-  constraint 'e = ('a, 'm mark) gexpr
+  constraint 'e = ('a, 'm mark) naked_gexpr
 (** This type is parametrized by the expression type so it can be reused in
     later intermediate representations. *)
 
@@ -320,7 +320,7 @@ type 'e scope_let = {
 and 'e scope_body_expr =
   | Result of 'e marked
   | ScopeLet of 'e scope_let
-  constraint 'e = ('a, 'm mark) gexpr
+  constraint 'e = ('a, 'm mark) naked_gexpr
 
 type 'e scope_body = {
   scope_body_input_struct : StructName.t;
@@ -343,7 +343,7 @@ type 'e scope_def = {
 and 'e scopes =
   | Nil
   | ScopeDef of 'e scope_def
-  constraint 'e = ('a, 'm mark) gexpr
+  constraint 'e = ('a, 'm mark) naked_gexpr
 
 type struct_ctx = (StructFieldName.t * marked_typ) list StructMap.t
 type enum_ctx = (EnumConstructor.t * marked_typ) list EnumMap.t

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -178,7 +178,7 @@ type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
 (** General expressions: groups all expression cases of the different ASTs, and
     uses a GADT to eliminate irrelevant cases for each one. The ['t] annotations
     are also totally unconstrained at this point. The dcalc exprs, for example,
-    are then defined with [type expr = dcalc naked_gexpr] plus the annotations.
+    are then defined with [type naked_expr = dcalc naked_gexpr] plus the annotations.
 
     A few tips on using this GADT:
 

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -178,7 +178,7 @@ type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
 (** General expressions: groups all expression cases of the different ASTs, and
     uses a GADT to eliminate irrelevant cases for each one. The ['t] annotations
     are also totally unconstrained at this point. The dcalc exprs, for example,
-    are then defined with [type naked_expr = dcalc naked_gexpr] plus the annotations.
+    are then defined with [type expr = dcalc gexpr] plus the annotations.
 
     A few tips on using this GADT:
 
@@ -187,14 +187,10 @@ type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
     - For recursive functions, you may need to additionally explicit the
       generalisation of the variable: [let rec f: type a . a naked_gexpr -> ...] *)
 
-(** The expressions use the {{:https://lepigre.fr/ocaml-bindlib/} Bindlib}
-    library, based on higher-order abstract syntax *)
 and ('a, 't) naked_gexpr =
   (* Constructors common to all ASTs *)
   | ELit : 'a glit -> ('a any, 't) naked_gexpr
-  | EApp :
-      ('a, 't) gexpr * ('a, 't) gexpr list
-      -> ('a any, 't) naked_gexpr
+  | EApp : ('a, 't) gexpr * ('a, 't) gexpr list -> ('a any, 't) naked_gexpr
   | EOp : operator -> ('a any, 't) naked_gexpr
   | EArray : ('a, 't) gexpr list -> ('a any, 't) naked_gexpr
   (* All but statement calculus *)
@@ -208,7 +204,9 @@ and ('a, 't) naked_gexpr =
       ('a, 't) gexpr * ('a, 't) gexpr * ('a, 't) gexpr
       -> (([< desugared | scopelang | dcalc | lcalc ] as 'a), 't) naked_gexpr
   (* Early stages *)
-  | ELocation : 'a glocation -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
+  | ELocation :
+      'a glocation
+      -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EStruct :
       StructName.t * ('a, 't) gexpr StructFieldMap.t
       -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
@@ -219,9 +217,7 @@ and ('a, 't) naked_gexpr =
       ('a, 't) gexpr * EnumConstructor.t * EnumName.t
       -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   | EMatchS :
-      ('a, 't) gexpr
-      * EnumName.t
-      * ('a, 't) gexpr EnumConstructorMap.t
+      ('a, 't) gexpr * EnumName.t * ('a, 't) gexpr EnumConstructorMap.t
       -> (([< desugared | scopelang ] as 'a), 't) naked_gexpr
   (* Lambda-like *)
   | ETuple :
@@ -250,6 +246,16 @@ and ('a, 't) naked_gexpr =
       ('a, 't) gexpr * except * ('a, 't) gexpr
       -> ((lcalc as 'a), 't) naked_gexpr
 
+type 'a box = 'a Bindlib.box
+
+type ('e, 'b) binder = (('a, 't) naked_gexpr, 'b) Bindlib.binder
+  constraint 'e = ('a, 't) gexpr
+(** The expressions use the {{:https://lepigre.fr/ocaml-bindlib/} Bindlib}
+    library, based on higher-order abstract syntax *)
+
+type ('e, 'b) mbinder = (('a, 't) naked_gexpr, 'b) Bindlib.mbinder
+  constraint 'e = ('a, 't) gexpr
+
 (* (\* Statement calculus *\)
  * | ESVar: LocalName.t -> (scalc as 'a, 't) naked_gexpr
  * | ESStruct: ('a, 't) gexpr list * StructName.t -> (scalc as 'a, 't) naked_gexpr
@@ -257,7 +263,7 @@ and ('a, 't) naked_gexpr =
  * | ESInj: ('a, 't) gexpr * EnumConstructor.t * EnumName.t -> (scalc as 'a, 't) naked_gexpr
  * | ESFunc: TopLevelName.t -> (scalc as 'a, 't) naked_gexpr *)
 
-type 'e anyexpr = 'e constraint 'e = (_ any, _) naked_gexpr
+type 'e anyexpr = 'e constraint 'e = (_ any, _) gexpr
 (** Shorter alias for functions taking any kind of expression *)
 
 (** {2 Markings} *)
@@ -268,27 +274,21 @@ type typed = { pos : Pos.t; ty : typ }
 (** The generic type of AST markings. Using a GADT allows functions to be
     polymorphic in the marking, but still do transformations on types when
     appropriate. Expected to fill the ['t] parameter of [naked_gexpr] and
-    [gexpr] (a ['t] annotation different from this type is used in the
-    middle of the typing processing, but all visible ASTs should otherwise use
-    this. *)
+    [gexpr] (a ['t] annotation different from this type is used in the middle of
+    the typing processing, but all visible ASTs should otherwise use this. *)
 type _ mark = Untyped : untyped -> untyped mark | Typed : typed -> typed mark
 
-type 'e marked = ('e, 'm mark) Marked.t constraint 'e = ('a, 'm mark) naked_gexpr
-(** [('a, 't) naked_gexpr marked] is equivalent to [('a, 'm mark) gexpr] but
-    often more convenient to write since we generally use the type of
-    expressions ['e = (_, _ mark) naked_gexpr] as type parameter. *)
-
 (** Useful for errors and printing, for example *)
-type any_marked_expr =
-  | AnyExpr : (_ any, _ mark) gexpr -> any_marked_expr
+type any_marked_expr = AnyExpr : (_ any, _ mark) gexpr -> any_marked_expr
 
 (** {2 Higher-level program structure} *)
 
 (** Constructs scopes and programs on top of expressions. The ['e] type
-    parameter throughout is expected to match instances of the [naked_gexpr] type
-    defined above. Markings are constrained to the [mark] GADT defined above.
-    Note that this structure is at the moment only relevant for [dcalc] and
-    [lcalc], as [scopelang] has its own scope structure, as the name implies. *)
+    parameter throughout is expected to match instances of the [naked_gexpr]
+    type defined above. Markings are constrained to the [mark] GADT defined
+    above. Note that this structure is at the moment only relevant for [dcalc]
+    and [lcalc], as [scopelang] has its own scope structure, as the name
+    implies. *)
 
 (** This kind annotation signals that the let-binding respects a structural
     invariant. These invariants concern the shape of the expression in the
@@ -306,11 +306,11 @@ type scope_let_kind =
 type 'e scope_let = {
   scope_let_kind : scope_let_kind;
   scope_let_typ : typ;
-  scope_let_expr : 'e marked;
-  scope_let_next : ('e, 'e scope_body_expr) Bindlib.binder;
+  scope_let_expr : 'e;
+  scope_let_next : ('e, 'e scope_body_expr) binder;
   scope_let_pos : Pos.t;
 }
-  constraint 'e = ('a, 'm mark) naked_gexpr
+  constraint 'e = ('a, 'm mark) gexpr
 (** This type is parametrized by the expression type so it can be reused in
     later intermediate representations. *)
 
@@ -318,15 +318,16 @@ type 'e scope_let = {
     let-binding expression, plus an annotation for the kind of the let-binding
     that comes from the compilation of a {!module: Scopelang.Ast} statement. *)
 and 'e scope_body_expr =
-  | Result of 'e marked
+  | Result of 'e
   | ScopeLet of 'e scope_let
-  constraint 'e = ('a, 'm mark) naked_gexpr
+  constraint 'e = (_, _ mark) gexpr
 
 type 'e scope_body = {
   scope_body_input_struct : StructName.t;
   scope_body_output_struct : StructName.t;
-  scope_body_expr : ('e, 'e scope_body_expr) Bindlib.binder;
+  scope_body_expr : ('e, 'e scope_body_expr) binder;
 }
+  constraint 'e = (_, _ mark) gexpr
 (** Instead of being a single expression, we give a little more ad-hoc structure
     to the scope body by decomposing it in an ordered list of let-bindings, and
     a result expression that uses the let-binded variables. The first binder is
@@ -335,15 +336,16 @@ type 'e scope_body = {
 type 'e scope_def = {
   scope_name : ScopeName.t;
   scope_body : 'e scope_body;
-  scope_next : ('e, 'e scopes) Bindlib.binder;
+  scope_next : ('e, 'e scopes) binder;
 }
+  constraint 'e = (_, _ mark) gexpr
 
 (** Finally, we do the same transformation for the whole program for the kinded
     lets. This permit us to use bindlib variables for scopes names. *)
 and 'e scopes =
   | Nil
   | ScopeDef of 'e scope_def
-  constraint 'e = ('a, 'm mark) naked_gexpr
+  constraint 'e = (_, _ mark) gexpr
 
 type struct_ctx = (StructFieldName.t * typ) list StructMap.t
 type enum_ctx = (EnumConstructor.t * typ) list EnumMap.t

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -729,7 +729,7 @@ let remove_logging_calls e =
   in
   f () e
 
-let format ?debug decl_ctx ppf e = Print.expr ?debug decl_ctx ppf e
+let format ?debug decl_ctx ppf e = Print.naked_expr ?debug decl_ctx ppf e
 
 let rec size : type a. (a, 't) naked_gexpr marked -> int =
  fun e ->

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -98,9 +98,9 @@ let mark_pos (type m) (m : m mark) : Pos.t =
 let pos (type m) (x : ('a, m mark) Marked.t) : Pos.t =
   mark_pos (Marked.get_mark x)
 
-let ty (_, m) : marked_typ = match m with Typed { ty; _ } -> ty
+let ty (_, m) : typ = match m with Typed { ty; _ } -> ty
 
-let with_ty (type m) (ty : marked_typ) (x : ('a, m mark) Marked.t) :
+let with_ty (type m) (ty : typ) (x : ('a, m mark) Marked.t) :
     ('a, typed mark) Marked.t =
   Marked.mark
     (match Marked.get_mark x with
@@ -111,7 +111,7 @@ let with_ty (type m) (ty : marked_typ) (x : ('a, m mark) Marked.t) :
 let map_mark
     (type m)
     (pos_f : Pos.t -> Pos.t)
-    (ty_f : marked_typ -> marked_typ)
+    (ty_f : typ -> typ)
     (m : m mark) : m mark =
   match m with
   | Untyped { pos } -> Untyped { pos = pos_f pos }
@@ -120,7 +120,7 @@ let map_mark
 let map_mark2
     (type m)
     (pos_f : Pos.t -> Pos.t -> Pos.t)
-    (ty_f : typed -> typed -> marked_typ)
+    (ty_f : typed -> typed -> typ)
     (m1 : m mark)
     (m2 : m mark) : m mark =
   match m1, m2 with
@@ -130,7 +130,7 @@ let map_mark2
 let fold_marks
     (type m)
     (pos_f : Pos.t list -> Pos.t)
-    (ty_f : typed list -> marked_typ)
+    (ty_f : typed list -> typ)
     (ms : m mark list) : m mark =
   match ms with
   | [] -> invalid_arg "Dcalc.Ast.fold_mark"

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -18,8 +18,6 @@
 open Utils
 open Definitions
 
-type 'a box = 'a Bindlib.box
-
 (** Functions handling the types of [shared_ast] *)
 
 (* Basic block constructors *)
@@ -108,11 +106,8 @@ let with_ty (type m) (ty : typ) (x : ('a, m mark) Marked.t) :
     | Typed m -> Typed { m with ty })
     (Marked.unmark x)
 
-let map_mark
-    (type m)
-    (pos_f : Pos.t -> Pos.t)
-    (ty_f : typ -> typ)
-    (m : m mark) : m mark =
+let map_mark (type m) (pos_f : Pos.t -> Pos.t) (ty_f : typ -> typ) (m : m mark)
+    : m mark =
   match m with
   | Untyped { pos } -> Untyped { pos = pos_f pos }
   | Typed { pos; ty } -> Typed { pos = pos_f pos; ty = ty_f ty }
@@ -283,7 +278,7 @@ let make_default exceptions just cons mark =
 
 (* Tests *)
 
-let is_value (type a) (e : (a, 'm mark) naked_gexpr marked) =
+let is_value (type a) (e : (a, _) gexpr) =
   match Marked.unmark e with
   | ELit _ | EAbs _ | EOp _ | ERaise _ -> true
   | _ -> false
@@ -532,8 +527,7 @@ let compare_except ex1 ex2 = Stdlib.compare ex1 ex2
 
 (* weird indentation; see
    https://github.com/ocaml-ppx/ocamlformat/issues/2143 *)
-let rec equal_list :
-          'a. ('a, 't) gexpr list -> ('a, 't) gexpr list -> bool =
+let rec equal_list : 'a. ('a, 't) gexpr list -> ('a, 't) gexpr list -> bool =
  fun es1 es2 ->
   try List.for_all2 equal es1 es2 with Invalid_argument _ -> false
 
@@ -683,7 +677,7 @@ let rec compare : type a. (a, _) gexpr -> (a, _) gexpr -> int =
   | ERaise _, _ -> -1 | _, ERaise _ -> 1
   | ECatch _, _ -> . | _, ECatch _ -> .
 
-let rec free_vars : type a. (a, 't) naked_gexpr marked -> (a, 't) naked_gexpr Var.Set.t =
+let rec free_vars : type a. (a, 't) gexpr -> (a, 't) gexpr Var.Set.t =
  fun e ->
   match Marked.unmark e with
   | EOp _ | ELit _ | ERaise _ -> Var.Set.empty
@@ -731,9 +725,9 @@ let remove_logging_calls e =
   in
   f () e
 
-let format ?debug decl_ctx ppf e = Print.naked_expr ?debug decl_ctx ppf e
+let format ?debug decl_ctx ppf e = Print.expr ?debug decl_ctx ppf e
 
-let rec size : type a. (a, 't) naked_gexpr marked -> int =
+let rec size : type a. (a, 't) gexpr -> int =
  fun e ->
   match Marked.unmark e with
   | EVar _ | ELit _ | EOp _ -> 1

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -18,6 +18,8 @@
 open Utils
 open Definitions
 
+type 'a box = 'a Bindlib.box
+
 (** Functions handling the types of [shared_ast] *)
 
 (* Basic block constructors *)
@@ -147,8 +149,8 @@ let fold_marks
 let map
     (type a)
     (ctx : 'ctx)
-    ~(f : 'ctx -> (a, 'm1) gexpr -> (a, 'm2) gexpr Bindlib.box)
-    (e : ((a, 'm1) naked_gexpr, 'm2) Marked.t) : (a, 'm2) gexpr Bindlib.box =
+    ~(f : 'ctx -> (a, 'm1) gexpr -> (a, 'm2) gexpr box)
+    (e : ((a, 'm1) naked_gexpr, 'm2) Marked.t) : (a, 'm2) gexpr box =
   let m = Marked.get_mark e in
   match Marked.unmark e with
   | ELit l -> elit l m

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -147,8 +147,8 @@ let fold_marks
 let map
     (type a)
     (ctx : 'ctx)
-    ~(f : 'ctx -> (a, 'm1) marked_gexpr -> (a, 'm2) marked_gexpr Bindlib.box)
-    (e : ((a, 'm1) gexpr, 'm2) Marked.t) : (a, 'm2) marked_gexpr Bindlib.box =
+    ~(f : 'ctx -> (a, 'm1) gexpr -> (a, 'm2) gexpr Bindlib.box)
+    (e : ((a, 'm1) naked_gexpr, 'm2) Marked.t) : (a, 'm2) gexpr Bindlib.box =
   let m = Marked.get_mark e in
   match Marked.unmark e with
   | ELit l -> elit l m
@@ -281,7 +281,7 @@ let make_default exceptions just cons mark =
 
 (* Tests *)
 
-let is_value (type a) (e : (a, 'm mark) gexpr marked) =
+let is_value (type a) (e : (a, 'm mark) naked_gexpr marked) =
   match Marked.unmark e with
   | ELit _ | EAbs _ | EOp _ | ERaise _ -> true
   | _ -> false
@@ -531,11 +531,11 @@ let compare_except ex1 ex2 = Stdlib.compare ex1 ex2
 (* weird indentation; see
    https://github.com/ocaml-ppx/ocamlformat/issues/2143 *)
 let rec equal_list :
-          'a. ('a, 't) marked_gexpr list -> ('a, 't) marked_gexpr list -> bool =
+          'a. ('a, 't) gexpr list -> ('a, 't) gexpr list -> bool =
  fun es1 es2 ->
   try List.for_all2 equal es1 es2 with Invalid_argument _ -> false
 
-and equal : type a. (a, 't) marked_gexpr -> (a, 't) marked_gexpr -> bool =
+and equal : type a. (a, 't) gexpr -> (a, 't) gexpr -> bool =
  fun e1 e2 ->
   match Marked.unmark e1, Marked.unmark e2 with
   | EVar v1, EVar v2 -> Bindlib.eq_vars v1 v2
@@ -584,7 +584,7 @@ and equal : type a. (a, 't) marked_gexpr -> (a, 't) marked_gexpr -> bool =
       _ ) ->
     false
 
-let rec compare : type a. (a, _) marked_gexpr -> (a, _) marked_gexpr -> int =
+let rec compare : type a. (a, _) gexpr -> (a, _) gexpr -> int =
  fun e1 e2 ->
   (* Infix operator to chain comparisons lexicographically. *)
   let ( @@< ) cmp1 cmpf = match cmp1 with 0 -> cmpf () | n -> n in
@@ -681,7 +681,7 @@ let rec compare : type a. (a, _) marked_gexpr -> (a, _) marked_gexpr -> int =
   | ERaise _, _ -> -1 | _, ERaise _ -> 1
   | ECatch _, _ -> . | _, ECatch _ -> .
 
-let rec free_vars : type a. (a, 't) gexpr marked -> (a, 't) gexpr Var.Set.t =
+let rec free_vars : type a. (a, 't) naked_gexpr marked -> (a, 't) naked_gexpr Var.Set.t =
  fun e ->
   match Marked.unmark e with
   | EOp _ | ELit _ | ERaise _ -> Var.Set.empty
@@ -731,7 +731,7 @@ let remove_logging_calls e =
 
 let format ?debug decl_ctx ppf e = Print.expr ?debug decl_ctx ppf e
 
-let rec size : type a. (a, 't) gexpr marked -> int =
+let rec size : type a. (a, 't) naked_gexpr marked -> int =
  fun e ->
   match Marked.unmark e with
   | EVar _ | ELit _ | EOp _ -> 1

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -37,7 +37,7 @@ val etupleaccess :
   (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
   int ->
   StructName.t option ->
-  marked_typ list ->
+  typ list ->
   't ->
   ('a, 't) gexpr box
 
@@ -45,7 +45,7 @@ val einj :
   (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
   int ->
   EnumName.t ->
-  marked_typ list ->
+  typ list ->
   't ->
   ('a, 't) gexpr box
 
@@ -65,7 +65,7 @@ val elit : 'a any glit -> 't -> ('a, 't) gexpr box
 
 val eabs :
   (('a any, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder box ->
-  marked_typ list ->
+  typ list ->
   't ->
   ('a, 't) gexpr box
 
@@ -115,21 +115,21 @@ val eraise : except -> 't -> (lcalc, 't) gexpr box
 val no_mark : 'm mark -> 'm mark
 val mark_pos : 'm mark -> Pos.t
 val pos : ('e, _) naked_gexpr marked -> Pos.t
-val ty : (_, typed mark) Marked.t -> marked_typ
-val with_ty : marked_typ -> ('a, _ mark) Marked.t -> ('a, typed mark) Marked.t
+val ty : (_, typed mark) Marked.t -> typ
+val with_ty : typ -> ('a, _ mark) Marked.t -> ('a, typed mark) Marked.t
 
 val map_mark :
-  (Pos.t -> Pos.t) -> (marked_typ -> marked_typ) -> 'm mark -> 'm mark
+  (Pos.t -> Pos.t) -> (typ -> typ) -> 'm mark -> 'm mark
 
 val map_mark2 :
   (Pos.t -> Pos.t -> Pos.t) ->
-  (typed -> typed -> marked_typ) ->
+  (typed -> typed -> typ) ->
   'm mark ->
   'm mark ->
   'm mark
 
 val fold_marks :
-  (Pos.t list -> Pos.t) -> (typed list -> marked_typ) -> 'm mark list -> 'm mark
+  (Pos.t list -> Pos.t) -> (typed list -> typ) -> 'm mark list -> 'm mark
 
 val untype :
   ('a, 'm mark) gexpr -> ('a, untyped mark) gexpr box
@@ -178,7 +178,7 @@ val make_var : 'a Bindlib.var * 'b -> ('a * 'b) box
 val make_abs :
   ('a, 't) naked_gexpr Var.vars ->
   ('a, 't) gexpr box ->
-  typ Marked.pos list ->
+  typ list ->
   't ->
   ('a, 't) gexpr box
 
@@ -193,7 +193,7 @@ val empty_thunked_term :
 
 val make_let_in :
   'e Bindlib.var ->
-  marked_typ ->
+  typ ->
   'e anyexpr marked box ->
   'e marked box ->
   Utils.Pos.t ->
@@ -201,7 +201,7 @@ val make_let_in :
 
 val make_let_in_raw :
   ('a any, 't) naked_gexpr Bindlib.var ->
-  marked_typ ->
+  typ ->
   ('a, 't) gexpr box ->
   ('a, 't) gexpr box ->
   't ->
@@ -210,7 +210,7 @@ val make_let_in_raw :
 
 val make_multiple_let_in :
   'e Var.vars ->
-  marked_typ list ->
+  typ list ->
   'e marked box list ->
   'e marked box ->
   Pos.t ->
@@ -263,7 +263,7 @@ val compare : ('a, 't) gexpr -> ('a, 't) gexpr -> int
 (** Standard comparison function, suitable for e.g. [Set.Make]. Ignores position
     information *)
 
-val compare_typ : marked_typ -> marked_typ -> int
+val compare_typ : typ -> typ -> int
 val is_value : (_ any, 'm mark) naked_gexpr marked -> bool
 val free_vars : 'e marked -> 'e Var.Set.t
 

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -22,97 +22,97 @@ open Definitions
 
 (** {2 Boxed constructors} *)
 
-val box : ('a, 't) marked_gexpr -> ('a, 't) marked_gexpr Bindlib.box
-val evar : ('a, 't) gexpr Bindlib.var -> 't -> ('a, 't) marked_gexpr Bindlib.box
+val box : ('a, 't) gexpr -> ('a, 't) gexpr Bindlib.box
+val evar : ('a, 't) naked_gexpr Bindlib.var -> 't -> ('a, 't) gexpr Bindlib.box
 
 val etuple :
-  (([< dcalc | lcalc ] as 'a), 't) marked_gexpr Bindlib.box list ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box list ->
   StructName.t option ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val etupleaccess :
-  (([< dcalc | lcalc ] as 'a), 't) marked_gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
   int ->
   StructName.t option ->
   marked_typ list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val einj :
-  (([< dcalc | lcalc ] as 'a), 't) marked_gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
   int ->
   EnumName.t ->
   marked_typ list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val ematch :
-  (([< dcalc | lcalc ] as 'a), 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box list ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box list ->
   EnumName.t ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val earray :
-  ('a any, 't) marked_gexpr Bindlib.box list ->
+  ('a any, 't) gexpr Bindlib.box list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
-val elit : 'a any glit -> 't -> ('a, 't) marked_gexpr Bindlib.box
+val elit : 'a any glit -> 't -> ('a, 't) gexpr Bindlib.box
 
 val eabs :
-  (('a any, 't) gexpr, ('a, 't) marked_gexpr) Bindlib.mbinder Bindlib.box ->
+  (('a any, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder Bindlib.box ->
   marked_typ list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val eapp :
-  ('a any, 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box list ->
+  ('a any, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val eassert :
-  (([< dcalc | lcalc ] as 'a), 't) marked_gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
-val eop : operator -> 't -> (_ any, 't) marked_gexpr Bindlib.box
+val eop : operator -> 't -> (_ any, 't) gexpr Bindlib.box
 
 val edefault :
-  (([< desugared | scopelang | dcalc ] as 'a), 't) marked_gexpr Bindlib.box list ->
-  ('a, 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box ->
+  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr Bindlib.box list ->
+  ('a, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val eifthenelse :
-  ('a any, 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box ->
+  ('a any, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val eerroronempty :
-  (([< desugared | scopelang | dcalc ] as 'a), 't) marked_gexpr Bindlib.box ->
+  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr Bindlib.box ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val ecatch :
-  (lcalc, 't) marked_gexpr Bindlib.box ->
+  (lcalc, 't) gexpr Bindlib.box ->
   except ->
-  (lcalc, 't) marked_gexpr Bindlib.box ->
+  (lcalc, 't) gexpr Bindlib.box ->
   't ->
-  (lcalc, 't) marked_gexpr Bindlib.box
+  (lcalc, 't) gexpr Bindlib.box
 
-val eraise : except -> 't -> (lcalc, 't) marked_gexpr Bindlib.box
+val eraise : except -> 't -> (lcalc, 't) gexpr Bindlib.box
 
 (** Manipulation of marks *)
 
 val no_mark : 'm mark -> 'm mark
 val mark_pos : 'm mark -> Pos.t
-val pos : ('e, _) gexpr marked -> Pos.t
+val pos : ('e, _) naked_gexpr marked -> Pos.t
 val ty : (_, typed mark) Marked.t -> marked_typ
 val with_ty : marked_typ -> ('a, _ mark) Marked.t -> ('a, typed mark) Marked.t
 
@@ -130,15 +130,15 @@ val fold_marks :
   (Pos.t list -> Pos.t) -> (typed list -> marked_typ) -> 'm mark list -> 'm mark
 
 val untype :
-  ('a, 'm mark) marked_gexpr -> ('a, untyped mark) marked_gexpr Bindlib.box
+  ('a, 'm mark) gexpr -> ('a, untyped mark) gexpr Bindlib.box
 
 (** {2 Traversal functions} *)
 
 val map :
   'ctx ->
-  f:('ctx -> ('a, 't1) marked_gexpr -> ('a, 't2) marked_gexpr Bindlib.box) ->
-  (('a, 't1) gexpr, 't2) Marked.t ->
-  ('a, 't2) marked_gexpr Bindlib.box
+  f:('ctx -> ('a, 't1) gexpr -> ('a, 't2) gexpr Bindlib.box) ->
+  (('a, 't1) naked_gexpr, 't2) Marked.t ->
+  ('a, 't2) gexpr Bindlib.box
 (** Flat (non-recursive) mapping on expressions.
 
     If you want to apply a map transform to an expression, you can save up
@@ -159,35 +159,35 @@ val map :
     around during your map traversal. *)
 
 val map_top_down :
-  f:(('a, 't1) marked_gexpr -> (('a, 't1) gexpr, 't2) Marked.t) ->
-  ('a, 't1) marked_gexpr ->
-  ('a, 't2) marked_gexpr Bindlib.box
+  f:(('a, 't1) gexpr -> (('a, 't1) naked_gexpr, 't2) Marked.t) ->
+  ('a, 't1) gexpr ->
+  ('a, 't2) gexpr Bindlib.box
 (** Recursively applies [f] to the nodes of the expression tree. The type
     returned by [f] is hybrid since the mark at top-level has been rewritten,
     but not yet the marks in the subtrees. *)
 
 val map_marks :
-  f:('t1 -> 't2) -> ('a, 't1) marked_gexpr -> ('a, 't2) marked_gexpr Bindlib.box
+  f:('t1 -> 't2) -> ('a, 't1) gexpr -> ('a, 't2) gexpr Bindlib.box
 
 (** {2 Expression building helpers} *)
 
 val make_var : 'a Bindlib.var * 'b -> ('a * 'b) Bindlib.box
 
 val make_abs :
-  ('a, 't) gexpr Var.vars ->
-  ('a, 't) marked_gexpr Bindlib.box ->
+  ('a, 't) naked_gexpr Var.vars ->
+  ('a, 't) gexpr Bindlib.box ->
   typ Marked.pos list ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 
 val make_app :
-  ((_ any, 'm mark) gexpr as 'e) marked Bindlib.box ->
+  ((_ any, 'm mark) naked_gexpr as 'e) marked Bindlib.box ->
   'e marked Bindlib.box list ->
   'm mark ->
   'e marked Bindlib.box
 
 val empty_thunked_term :
-  'm mark -> ([< dcalc | desugared | scopelang ], 'm mark) gexpr marked
+  'm mark -> ([< dcalc | desugared | scopelang ], 'm mark) naked_gexpr marked
 
 val make_let_in :
   'e Bindlib.var ->
@@ -198,12 +198,12 @@ val make_let_in :
   'e marked Bindlib.box
 
 val make_let_in_raw :
-  ('a any, 't) gexpr Bindlib.var ->
+  ('a any, 't) naked_gexpr Bindlib.var ->
   marked_typ ->
-  ('a, 't) marked_gexpr Bindlib.box ->
-  ('a, 't) marked_gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr Bindlib.box ->
   't ->
-  ('a, 't) marked_gexpr Bindlib.box
+  ('a, 't) gexpr Bindlib.box
 (** Version with any mark; to be removed once we use the [mark] type everywhere. *)
 
 val make_multiple_let_in :
@@ -215,11 +215,11 @@ val make_multiple_let_in :
   'e marked Bindlib.box
 
 val make_default :
-  (([< desugared | scopelang | dcalc ] as 'a), 't) marked_gexpr list ->
-  ('a, 't) marked_gexpr ->
-  ('a, 't) marked_gexpr ->
+  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr list ->
+  ('a, 't) gexpr ->
+  ('a, 't) gexpr ->
   't ->
-  ('a, 't) marked_gexpr
+  ('a, 't) gexpr
 (** [make_default ?pos exceptions just cons] builds a term semantically
     equivalent to [<exceptions | just :- cons>] (the [EDefault] constructor)
     while avoiding redundant nested constructions. The position is extracted
@@ -236,7 +236,7 @@ val make_default :
 (** {2 Transformations} *)
 
 val remove_logging_calls :
-  ((_ any, 't) gexpr as 'e) marked -> 'e marked Bindlib.box
+  ((_ any, 't) naked_gexpr as 'e) marked -> 'e marked Bindlib.box
 (** Removes all calls to [Log] unary operators in the AST, replacing them by
     their argument. *)
 
@@ -254,16 +254,16 @@ val compare_lit : 'a glit -> 'a glit -> int
 val equal_location : 'a glocation Marked.pos -> 'a glocation Marked.pos -> bool
 val compare_location : 'a glocation Marked.pos -> 'a glocation Marked.pos -> int
 
-val equal : ('a, 't) marked_gexpr -> ('a, 't) marked_gexpr -> bool
+val equal : ('a, 't) gexpr -> ('a, 't) gexpr -> bool
 (** Determines if two expressions are equal, omitting their position information *)
 
-val compare : ('a, 't) marked_gexpr -> ('a, 't) marked_gexpr -> int
+val compare : ('a, 't) gexpr -> ('a, 't) gexpr -> int
 (** Standard comparison function, suitable for e.g. [Set.Make]. Ignores position
     information *)
 
 val compare_typ : marked_typ -> marked_typ -> int
-val is_value : (_ any, 'm mark) gexpr marked -> bool
+val is_value : (_ any, 'm mark) naked_gexpr marked -> bool
 val free_vars : 'e marked -> 'e Var.Set.t
 
-val size : (_ any, 't) gexpr marked -> int
+val size : (_ any, 't) naked_gexpr marked -> int
 (** Used by the optimizer to know when to stop *)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -20,93 +20,95 @@
 open Utils
 open Definitions
 
+type 'a box = 'a Bindlib.box
+
 (** {2 Boxed constructors} *)
 
-val box : ('a, 't) gexpr -> ('a, 't) gexpr Bindlib.box
-val evar : ('a, 't) naked_gexpr Bindlib.var -> 't -> ('a, 't) gexpr Bindlib.box
+val box : ('a, 't) gexpr -> ('a, 't) gexpr box
+val evar : ('a, 't) naked_gexpr Bindlib.var -> 't -> ('a, 't) gexpr box
 
 val etuple :
-  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box list ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr box list ->
   StructName.t option ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val etupleaccess :
-  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
   int ->
   StructName.t option ->
   marked_typ list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val einj :
-  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
   int ->
   EnumName.t ->
   marked_typ list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val ematch :
-  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box list ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
+  ('a, 't) gexpr box list ->
   EnumName.t ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val earray :
-  ('a any, 't) gexpr Bindlib.box list ->
+  ('a any, 't) gexpr box list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
-val elit : 'a any glit -> 't -> ('a, 't) gexpr Bindlib.box
+val elit : 'a any glit -> 't -> ('a, 't) gexpr box
 
 val eabs :
-  (('a any, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder Bindlib.box ->
+  (('a any, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder box ->
   marked_typ list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val eapp :
-  ('a any, 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box list ->
+  ('a any, 't) gexpr box ->
+  ('a, 't) gexpr box list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val eassert :
-  (([< dcalc | lcalc ] as 'a), 't) gexpr Bindlib.box ->
+  (([< dcalc | lcalc ] as 'a), 't) gexpr box ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
-val eop : operator -> 't -> (_ any, 't) gexpr Bindlib.box
+val eop : operator -> 't -> (_ any, 't) gexpr box
 
 val edefault :
-  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr Bindlib.box list ->
-  ('a, 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box ->
+  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr box list ->
+  ('a, 't) gexpr box ->
+  ('a, 't) gexpr box ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val eifthenelse :
-  ('a any, 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box ->
+  ('a any, 't) gexpr box ->
+  ('a, 't) gexpr box ->
+  ('a, 't) gexpr box ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val eerroronempty :
-  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr Bindlib.box ->
+  (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr box ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val ecatch :
-  (lcalc, 't) gexpr Bindlib.box ->
+  (lcalc, 't) gexpr box ->
   except ->
-  (lcalc, 't) gexpr Bindlib.box ->
+  (lcalc, 't) gexpr box ->
   't ->
-  (lcalc, 't) gexpr Bindlib.box
+  (lcalc, 't) gexpr box
 
-val eraise : except -> 't -> (lcalc, 't) gexpr Bindlib.box
+val eraise : except -> 't -> (lcalc, 't) gexpr box
 
 (** Manipulation of marks *)
 
@@ -130,15 +132,15 @@ val fold_marks :
   (Pos.t list -> Pos.t) -> (typed list -> marked_typ) -> 'm mark list -> 'm mark
 
 val untype :
-  ('a, 'm mark) gexpr -> ('a, untyped mark) gexpr Bindlib.box
+  ('a, 'm mark) gexpr -> ('a, untyped mark) gexpr box
 
 (** {2 Traversal functions} *)
 
 val map :
   'ctx ->
-  f:('ctx -> ('a, 't1) gexpr -> ('a, 't2) gexpr Bindlib.box) ->
+  f:('ctx -> ('a, 't1) gexpr -> ('a, 't2) gexpr box) ->
   (('a, 't1) naked_gexpr, 't2) Marked.t ->
-  ('a, 't2) gexpr Bindlib.box
+  ('a, 't2) gexpr box
 (** Flat (non-recursive) mapping on expressions.
 
     If you want to apply a map transform to an expression, you can save up
@@ -161,30 +163,30 @@ val map :
 val map_top_down :
   f:(('a, 't1) gexpr -> (('a, 't1) naked_gexpr, 't2) Marked.t) ->
   ('a, 't1) gexpr ->
-  ('a, 't2) gexpr Bindlib.box
+  ('a, 't2) gexpr box
 (** Recursively applies [f] to the nodes of the expression tree. The type
     returned by [f] is hybrid since the mark at top-level has been rewritten,
     but not yet the marks in the subtrees. *)
 
 val map_marks :
-  f:('t1 -> 't2) -> ('a, 't1) gexpr -> ('a, 't2) gexpr Bindlib.box
+  f:('t1 -> 't2) -> ('a, 't1) gexpr -> ('a, 't2) gexpr box
 
 (** {2 Expression building helpers} *)
 
-val make_var : 'a Bindlib.var * 'b -> ('a * 'b) Bindlib.box
+val make_var : 'a Bindlib.var * 'b -> ('a * 'b) box
 
 val make_abs :
   ('a, 't) naked_gexpr Var.vars ->
-  ('a, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr box ->
   typ Marked.pos list ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 
 val make_app :
-  ((_ any, 'm mark) naked_gexpr as 'e) marked Bindlib.box ->
-  'e marked Bindlib.box list ->
+  ((_ any, 'm mark) naked_gexpr as 'e) marked box ->
+  'e marked box list ->
   'm mark ->
-  'e marked Bindlib.box
+  'e marked box
 
 val empty_thunked_term :
   'm mark -> ([< dcalc | desugared | scopelang ], 'm mark) naked_gexpr marked
@@ -192,27 +194,27 @@ val empty_thunked_term :
 val make_let_in :
   'e Bindlib.var ->
   marked_typ ->
-  'e anyexpr marked Bindlib.box ->
-  'e marked Bindlib.box ->
+  'e anyexpr marked box ->
+  'e marked box ->
   Utils.Pos.t ->
-  'e marked Bindlib.box
+  'e marked box
 
 val make_let_in_raw :
   ('a any, 't) naked_gexpr Bindlib.var ->
   marked_typ ->
-  ('a, 't) gexpr Bindlib.box ->
-  ('a, 't) gexpr Bindlib.box ->
+  ('a, 't) gexpr box ->
+  ('a, 't) gexpr box ->
   't ->
-  ('a, 't) gexpr Bindlib.box
+  ('a, 't) gexpr box
 (** Version with any mark; to be removed once we use the [mark] type everywhere. *)
 
 val make_multiple_let_in :
   'e Var.vars ->
   marked_typ list ->
-  'e marked Bindlib.box list ->
-  'e marked Bindlib.box ->
+  'e marked box list ->
+  'e marked box ->
   Pos.t ->
-  'e marked Bindlib.box
+  'e marked box
 
 val make_default :
   (([< desugared | scopelang | dcalc ] as 'a), 't) gexpr list ->
@@ -236,7 +238,7 @@ val make_default :
 (** {2 Transformations} *)
 
 val remove_logging_calls :
-  ((_ any, 't) naked_gexpr as 'e) marked -> 'e marked Bindlib.box
+  ((_ any, 't) naked_gexpr as 'e) marked -> 'e marked box
 (** Removes all calls to [Log] unary operators in the AST, replacing them by
     their argument. *)
 

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -211,7 +211,7 @@ let var fmt v =
 let needs_parens (type a) (e : (a, _) gexpr) : bool =
   match Marked.unmark e with EAbs _ | ETuple (_, Some _) -> true | _ -> false
 
-let rec expr :
+let rec naked_expr :
           'a.
           ?debug:bool ->
           decl_ctx ->
@@ -220,13 +220,13 @@ let rec expr :
           unit =
   fun (type a) ?(debug : bool = false) (ctx : decl_ctx) (fmt : Format.formatter)
       (e : (a, 't) gexpr) ->
-   let expr e = expr ~debug ctx e in
+   let naked_expr e = naked_expr ~debug ctx e in
    let with_parens fmt e =
      if needs_parens e then (
        punctuation fmt "(";
-       expr fmt e;
+       naked_expr fmt e;
        punctuation fmt ")")
-     else expr fmt e
+     else naked_expr fmt e
    in
    match Marked.unmark e with
    | EVar v -> Format.fprintf fmt "%a" var v
@@ -234,7 +234,7 @@ let rec expr :
      Format.fprintf fmt "@[<hov 2>%a%a%a@]" punctuation "("
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
-          (fun fmt e -> Format.fprintf fmt "%a" expr e))
+          (fun fmt e -> Format.fprintf fmt "%a" naked_expr e))
        es punctuation ")"
    | ETuple (es, Some s) ->
      Format.fprintf fmt "@[<hov 2>%a@ @[<hov 2>%a%a%a@]@]" StructName.format_t s
@@ -244,35 +244,35 @@ let rec expr :
           (fun fmt (e, struct_field) ->
             Format.fprintf fmt "%a%a%a%a@ %a" punctuation "\""
               StructFieldName.format_t struct_field punctuation "\"" punctuation
-              "=" expr e))
+              "=" naked_expr e))
        (List.combine es (List.map fst (StructMap.find s ctx.ctx_structs)))
        punctuation "}"
    | EArray es ->
      Format.fprintf fmt "@[<hov 2>%a%a%a@]" punctuation "["
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
-          (fun fmt e -> Format.fprintf fmt "%a" expr e))
+          (fun fmt e -> Format.fprintf fmt "%a" naked_expr e))
        es punctuation "]"
    | ETupleAccess (e1, n, s, _ts) -> (
      match s with
-     | None -> Format.fprintf fmt "%a%a%d" expr e1 punctuation "." n
+     | None -> Format.fprintf fmt "%a%a%d" naked_expr e1 punctuation "." n
      | Some s ->
-       Format.fprintf fmt "%a%a%a%a%a" expr e1 operator "." punctuation "\""
+       Format.fprintf fmt "%a%a%a%a%a" naked_expr e1 operator "." punctuation "\""
          StructFieldName.format_t
          (fst (List.nth (StructMap.find s ctx.ctx_structs) n))
          punctuation "\"")
    | EInj (e, n, en, _ts) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@]" enum_constructor
        (fst (List.nth (EnumMap.find en ctx.ctx_enums) n))
-       expr e
+       naked_expr e
    | EMatch (e, es, e_name) ->
      Format.fprintf fmt "@[<hov 0>%a@ @[<hov 2>%a@]@ %a@ %a@]" keyword "match"
-       expr e keyword "with"
+       naked_expr e keyword "with"
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
           (fun fmt (e, c) ->
             Format.fprintf fmt "@[<hov 2>%a %a%a@ %a@]" punctuation "|"
-              enum_constructor c punctuation ":" expr e))
+              enum_constructor c punctuation ":" naked_expr e))
        (List.combine es (List.map fst (EnumMap.find e_name ctx.ctx_enums)))
    | ELit l -> lit fmt l
    | EApp ((EAbs (binder, taus), _), args) ->
@@ -285,8 +285,8 @@ let rec expr :
           (fun fmt (x, tau, arg) ->
             Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@ %a@]@\n"
               keyword "let" var x punctuation ":" (typ ctx) tau punctuation "="
-              expr arg keyword "in"))
-       xs_tau_arg expr body
+              naked_expr arg keyword "in"))
+       xs_tau_arg naked_expr body
    | EAbs (binder, taus) ->
      let xs, body = Bindlib.unmbind binder in
      let xs_tau = List.mapi (fun i tau -> xs.(i), tau) taus in
@@ -296,44 +296,44 @@ let rec expr :
           (fun fmt (x, tau) ->
             Format.fprintf fmt "%a%a%a %a%a" punctuation "(" var x punctuation
               ":" (typ ctx) tau punctuation ")"))
-       xs_tau punctuation "→" expr body
+       xs_tau punctuation "→" naked_expr body
    | EApp ((EOp (Binop ((Map | Filter) as op)), _), [arg1; arg2]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" binop op with_parens arg1
        with_parens arg2
    | EApp ((EOp (Binop op), _), [arg1; arg2]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" with_parens arg1 binop op
        with_parens arg2
-   | EApp ((EOp (Unop (Log _)), _), [arg1]) when not debug -> expr fmt arg1
+   | EApp ((EOp (Unop (Log _)), _), [arg1]) when not debug -> naked_expr fmt arg1
    | EApp ((EOp (Unop op), _), [arg1]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@]" unop op with_parens arg1
    | EApp (f, args) ->
-     Format.fprintf fmt "@[<hov 2>%a@ %a@]" expr f
+     Format.fprintf fmt "@[<hov 2>%a@ %a@]" naked_expr f
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
           with_parens)
        args
    | EIfThenElse (e1, e2, e3) ->
-     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@]" keyword "if" expr e1
-       keyword "then" expr e2 keyword "else" expr e3
+     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@]" keyword "if" naked_expr e1
+       keyword "then" naked_expr e2 keyword "else" naked_expr e3
    | EOp (Ternop op) -> Format.fprintf fmt "%a" ternop op
    | EOp (Binop op) -> Format.fprintf fmt "%a" binop op
    | EOp (Unop op) -> Format.fprintf fmt "%a" unop op
    | EDefault (exceptions, just, cons) ->
      if List.length exceptions = 0 then
-       Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a%a@]" punctuation "⟨" expr just
-         punctuation "⊢" expr cons punctuation "⟩"
+       Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a%a@]" punctuation "⟨" naked_expr just
+         punctuation "⊢" naked_expr cons punctuation "⟩"
      else
        Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a@ %a@ %a%a@]" punctuation "⟨"
          (Format.pp_print_list
             ~pp_sep:(fun fmt () -> Format.fprintf fmt "%a@ " punctuation ",")
-            expr)
-         exceptions punctuation "|" expr just punctuation "⊢" expr cons
+            naked_expr)
+         exceptions punctuation "|" naked_expr just punctuation "⊢" naked_expr cons
          punctuation "⟩"
    | ErrorOnEmpty e' ->
      Format.fprintf fmt "%a@ %a" operator "error_empty" with_parens e'
    | EAssert e' ->
      Format.fprintf fmt "@[<hov 2>%a@ %a%a%a@]" keyword "assert" punctuation "("
-       expr e' punctuation ")"
+       naked_expr e' punctuation ")"
    | ECatch (e1, exn, e2) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a ->@ %a@]" keyword "try"
        with_parens e1 keyword "with" except exn with_parens e2
@@ -348,20 +348,20 @@ let rec expr :
           (fun fmt (field_name, field_expr) ->
             Format.fprintf fmt "%a%a%a%a@ %a" punctuation "\""
               StructFieldName.format_t field_name punctuation "\"" punctuation
-              "=" expr field_expr))
+              "=" naked_expr field_expr))
        (StructFieldMap.bindings fields)
        punctuation "}"
    | EStructAccess (e1, field, _) ->
-     Format.fprintf fmt "%a%a%a%a%a" expr e1 punctuation "." punctuation "\""
+     Format.fprintf fmt "%a%a%a%a%a" naked_expr e1 punctuation "." punctuation "\""
        StructFieldName.format_t field punctuation "\""
    | EEnumInj (e1, cons, _) ->
-     Format.fprintf fmt "%a@ %a" EnumConstructor.format_t cons expr e1
+     Format.fprintf fmt "%a@ %a" EnumConstructor.format_t cons naked_expr e1
    | EMatchS (e1, _, cases) ->
      Format.fprintf fmt "@[<hov 0>%a@ @[<hov 2>%a@]@ %a@ %a@]" keyword "match"
-       expr e1 keyword "with"
+       naked_expr e1 keyword "with"
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
           (fun fmt (cons_name, case_expr) ->
             Format.fprintf fmt "@[<hov 2>%a %a@ %a@ %a@]" punctuation "|"
-              enum_constructor cons_name punctuation "→" expr case_expr))
+              enum_constructor cons_name punctuation "→" naked_expr case_expr))
        (EnumConstructorMap.bindings cases)

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -18,7 +18,7 @@ open Utils
 open String_common
 open Definitions
 
-let typ_needs_parens (ty : marked_typ) : bool =
+let typ_needs_parens (ty : typ) : bool =
   match Marked.unmark ty with TArrow _ | TArray _ -> true | _ -> false
 
 let uid_list (fmt : Format.formatter) (infos : Uid.MarkedString.info list) :
@@ -74,9 +74,9 @@ let enum_constructor (fmt : Format.formatter) (c : EnumConstructor.t) : unit =
     (Utils.Cli.format_with_style [ANSITerminal.magenta])
     (Format.asprintf "%a" EnumConstructor.format_t c)
 
-let rec typ (ctx : decl_ctx) (fmt : Format.formatter) (ty : marked_typ) : unit =
+let rec typ (ctx : decl_ctx) (fmt : Format.formatter) (ty : typ) : unit =
   let typ = typ ctx in
-  let typ_with_parens (fmt : Format.formatter) (t : marked_typ) =
+  let typ_with_parens (fmt : Format.formatter) (t : typ) =
     if typ_needs_parens t then Format.fprintf fmt "(%a)" typ t
     else Format.fprintf fmt "%a" typ t
   in

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -211,22 +211,19 @@ let var fmt v =
 let needs_parens (type a) (e : (a, _) gexpr) : bool =
   match Marked.unmark e with EAbs _ | ETuple (_, Some _) -> true | _ -> false
 
-let rec naked_expr :
+let rec expr :
           'a.
-          ?debug:bool ->
-          decl_ctx ->
-          Format.formatter ->
-          ('a, 't) gexpr ->
-          unit =
+          ?debug:bool -> decl_ctx -> Format.formatter -> ('a, 't) gexpr -> unit
+    =
   fun (type a) ?(debug : bool = false) (ctx : decl_ctx) (fmt : Format.formatter)
       (e : (a, 't) gexpr) ->
-   let naked_expr e = naked_expr ~debug ctx e in
+   let expr e = expr ~debug ctx e in
    let with_parens fmt e =
      if needs_parens e then (
        punctuation fmt "(";
-       naked_expr fmt e;
+       expr fmt e;
        punctuation fmt ")")
-     else naked_expr fmt e
+     else expr fmt e
    in
    match Marked.unmark e with
    | EVar v -> Format.fprintf fmt "%a" var v
@@ -234,7 +231,7 @@ let rec naked_expr :
      Format.fprintf fmt "@[<hov 2>%a%a%a@]" punctuation "("
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
-          (fun fmt e -> Format.fprintf fmt "%a" naked_expr e))
+          (fun fmt e -> Format.fprintf fmt "%a" expr e))
        es punctuation ")"
    | ETuple (es, Some s) ->
      Format.fprintf fmt "@[<hov 2>%a@ @[<hov 2>%a%a%a@]@]" StructName.format_t s
@@ -244,35 +241,35 @@ let rec naked_expr :
           (fun fmt (e, struct_field) ->
             Format.fprintf fmt "%a%a%a%a@ %a" punctuation "\""
               StructFieldName.format_t struct_field punctuation "\"" punctuation
-              "=" naked_expr e))
+              "=" expr e))
        (List.combine es (List.map fst (StructMap.find s ctx.ctx_structs)))
        punctuation "}"
    | EArray es ->
      Format.fprintf fmt "@[<hov 2>%a%a%a@]" punctuation "["
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@ ")
-          (fun fmt e -> Format.fprintf fmt "%a" naked_expr e))
+          (fun fmt e -> Format.fprintf fmt "%a" expr e))
        es punctuation "]"
    | ETupleAccess (e1, n, s, _ts) -> (
      match s with
-     | None -> Format.fprintf fmt "%a%a%d" naked_expr e1 punctuation "." n
+     | None -> Format.fprintf fmt "%a%a%d" expr e1 punctuation "." n
      | Some s ->
-       Format.fprintf fmt "%a%a%a%a%a" naked_expr e1 operator "." punctuation "\""
+       Format.fprintf fmt "%a%a%a%a%a" expr e1 operator "." punctuation "\""
          StructFieldName.format_t
          (fst (List.nth (StructMap.find s ctx.ctx_structs) n))
          punctuation "\"")
    | EInj (e, n, en, _ts) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@]" enum_constructor
        (fst (List.nth (EnumMap.find en ctx.ctx_enums) n))
-       naked_expr e
+       expr e
    | EMatch (e, es, e_name) ->
      Format.fprintf fmt "@[<hov 0>%a@ @[<hov 2>%a@]@ %a@ %a@]" keyword "match"
-       naked_expr e keyword "with"
+       expr e keyword "with"
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
           (fun fmt (e, c) ->
             Format.fprintf fmt "@[<hov 2>%a %a%a@ %a@]" punctuation "|"
-              enum_constructor c punctuation ":" naked_expr e))
+              enum_constructor c punctuation ":" expr e))
        (List.combine es (List.map fst (EnumMap.find e_name ctx.ctx_enums)))
    | ELit l -> lit fmt l
    | EApp ((EAbs (binder, taus), _), args) ->
@@ -285,8 +282,8 @@ let rec naked_expr :
           (fun fmt (x, tau, arg) ->
             Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@ %a@]@\n"
               keyword "let" var x punctuation ":" (typ ctx) tau punctuation "="
-              naked_expr arg keyword "in"))
-       xs_tau_arg naked_expr body
+              expr arg keyword "in"))
+       xs_tau_arg expr body
    | EAbs (binder, taus) ->
      let xs, body = Bindlib.unmbind binder in
      let xs_tau = List.mapi (fun i tau -> xs.(i), tau) taus in
@@ -296,44 +293,44 @@ let rec naked_expr :
           (fun fmt (x, tau) ->
             Format.fprintf fmt "%a%a%a %a%a" punctuation "(" var x punctuation
               ":" (typ ctx) tau punctuation ")"))
-       xs_tau punctuation "→" naked_expr body
+       xs_tau punctuation "→" expr body
    | EApp ((EOp (Binop ((Map | Filter) as op)), _), [arg1; arg2]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" binop op with_parens arg1
        with_parens arg2
    | EApp ((EOp (Binop op), _), [arg1; arg2]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" with_parens arg1 binop op
        with_parens arg2
-   | EApp ((EOp (Unop (Log _)), _), [arg1]) when not debug -> naked_expr fmt arg1
+   | EApp ((EOp (Unop (Log _)), _), [arg1]) when not debug -> expr fmt arg1
    | EApp ((EOp (Unop op), _), [arg1]) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@]" unop op with_parens arg1
    | EApp (f, args) ->
-     Format.fprintf fmt "@[<hov 2>%a@ %a@]" naked_expr f
+     Format.fprintf fmt "@[<hov 2>%a@ %a@]" expr f
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
           with_parens)
        args
    | EIfThenElse (e1, e2, e3) ->
-     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@]" keyword "if" naked_expr e1
-       keyword "then" naked_expr e2 keyword "else" naked_expr e3
+     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@ %a@]" keyword "if" expr e1
+       keyword "then" expr e2 keyword "else" expr e3
    | EOp (Ternop op) -> Format.fprintf fmt "%a" ternop op
    | EOp (Binop op) -> Format.fprintf fmt "%a" binop op
    | EOp (Unop op) -> Format.fprintf fmt "%a" unop op
    | EDefault (exceptions, just, cons) ->
      if List.length exceptions = 0 then
-       Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a%a@]" punctuation "⟨" naked_expr just
-         punctuation "⊢" naked_expr cons punctuation "⟩"
+       Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a%a@]" punctuation "⟨" expr just
+         punctuation "⊢" expr cons punctuation "⟩"
      else
        Format.fprintf fmt "@[<hov 2>%a%a@ %a@ %a@ %a@ %a%a@]" punctuation "⟨"
          (Format.pp_print_list
             ~pp_sep:(fun fmt () -> Format.fprintf fmt "%a@ " punctuation ",")
-            naked_expr)
-         exceptions punctuation "|" naked_expr just punctuation "⊢" naked_expr cons
+            expr)
+         exceptions punctuation "|" expr just punctuation "⊢" expr cons
          punctuation "⟩"
    | ErrorOnEmpty e' ->
      Format.fprintf fmt "%a@ %a" operator "error_empty" with_parens e'
    | EAssert e' ->
      Format.fprintf fmt "@[<hov 2>%a@ %a%a%a@]" keyword "assert" punctuation "("
-       naked_expr e' punctuation ")"
+       expr e' punctuation ")"
    | ECatch (e1, exn, e2) ->
      Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a ->@ %a@]" keyword "try"
        with_parens e1 keyword "with" except exn with_parens e2
@@ -348,20 +345,20 @@ let rec naked_expr :
           (fun fmt (field_name, field_expr) ->
             Format.fprintf fmt "%a%a%a%a@ %a" punctuation "\""
               StructFieldName.format_t field_name punctuation "\"" punctuation
-              "=" naked_expr field_expr))
+              "=" expr field_expr))
        (StructFieldMap.bindings fields)
        punctuation "}"
    | EStructAccess (e1, field, _) ->
-     Format.fprintf fmt "%a%a%a%a%a" naked_expr e1 punctuation "." punctuation "\""
+     Format.fprintf fmt "%a%a%a%a%a" expr e1 punctuation "." punctuation "\""
        StructFieldName.format_t field punctuation "\""
    | EEnumInj (e1, cons, _) ->
-     Format.fprintf fmt "%a@ %a" EnumConstructor.format_t cons naked_expr e1
+     Format.fprintf fmt "%a@ %a" EnumConstructor.format_t cons expr e1
    | EMatchS (e1, _, cases) ->
      Format.fprintf fmt "@[<hov 0>%a@ @[<hov 2>%a@]@ %a@ %a@]" keyword "match"
-       naked_expr e1 keyword "with"
+       expr e1 keyword "with"
        (Format.pp_print_list
           ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
           (fun fmt (cons_name, case_expr) ->
             Format.fprintf fmt "@[<hov 2>%a %a@ %a@ %a@]" punctuation "|"
-              enum_constructor cons_name punctuation "→" naked_expr case_expr))
+              enum_constructor cons_name punctuation "→" expr case_expr))
        (EnumConstructorMap.bindings cases)

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -208,7 +208,7 @@ let except (fmt : Format.formatter) (exn : except) : unit =
 let var fmt v =
   Format.fprintf fmt "%s_%d" (Bindlib.name_of v) (Bindlib.uid_of v)
 
-let needs_parens (type a) (e : (a, _) marked_gexpr) : bool =
+let needs_parens (type a) (e : (a, _) gexpr) : bool =
   match Marked.unmark e with EAbs _ | ETuple (_, Some _) -> true | _ -> false
 
 let rec expr :
@@ -216,10 +216,10 @@ let rec expr :
           ?debug:bool ->
           decl_ctx ->
           Format.formatter ->
-          ('a, 't) marked_gexpr ->
+          ('a, 't) gexpr ->
           unit =
   fun (type a) ?(debug : bool = false) (ctx : decl_ctx) (fmt : Format.formatter)
-      (e : (a, 't) marked_gexpr) ->
+      (e : (a, 't) gexpr) ->
    let expr e = expr ~debug ctx e in
    let with_parens fmt e =
      if needs_parens e then (

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -33,7 +33,7 @@ val uid_list : Format.formatter -> Uid.MarkedString.info list -> unit
 val enum_constructor : Format.formatter -> EnumConstructor.t -> unit
 val tlit : Format.formatter -> typ_lit -> unit
 val location : Format.formatter -> 'a glocation -> unit
-val typ : decl_ctx -> Format.formatter -> marked_typ -> unit
+val typ : decl_ctx -> Format.formatter -> typ -> unit
 val lit : Format.formatter -> 'a glit -> unit
 val op_kind : Format.formatter -> op_kind -> unit
 val binop : Format.formatter -> binop -> unit

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -43,7 +43,7 @@ val unop : Format.formatter -> unop -> unit
 val except : Format.formatter -> except -> unit
 val var : Format.formatter -> 'e Var.t -> unit
 
-val naked_expr :
+val expr :
   ?debug:bool (** [true] for debug printing *) ->
   decl_ctx ->
   Format.formatter ->

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -43,7 +43,7 @@ val unop : Format.formatter -> unop -> unit
 val except : Format.formatter -> except -> unit
 val var : Format.formatter -> 'e Var.t -> unit
 
-val expr :
+val naked_expr :
   ?debug:bool (** [true] for debug printing *) ->
   decl_ctx ->
   Format.formatter ->

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -47,5 +47,5 @@ val expr :
   ?debug:bool (** [true] for debug printing *) ->
   decl_ctx ->
   Format.formatter ->
-  ('a, 't) marked_gexpr ->
+  ('a, 't) gexpr ->
   unit

--- a/compiler/shared_ast/program.ml
+++ b/compiler/shared_ast/program.ml
@@ -22,9 +22,9 @@ let map_exprs ~f ~varf { scopes; decl_ctx } =
     (fun scopes -> { scopes; decl_ctx })
     (Scope.map_exprs ~f ~varf scopes)
 
-let untype : 'm. ('a, 'm mark) gexpr program -> ('a, untyped mark) gexpr program
+let untype : 'm. ('a, 'm mark) naked_gexpr program -> ('a, untyped mark) naked_gexpr program
     =
- fun (prg : ('a, 'm mark) gexpr program) ->
+ fun (prg : ('a, 'm mark) naked_gexpr program) ->
   Bindlib.unbox (map_exprs ~f:Expr.untype ~varf:Var.translate prg)
 
 let rec find_scope name vars = function

--- a/compiler/shared_ast/program.ml
+++ b/compiler/shared_ast/program.ml
@@ -22,10 +22,9 @@ let map_exprs ~f ~varf { scopes; decl_ctx } =
     (fun scopes -> { scopes; decl_ctx })
     (Scope.map_exprs ~f ~varf scopes)
 
-let untype : 'm. ('a, 'm mark) naked_gexpr program -> ('a, untyped mark) naked_gexpr program
+let untype : 'm. ('a, 'm mark) gexpr program -> ('a, untyped mark) gexpr program
     =
- fun (prg : ('a, 'm mark) naked_gexpr program) ->
-  Bindlib.unbox (map_exprs ~f:Expr.untype ~varf:Var.translate prg)
+ fun prg -> Bindlib.unbox (map_exprs ~f:Expr.untype ~varf:Var.translate prg)
 
 let rec find_scope name vars = function
   | Nil -> raise Not_found

--- a/compiler/shared_ast/program.mli
+++ b/compiler/shared_ast/program.mli
@@ -20,19 +20,17 @@ open Definitions
 (** {2 Transformations} *)
 
 val map_exprs :
-  f:('expr1 marked -> 'expr2 marked Bindlib.box) ->
-  varf:('expr1 Bindlib.var -> 'expr2 Bindlib.var) ->
+  f:('expr1 -> 'expr2 box) ->
+  varf:('expr1 Var.t -> 'expr2 Var.t) ->
   'expr1 program ->
-  'expr2 program Bindlib.box
+  'expr2 program box
 
 val untype :
-  (([< dcalc | lcalc ] as 'a), 'm mark) naked_gexpr program ->
-  ('a, untyped mark) naked_gexpr program
+  (([< dcalc | lcalc ] as 'a), 'm mark) gexpr program ->
+  ('a, untyped mark) gexpr program
 
 val to_expr :
-  (([< dcalc | lcalc ], _) naked_gexpr as 'e) program ->
-  ScopeName.t ->
-  'e marked Bindlib.box
+  (([< dcalc | lcalc ], _) gexpr as 'e) program -> ScopeName.t -> 'e box
 (** Usage: [build_whole_program_expr program main_scope] builds an expression
     corresponding to the main program and returning the main scope as a
     function. *)

--- a/compiler/shared_ast/program.mli
+++ b/compiler/shared_ast/program.mli
@@ -26,11 +26,11 @@ val map_exprs :
   'expr2 program Bindlib.box
 
 val untype :
-  (([< dcalc | lcalc ] as 'a), 'm mark) gexpr program ->
-  ('a, untyped mark) gexpr program
+  (([< dcalc | lcalc ] as 'a), 'm mark) naked_gexpr program ->
+  ('a, untyped mark) naked_gexpr program
 
 val to_expr :
-  (([< dcalc | lcalc ], _) gexpr as 'e) program ->
+  (([< dcalc | lcalc ], _) naked_gexpr as 'e) program ->
   ScopeName.t ->
   'e marked Bindlib.box
 (** Usage: [build_whole_program_expr program main_scope] builds an expression

--- a/compiler/shared_ast/scope.ml
+++ b/compiler/shared_ast/scope.ml
@@ -117,7 +117,7 @@ let build_typ_from_sig
     (_ctx : decl_ctx)
     (scope_input_struct_name : StructName.t)
     (scope_return_struct_name : StructName.t)
-    (pos : Pos.t) : typ Marked.pos =
+    (pos : Pos.t) : typ =
   let input_typ = Marked.mark pos (TStruct scope_input_struct_name) in
   let result_typ = Marked.mark pos (TStruct scope_return_struct_name) in
   Marked.mark pos (TArrow (input_typ, result_typ))

--- a/compiler/shared_ast/scope.ml
+++ b/compiler/shared_ast/scope.ml
@@ -152,7 +152,7 @@ let rec unfold
     (ctx : decl_ctx)
     (s : 'e scopes)
     (mark : 'm mark)
-    (main_scope : 'expr scope_name_or_var) : 'e marked Bindlib.box =
+    (main_scope : 'naked_expr scope_name_or_var) : 'e marked Bindlib.box =
   match s with
   | Nil -> (
     match main_scope with

--- a/compiler/shared_ast/scope.ml
+++ b/compiler/shared_ast/scope.ml
@@ -97,7 +97,7 @@ let get_body_mark scope_body =
   | Result e | ScopeLet { scope_let_expr = e; _ } -> Marked.get_mark e
 
 let rec unfold_body_expr (ctx : decl_ctx) (scope_let : 'e scope_body_expr) :
-    'e marked Bindlib.box =
+    'e box =
   match scope_let with
   | Result e -> Expr.box e
   | ScopeLet
@@ -122,12 +122,10 @@ let build_typ_from_sig
   let result_typ = Marked.mark pos (TStruct scope_return_struct_name) in
   Marked.mark pos (TArrow (input_typ, result_typ))
 
-type 'e scope_name_or_var =
-  | ScopeName of ScopeName.t
-  | ScopeVar of 'e Bindlib.var
+type 'e scope_name_or_var = ScopeName of ScopeName.t | ScopeVar of 'e Var.t
 
 let to_expr (ctx : decl_ctx) (body : 'e scope_body) (mark_scope : 'm mark) :
-    'e marked Bindlib.box =
+    'e box =
   let var, body_expr = Bindlib.unbind body.scope_body_expr in
   let body_expr = unfold_body_expr ctx body_expr in
   Expr.make_abs [| var |] body_expr
@@ -152,7 +150,7 @@ let rec unfold
     (ctx : decl_ctx)
     (s : 'e scopes)
     (mark : 'm mark)
-    (main_scope : 'naked_expr scope_name_or_var) : 'e marked Bindlib.box =
+    (main_scope : 'expr scope_name_or_var) : 'e Bindlib.box =
   match s with
   | Nil -> (
     match main_scope with

--- a/compiler/shared_ast/scope.mli
+++ b/compiler/shared_ast/scope.mli
@@ -111,7 +111,7 @@ val unfold :
   'e marked Bindlib.box
 
 val build_typ_from_sig :
-  decl_ctx -> StructName.t -> StructName.t -> Pos.t -> typ Marked.pos
+  decl_ctx -> StructName.t -> StructName.t -> Pos.t -> typ
 (** [build_typ_from_sig ctx in_struct out_struct pos] builds the arrow type for
     the specified scope *)
 

--- a/compiler/shared_ast/scope.mli
+++ b/compiler/shared_ast/scope.mli
@@ -23,7 +23,7 @@ open Definitions
 (** {2 Traversal functions} *)
 
 val fold_left_lets :
-  f:('a -> 'e scope_let -> 'e Bindlib.var -> 'a) ->
+  f:('a -> 'e scope_let -> 'e Var.t -> 'a) ->
   init:'a ->
   'e scope_body_expr ->
   'a
@@ -33,8 +33,8 @@ val fold_left_lets :
     scope lets to be examined. *)
 
 val fold_right_lets :
-  f:('expr1 scope_let -> 'expr1 Bindlib.var -> 'a -> 'a) ->
-  init:('expr1 marked -> 'a) ->
+  f:('expr1 scope_let -> 'expr1 Var.t -> 'a -> 'a) ->
+  init:('expr1 -> 'a) ->
   'expr1 scope_body_expr ->
   'a
 (** Usage:
@@ -43,13 +43,13 @@ val fold_right_lets :
     scope lets to be examined (which are before in the program order). *)
 
 val map_exprs_in_lets :
-  f:('expr1 marked -> 'expr2 marked Bindlib.box) ->
-  varf:('expr1 Bindlib.var -> 'expr2 Bindlib.var) ->
+  f:('expr1 -> 'expr2 box) ->
+  varf:('expr1 Var.t -> 'expr2 Var.t) ->
   'expr1 scope_body_expr ->
-  'expr2 scope_body_expr Bindlib.box
+  'expr2 scope_body_expr box
 
 val fold_left :
-  f:('a -> 'expr1 scope_def -> 'expr1 Bindlib.var -> 'a) ->
+  f:('a -> 'expr1 scope_def -> 'expr1 Var.t -> 'a) ->
   init:'a ->
   'expr1 scopes ->
   'a
@@ -58,7 +58,7 @@ val fold_left :
     be examined. *)
 
 val fold_right :
-  f:('expr1 scope_def -> 'expr1 Bindlib.var -> 'a -> 'a) ->
+  f:('expr1 scope_def -> 'expr1 Var.t -> 'a -> 'a) ->
   init:'a ->
   'expr1 scopes ->
   'a
@@ -67,20 +67,17 @@ val fold_right :
     where [scope_var] is the variable bound to the scope in the next scopes to
     be examined (which are before in the program order). *)
 
-val map :
-  f:('e scope_def -> 'e scope_def Bindlib.box) ->
-  'e scopes ->
-  'e scopes Bindlib.box
+val map : f:('e scope_def -> 'e scope_def box) -> 'e scopes -> 'e scopes box
 
 val map_exprs :
-  f:('expr1 marked -> 'expr2 marked Bindlib.box) ->
-  varf:('expr1 Bindlib.var -> 'expr2 Bindlib.var) ->
+  f:('expr1 -> 'expr2 box) ->
+  varf:('expr1 Var.t -> 'expr2 Var.t) ->
   'expr1 scopes ->
-  'expr2 scopes Bindlib.box
+  'expr2 scopes box
 (** This is the main map visitor for all the expressions inside all the scopes
     of the program. *)
 
-val get_body_mark : (_, 'm mark) naked_gexpr scope_body -> 'm mark
+val get_body_mark : (_, 'm mark) gexpr scope_body -> 'm mark
 
 (** {2 Conversions} *)
 
@@ -93,22 +90,20 @@ val format :
 
 val to_expr :
   decl_ctx ->
-  ((_ any, 'm mark) naked_gexpr as 'e) scope_body ->
+  ('a any, 'm mark) gexpr scope_body ->
   'm mark ->
-  'e marked Bindlib.box
+  ('a, 'm mark) gexpr box
 (** Usage: [to_expr ctx body scope_position] where [scope_position] corresponds
     to the line of the scope declaration for instance. *)
 
-type 'e scope_name_or_var =
-  | ScopeName of ScopeName.t
-  | ScopeVar of 'e Bindlib.var
+type 'e scope_name_or_var = ScopeName of ScopeName.t | ScopeVar of 'e Var.t
 
 val unfold :
   decl_ctx ->
-  ((_ any, 'm mark) naked_gexpr as 'e) scopes ->
+  ((_, 'm mark) gexpr as 'e) scopes ->
   'm mark ->
   'e scope_name_or_var ->
-  'e marked Bindlib.box
+  'e box
 
 val build_typ_from_sig :
   decl_ctx -> StructName.t -> StructName.t -> Pos.t -> typ

--- a/compiler/shared_ast/scope.mli
+++ b/compiler/shared_ast/scope.mli
@@ -80,7 +80,7 @@ val map_exprs :
 (** This is the main map visitor for all the expressions inside all the scopes
     of the program. *)
 
-val get_body_mark : (_, 'm mark) gexpr scope_body -> 'm mark
+val get_body_mark : (_, 'm mark) naked_gexpr scope_body -> 'm mark
 
 (** {2 Conversions} *)
 
@@ -93,7 +93,7 @@ val format :
 
 val to_expr :
   decl_ctx ->
-  ((_ any, 'm mark) gexpr as 'e) scope_body ->
+  ((_ any, 'm mark) naked_gexpr as 'e) scope_body ->
   'm mark ->
   'e marked Bindlib.box
 (** Usage: [to_expr ctx body scope_position] where [scope_position] corresponds
@@ -105,7 +105,7 @@ type 'e scope_name_or_var =
 
 val unfold :
   decl_ctx ->
-  ((_ any, 'm mark) gexpr as 'e) scopes ->
+  ((_ any, 'm mark) naked_gexpr as 'e) scopes ->
   'm mark ->
   'e scope_name_or_var ->
   'e marked Bindlib.box

--- a/compiler/shared_ast/shared_ast.mld
+++ b/compiler/shared_ast/shared_ast.mld
@@ -17,7 +17,7 @@ irrelevant cases, so that e.g. [(dcalc, _) naked_gexpr] doesn't have the [ERaise
 [ECatch] cases, while [(lcalc, _) naked_gexpr] doesn't have [EDefault].
 
 For example, Lcalc expressions are then defined as
-[type 'm naked_expr = (Shared_ast.lcalc, 'm mark) Shared_ast.naked_gexpr].
+[type 'm expr = (Shared_ast.lcalc, 'm mark) Shared_ast.gexpr].
 
 This makes it possible to write a single function that works on the different
 ASTs, by having it take a [('a, _) naked_gexpr] as input, while retaining a much

--- a/compiler/shared_ast/shared_ast.mld
+++ b/compiler/shared_ast/shared_ast.mld
@@ -17,7 +17,7 @@ irrelevant cases, so that e.g. [(dcalc, _) naked_gexpr] doesn't have the [ERaise
 [ECatch] cases, while [(lcalc, _) naked_gexpr] doesn't have [EDefault].
 
 For example, Lcalc expressions are then defined as
-[type 'm expr = (Shared_ast.lcalc, 'm mark) Shared_ast.naked_gexpr].
+[type 'm naked_expr = (Shared_ast.lcalc, 'm mark) Shared_ast.naked_gexpr].
 
 This makes it possible to write a single function that works on the different
 ASTs, by having it take a [('a, _) naked_gexpr] as input, while retaining a much

--- a/compiler/shared_ast/shared_ast.mld
+++ b/compiler/shared_ast/shared_ast.mld
@@ -8,19 +8,19 @@ helpers that are reused in various passes of the compiler.
 The main module {!modules: Shared_ast.Definitions} is exposed at top-level of
 the library (so that [open Shared_ast] gives access to the structures). It
 defines literals, operators, and in particular the type {!types:
-Shared_ast.gexpr}.
+Shared_ast.naked_gexpr}.
 
-The {!types: Shared_ast.gexpr} type regroups all the cases for the {{:
+The {!types: Shared_ast.naked_gexpr} type regroups all the cases for the {{:
 ../dcalc.html} Dcalc} and {{: ../lcalc.html} Lcalc} ASTs, with unconstrained
 annotations (used for positions, types, etc.). A GADT is used to eliminate
-irrelevant cases, so that e.g. [(dcalc, _) gexpr] doesn't have the [ERaise] and
-[ECatch] cases, while [(lcalc, _) gexpr] doesn't have [EDefault].
+irrelevant cases, so that e.g. [(dcalc, _) naked_gexpr] doesn't have the [ERaise] and
+[ECatch] cases, while [(lcalc, _) naked_gexpr] doesn't have [EDefault].
 
 For example, Lcalc expressions are then defined as
-[type 'm expr = (Shared_ast.lcalc, 'm mark) Shared_ast.gexpr].
+[type 'm expr = (Shared_ast.lcalc, 'm mark) Shared_ast.naked_gexpr].
 
 This makes it possible to write a single function that works on the different
-ASTs, by having it take a [('a, _) gexpr] as input, while retaining a much
+ASTs, by having it take a [('a, _) naked_gexpr] as input, while retaining a much
 stricter policy than polymorphic variants.
 
 The module additionally defines the encompassing [scope] and [program]

--- a/compiler/shared_ast/var.ml
+++ b/compiler/shared_ast/var.ml
@@ -18,7 +18,7 @@ open Definitions
 
 (** {1 Variables and their collections} *)
 
-(** This module provides types and helpers for Bindlib variables on the [gexpr]
+(** This module provides types and helpers for Bindlib variables on the [naked_gexpr]
     type *)
 
 type 'e t = 'e anyexpr Bindlib.var
@@ -36,7 +36,7 @@ type 'e var = 'e t
 
 (* The purpose of this module is just to lift a type parameter outside of
    [Set.S] and [Map.S], so that we can have ['e Var.Set.t] for sets of variables
-   bound to the ['e = ('a, 't) gexpr] expression type. This is made possible by
+   bound to the ['e = ('a, 't) naked_gexpr] expression type. This is made possible by
    the fact that [Bindlib.compare_vars] is polymorphic in that parameter; we
    first hide that parameter inside an existential, then re-add a phantom type
    outside of the set to ensure consistency. Extracting the elements is then

--- a/compiler/shared_ast/var.ml
+++ b/compiler/shared_ast/var.ml
@@ -18,12 +18,13 @@ open Definitions
 
 (** {1 Variables and their collections} *)
 
-(** This module provides types and helpers for Bindlib variables on the [naked_gexpr]
+(** This module provides types and helpers for Bindlib variables on the [gexpr]
     type *)
 
-type 'e t = 'e anyexpr Bindlib.var
-type 'e vars = 'e anyexpr Bindlib.mvar
-type 'e binder = ('e, 'e marked) Bindlib.binder
+type 'e t = ('a, 't) naked_gexpr Bindlib.var constraint 'e = ('a any, 't) gexpr
+
+type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar
+  constraint 'e = ('a any, 't) gexpr
 
 let make (name : string) : 'e t = Bindlib.new_var (fun x -> EVar x) name
 let compare = Bindlib.compare_vars
@@ -36,7 +37,7 @@ type 'e var = 'e t
 
 (* The purpose of this module is just to lift a type parameter outside of
    [Set.S] and [Map.S], so that we can have ['e Var.Set.t] for sets of variables
-   bound to the ['e = ('a, 't) naked_gexpr] expression type. This is made possible by
+   bound to the ['e = ('a, 't) gexpr] expression type. This is made possible by
    the fact that [Bindlib.compare_vars] is polymorphic in that parameter; we
    first hide that parameter inside an existential, then re-add a phantom type
    outside of the set to ensure consistency. Extracting the elements is then

--- a/compiler/shared_ast/var.mli
+++ b/compiler/shared_ast/var.mli
@@ -18,12 +18,13 @@ open Definitions
 
 (** {1 Variables and their collections} *)
 
-(** This module provides types and helpers for Bindlib variables on the [naked_gexpr]
+(** This module provides types and helpers for Bindlib variables on the [gexpr]
     type *)
 
-type 'e t = 'e anyexpr Bindlib.var
-type 'e vars = 'e anyexpr Bindlib.mvar
-type 'e binder = ('e, 'e marked) Bindlib.binder
+type 'e t = ('a, 't) naked_gexpr Bindlib.var constraint 'e = ('a any, 't) gexpr
+
+type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar
+  constraint 'e = ('a any, 't) gexpr
 
 val make : string -> 'e t
 val compare : 'e t -> 'e t -> int

--- a/compiler/shared_ast/var.mli
+++ b/compiler/shared_ast/var.mli
@@ -18,7 +18,7 @@ open Definitions
 
 (** {1 Variables and their collections} *)
 
-(** This module provides types and helpers for Bindlib variables on the [gexpr]
+(** This module provides types and helpers for Bindlib variables on the [naked_gexpr]
     type *)
 
 type 'e t = 'e anyexpr Bindlib.var

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -135,6 +135,7 @@ type func_typ = {
       }]
 
 type typ = naked_typ Marked.pos
+
 and naked_typ = Base of base_typ | Func of func_typ
 [@@deriving
   visitors

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -134,7 +134,8 @@ type func_typ = {
         nude = true;
       }]
 
-type typ = Base of base_typ | Func of func_typ
+type typ = naked_typ Marked.pos
+and naked_typ = Base of base_typ | Func of func_typ
 [@@deriving
   visitors
     {
@@ -153,7 +154,7 @@ type typ = Base of base_typ | Func of func_typ
 
 type struct_decl_field = {
   struct_decl_field_name : ident Marked.pos;
-  struct_decl_field_typ : typ Marked.pos;
+  struct_decl_field_typ : typ;
 }
 [@@deriving
   visitors
@@ -189,7 +190,7 @@ type struct_decl = {
 
 type enum_decl_case = {
   enum_decl_case_name : constructor Marked.pos;
-  enum_decl_case_typ : typ Marked.pos option;
+  enum_decl_case_typ : typ option;
 }
 [@@deriving
   visitors
@@ -671,7 +672,7 @@ type scope_decl_context_scope = {
 
 type scope_decl_context_data = {
   scope_decl_context_item_name : ident Marked.pos;
-  scope_decl_context_item_typ : typ Marked.pos;
+  scope_decl_context_item_typ : typ;
   scope_decl_context_item_attribute : scope_decl_context_io;
   scope_decl_context_item_states : ident Marked.pos list;
 }

--- a/compiler/surface/desugaring.ml
+++ b/compiler/surface/desugaring.ml
@@ -116,19 +116,18 @@ let disambiguate_constructor
       Errors.raise_spanned_error (Marked.get_mark enum)
         "Enum %s has not been defined before" (Marked.unmark enum))
 
-(** Usage: [translate_expr scope ctxt naked_expr]
+(** Usage: [translate_expr scope ctxt expr]
 
-    Translates [naked_expr] into its desugared equivalent. [scope] is used to
+    Translates [expr] into its desugared equivalent. [scope] is used to
     disambiguate the scope and subscopes variables than occur in the expression *)
 let rec translate_expr
     (scope : ScopeName.t)
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
-    ((naked_expr, pos) : Ast.expression Marked.pos) :
-    Desugared.Ast.expr Bindlib.box =
+    ((expr, pos) : Ast.expression Marked.pos) : Desugared.Ast.expr Bindlib.box =
   let scope_ctxt = Scopelang.Ast.ScopeMap.find scope ctxt.scopes in
   let rec_helper = translate_expr scope inside_definition_of ctxt in
-  match naked_expr with
+  match expr with
   | Binop
       ( (Ast.And, _pos_op),
         ( TestMatchCase (e1_sub, ((constructors, Some binding), pos_pattern)),
@@ -785,8 +784,7 @@ and disambiguate_match_and_build_expression
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
     (cases : Ast.match_case Marked.pos list) :
-    Desugared.Ast.expr Bindlib.box EnumConstructorMap.t * EnumName.t
-    =
+    Desugared.Ast.expr Bindlib.box EnumConstructorMap.t * EnumName.t =
   let create_var = function
     | None -> ctxt, Var.make "_"
     | Some param ->
@@ -798,9 +796,8 @@ and disambiguate_match_and_build_expression
       (e_uid : EnumName.t)
       (ctxt : Name_resolution.context)
       (case_body : ('a * Pos.t) Bindlib.box)
-      (e_binder :
-        (Desugared.Ast.naked_expr, Desugared.Ast.naked_expr * Pos.t) Bindlib.mbinder
-        Bindlib.box) : 'c Bindlib.box =
+      (e_binder : (Desugared.Ast.expr, Desugared.Ast.expr) mbinder Bindlib.box)
+      : 'c Bindlib.box =
     Bindlib.box_apply2
       (fun e_binder case_body ->
         Marked.same_mark_as
@@ -912,10 +909,10 @@ and disambiguate_match_and_build_expression
           missing_constructors
           (cases_d, Some e_uid, curr_index))
   in
-  let naked_expr, e_name, _ =
+  let expr, e_name, _ =
     List.fold_left bind_match_cases (EnumConstructorMap.empty, None, 0) cases
   in
-  naked_expr, Option.get e_name
+  expr, Option.get e_name
   [@@ocamlformat "wrap-comments=false"]
 
 (** {1 Translating scope definitions} *)
@@ -948,7 +945,7 @@ let process_default
     (scope : ScopeName.t)
     (def_key : Desugared.Ast.ScopeDef.t Marked.pos)
     (rule_id : Desugared.Ast.RuleName.t)
-    (param_uid : Desugared.Ast.naked_expr Var.t Marked.pos option)
+    (param_uid : Desugared.Ast.expr Var.t Marked.pos option)
     (precond : Desugared.Ast.expr Bindlib.box option)
     (exception_situation : Desugared.Ast.exception_situation)
     (label_situation : Desugared.Ast.label_situation)

--- a/compiler/surface/desugaring.ml
+++ b/compiler/surface/desugaring.ml
@@ -125,7 +125,7 @@ let rec translate_expr
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
     ((naked_expr, pos) : Ast.expression Marked.pos) :
-    Desugared.Ast.naked_expr Marked.pos Bindlib.box =
+    Desugared.Ast.expr Bindlib.box =
   let scope_ctxt = Scopelang.Ast.ScopeMap.find scope ctxt.scopes in
   let rec_helper = translate_expr scope inside_definition_of ctxt in
   match naked_expr with
@@ -637,7 +637,7 @@ let rec translate_expr
           (translate_expr scope inside_definition_of ctxt predicate)
           acc
       in
-      let make_extr_body (cmp_op : binop) (t : typ Marked.pos) =
+      let make_extr_body (cmp_op : binop) (t : typ) =
         let tmp_var = Var.make "tmp" in
         let tmp = Expr.make_var (tmp_var, Marked.get_mark param') in
         Expr.make_let_in_raw tmp_var t
@@ -785,7 +785,7 @@ and disambiguate_match_and_build_expression
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
     (cases : Ast.match_case Marked.pos list) :
-    Desugared.Ast.naked_expr Marked.pos Bindlib.box EnumConstructorMap.t * EnumName.t
+    Desugared.Ast.expr Bindlib.box EnumConstructorMap.t * EnumName.t
     =
   let create_var = function
     | None -> ctxt, Var.make "_"
@@ -924,9 +924,9 @@ and disambiguate_match_and_build_expression
     this precondition has to be appended to the justifications of each
     definition in the subscope use. This is what this function does. *)
 let merge_conditions
-    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
-    (cond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
-    (default_pos : Pos.t) : Desugared.Ast.naked_expr Marked.pos Bindlib.box =
+    (precond : Desugared.Ast.expr Bindlib.box option)
+    (cond : Desugared.Ast.expr Bindlib.box option)
+    (default_pos : Pos.t) : Desugared.Ast.expr Bindlib.box =
   match precond, cond with
   | Some precond, Some cond ->
     let op_term = EOp (Binop And), Marked.get_mark (Bindlib.unbox cond) in
@@ -949,7 +949,7 @@ let process_default
     (def_key : Desugared.Ast.ScopeDef.t Marked.pos)
     (rule_id : Desugared.Ast.RuleName.t)
     (param_uid : Desugared.Ast.naked_expr Var.t Marked.pos option)
-    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.expr Bindlib.box option)
     (exception_situation : Desugared.Ast.exception_situation)
     (label_situation : Desugared.Ast.label_situation)
     (just : Ast.expression Marked.pos option)
@@ -987,7 +987,7 @@ let process_default
 (** Wrapper around {!val: process_default} that performs some name
     disambiguation *)
 let process_def
-    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.expr Bindlib.box option)
     (scope_uid : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)
@@ -1076,7 +1076,7 @@ let process_def
 
 (** Translates a {!type: Surface.Ast.rule} from the surface language *)
 let process_rule
-    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.expr Bindlib.box option)
     (scope : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)
@@ -1086,7 +1086,7 @@ let process_rule
 
 (** Translates assertions *)
 let process_assert
-    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.expr Bindlib.box option)
     (scope_uid : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)

--- a/compiler/surface/desugaring.ml
+++ b/compiler/surface/desugaring.ml
@@ -116,19 +116,19 @@ let disambiguate_constructor
       Errors.raise_spanned_error (Marked.get_mark enum)
         "Enum %s has not been defined before" (Marked.unmark enum))
 
-(** Usage: [translate_expr scope ctxt expr]
+(** Usage: [translate_expr scope ctxt naked_expr]
 
-    Translates [expr] into its desugared equivalent. [scope] is used to
+    Translates [naked_expr] into its desugared equivalent. [scope] is used to
     disambiguate the scope and subscopes variables than occur in the expression *)
 let rec translate_expr
     (scope : ScopeName.t)
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
-    ((expr, pos) : Ast.expression Marked.pos) :
-    Desugared.Ast.expr Marked.pos Bindlib.box =
+    ((naked_expr, pos) : Ast.expression Marked.pos) :
+    Desugared.Ast.naked_expr Marked.pos Bindlib.box =
   let scope_ctxt = Scopelang.Ast.ScopeMap.find scope ctxt.scopes in
   let rec_helper = translate_expr scope inside_definition_of ctxt in
-  match expr with
+  match naked_expr with
   | Binop
       ( (Ast.And, _pos_op),
         ( TestMatchCase (e1_sub, ((constructors, Some binding), pos_pattern)),
@@ -785,7 +785,7 @@ and disambiguate_match_and_build_expression
     (inside_definition_of : Desugared.Ast.ScopeDef.t Marked.pos option)
     (ctxt : Name_resolution.context)
     (cases : Ast.match_case Marked.pos list) :
-    Desugared.Ast.expr Marked.pos Bindlib.box EnumConstructorMap.t * EnumName.t
+    Desugared.Ast.naked_expr Marked.pos Bindlib.box EnumConstructorMap.t * EnumName.t
     =
   let create_var = function
     | None -> ctxt, Var.make "_"
@@ -799,7 +799,7 @@ and disambiguate_match_and_build_expression
       (ctxt : Name_resolution.context)
       (case_body : ('a * Pos.t) Bindlib.box)
       (e_binder :
-        (Desugared.Ast.expr, Desugared.Ast.expr * Pos.t) Bindlib.mbinder
+        (Desugared.Ast.naked_expr, Desugared.Ast.naked_expr * Pos.t) Bindlib.mbinder
         Bindlib.box) : 'c Bindlib.box =
     Bindlib.box_apply2
       (fun e_binder case_body ->
@@ -912,10 +912,10 @@ and disambiguate_match_and_build_expression
           missing_constructors
           (cases_d, Some e_uid, curr_index))
   in
-  let expr, e_name, _ =
+  let naked_expr, e_name, _ =
     List.fold_left bind_match_cases (EnumConstructorMap.empty, None, 0) cases
   in
-  expr, Option.get e_name
+  naked_expr, Option.get e_name
   [@@ocamlformat "wrap-comments=false"]
 
 (** {1 Translating scope definitions} *)
@@ -924,9 +924,9 @@ and disambiguate_match_and_build_expression
     this precondition has to be appended to the justifications of each
     definition in the subscope use. This is what this function does. *)
 let merge_conditions
-    (precond : Desugared.Ast.expr Marked.pos Bindlib.box option)
-    (cond : Desugared.Ast.expr Marked.pos Bindlib.box option)
-    (default_pos : Pos.t) : Desugared.Ast.expr Marked.pos Bindlib.box =
+    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (cond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
+    (default_pos : Pos.t) : Desugared.Ast.naked_expr Marked.pos Bindlib.box =
   match precond, cond with
   | Some precond, Some cond ->
     let op_term = EOp (Binop And), Marked.get_mark (Bindlib.unbox cond) in
@@ -948,8 +948,8 @@ let process_default
     (scope : ScopeName.t)
     (def_key : Desugared.Ast.ScopeDef.t Marked.pos)
     (rule_id : Desugared.Ast.RuleName.t)
-    (param_uid : Desugared.Ast.expr Var.t Marked.pos option)
-    (precond : Desugared.Ast.expr Marked.pos Bindlib.box option)
+    (param_uid : Desugared.Ast.naked_expr Var.t Marked.pos option)
+    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
     (exception_situation : Desugared.Ast.exception_situation)
     (label_situation : Desugared.Ast.label_situation)
     (just : Ast.expression Marked.pos option)
@@ -987,7 +987,7 @@ let process_default
 (** Wrapper around {!val: process_default} that performs some name
     disambiguation *)
 let process_def
-    (precond : Desugared.Ast.expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
     (scope_uid : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)
@@ -1076,7 +1076,7 @@ let process_def
 
 (** Translates a {!type: Surface.Ast.rule} from the surface language *)
 let process_rule
-    (precond : Desugared.Ast.expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
     (scope : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)
@@ -1086,7 +1086,7 @@ let process_rule
 
 (** Translates assertions *)
 let process_assert
-    (precond : Desugared.Ast.expr Marked.pos Bindlib.box option)
+    (precond : Desugared.Ast.naked_expr Marked.pos Bindlib.box option)
     (scope_uid : ScopeName.t)
     (ctxt : Name_resolution.context)
     (prgm : Desugared.Ast.program)

--- a/compiler/surface/name_resolution.ml
+++ b/compiler/surface/name_resolution.ml
@@ -60,7 +60,7 @@ type var_sig = {
 }
 
 type context = {
-  local_var_idmap : Desugared.Ast.naked_expr Var.t Desugared.Ast.IdentMap.t;
+  local_var_idmap : Desugared.Ast.expr Var.t Desugared.Ast.IdentMap.t;
       (** Inside a definition, local variables can be introduced by functions
           arguments or pattern matching *)
   scope_idmap : ScopeName.t Desugared.Ast.IdentMap.t;
@@ -148,8 +148,7 @@ let belongs_to (ctxt : context) (uid : ScopeVar.t) (scope_uid : ScopeName.t) :
     scope.var_idmap
 
 (** Retrieves the type of a scope definition from the context *)
-let get_def_typ (ctxt : context) (def : Desugared.Ast.ScopeDef.t) :
-    typ =
+let get_def_typ (ctxt : context) (def : Desugared.Ast.ScopeDef.t) : typ =
   match def with
   | Desugared.Ast.ScopeDef.SubScopeVar (_, x)
   (* we don't need to look at the subscope prefix because [x] is already the uid
@@ -249,8 +248,7 @@ let rec process_base_typ
             ident)))
 
 (** Process a type (function or not) *)
-let process_type (ctxt : context) ((naked_typ, typ_pos) : Ast.typ) :
-    typ =
+let process_type (ctxt : context) ((naked_typ, typ_pos) : Ast.typ) : typ =
   match naked_typ with
   | Ast.Base base_typ -> process_base_typ ctxt (base_typ, typ_pos)
   | Ast.Func { arg_typ; return_typ } ->
@@ -321,7 +319,7 @@ let process_item_decl
 
 (** Adds a binding to the context *)
 let add_def_local_var (ctxt : context) (name : ident) :
-    context * Desugared.Ast.naked_expr Var.t =
+    context * Desugared.Ast.expr Var.t =
   let local_var_uid = Var.make name in
   let ctxt =
     {

--- a/compiler/surface/name_resolution.ml
+++ b/compiler/surface/name_resolution.ml
@@ -45,14 +45,14 @@ type scope_context = {
 }
 (** Inside a scope, we distinguish between the variables and the subscopes. *)
 
-type struct_context = typ Marked.pos StructFieldMap.t
+type struct_context = typ StructFieldMap.t
 (** Types of the fields of a struct *)
 
-type enum_context = typ Marked.pos EnumConstructorMap.t
+type enum_context = typ EnumConstructorMap.t
 (** Types of the payloads of the cases of an enum *)
 
 type var_sig = {
-  var_sig_typ : typ Marked.pos;
+  var_sig_typ : typ;
   var_sig_is_condition : bool;
   var_sig_io : Ast.scope_decl_context_io;
   var_sig_states_idmap : StateName.t Desugared.Ast.IdentMap.t;
@@ -100,7 +100,7 @@ let raise_unknown_identifier (msg : string) (ident : ident Marked.pos) =
     msg
 
 (** Gets the type associated to an uid *)
-let get_var_typ (ctxt : context) (uid : ScopeVar.t) : typ Marked.pos =
+let get_var_typ (ctxt : context) (uid : ScopeVar.t) : typ =
   (ScopeVarMap.find uid ctxt.var_typs).var_sig_typ
 
 let is_var_cond (ctxt : context) (uid : ScopeVar.t) : bool =
@@ -149,7 +149,7 @@ let belongs_to (ctxt : context) (uid : ScopeVar.t) (scope_uid : ScopeName.t) :
 
 (** Retrieves the type of a scope definition from the context *)
 let get_def_typ (ctxt : context) (def : Desugared.Ast.ScopeDef.t) :
-    typ Marked.pos =
+    typ =
   match def with
   | Desugared.Ast.ScopeDef.SubScopeVar (_, x)
   (* we don't need to look at the subscope prefix because [x] is already the uid
@@ -210,7 +210,7 @@ let process_subscope_decl
       scopes = Scopelang.Ast.ScopeMap.add scope scope_ctxt ctxt.scopes;
     }
 
-let is_type_cond ((typ, _) : Ast.typ Marked.pos) =
+let is_type_cond ((typ, _) : Ast.typ) =
   match typ with
   | Ast.Base Ast.Condition
   | Ast.Func { arg_typ = _; return_typ = Ast.Condition, _ } ->
@@ -220,7 +220,7 @@ let is_type_cond ((typ, _) : Ast.typ Marked.pos) =
 (** Process a basic type (all types except function types) *)
 let rec process_base_typ
     (ctxt : context)
-    ((typ, typ_pos) : Ast.base_typ Marked.pos) : typ Marked.pos =
+    ((typ, typ_pos) : Ast.base_typ Marked.pos) : typ =
   match typ with
   | Ast.Condition -> TLit TBool, typ_pos
   | Ast.Data (Ast.Collection t) ->
@@ -249,9 +249,9 @@ let rec process_base_typ
             ident)))
 
 (** Process a type (function or not) *)
-let process_type (ctxt : context) ((typ, typ_pos) : Ast.typ Marked.pos) :
-    typ Marked.pos =
-  match typ with
+let process_type (ctxt : context) ((naked_typ, typ_pos) : Ast.typ) :
+    typ =
+  match naked_typ with
   | Ast.Base base_typ -> process_base_typ ctxt (base_typ, typ_pos)
   | Ast.Func { arg_typ; return_typ } ->
     ( TArrow (process_base_typ ctxt arg_typ, process_base_typ ctxt return_typ),

--- a/compiler/surface/name_resolution.ml
+++ b/compiler/surface/name_resolution.ml
@@ -60,7 +60,7 @@ type var_sig = {
 }
 
 type context = {
-  local_var_idmap : Desugared.Ast.expr Var.t Desugared.Ast.IdentMap.t;
+  local_var_idmap : Desugared.Ast.naked_expr Var.t Desugared.Ast.IdentMap.t;
       (** Inside a definition, local variables can be introduced by functions
           arguments or pattern matching *)
   scope_idmap : ScopeName.t Desugared.Ast.IdentMap.t;
@@ -321,7 +321,7 @@ let process_item_decl
 
 (** Adds a binding to the context *)
 let add_def_local_var (ctxt : context) (name : ident) :
-    context * Desugared.Ast.expr Var.t =
+    context * Desugared.Ast.naked_expr Var.t =
   let local_var_uid = Var.make name in
   let ctxt =
     {

--- a/compiler/surface/name_resolution.mli
+++ b/compiler/surface/name_resolution.mli
@@ -60,7 +60,7 @@ type var_sig = {
 }
 
 type context = {
-  local_var_idmap : Desugared.Ast.naked_expr Var.t Desugared.Ast.IdentMap.t;
+  local_var_idmap : Desugared.Ast.expr Var.t Desugared.Ast.IdentMap.t;
       (** Inside a definition, local variables can be introduced by functions
           arguments or pattern matching *)
   scope_idmap : ScopeName.t Desugared.Ast.IdentMap.t;
@@ -120,7 +120,7 @@ val get_def_typ : context -> Desugared.Ast.ScopeDef.t -> typ
 val is_def_cond : context -> Desugared.Ast.ScopeDef.t -> bool
 val is_type_cond : Ast.typ -> bool
 
-val add_def_local_var : context -> ident -> context * Desugared.Ast.naked_expr Var.t
+val add_def_local_var : context -> ident -> context * Desugared.Ast.expr Var.t
 (** Adds a binding to the context *)
 
 val get_def_key :

--- a/compiler/surface/name_resolution.mli
+++ b/compiler/surface/name_resolution.mli
@@ -60,7 +60,7 @@ type var_sig = {
 }
 
 type context = {
-  local_var_idmap : Desugared.Ast.expr Var.t Desugared.Ast.IdentMap.t;
+  local_var_idmap : Desugared.Ast.naked_expr Var.t Desugared.Ast.IdentMap.t;
       (** Inside a definition, local variables can be introduced by functions
           arguments or pattern matching *)
   scope_idmap : ScopeName.t Desugared.Ast.IdentMap.t;
@@ -120,7 +120,7 @@ val get_def_typ : context -> Desugared.Ast.ScopeDef.t -> typ Marked.pos
 val is_def_cond : context -> Desugared.Ast.ScopeDef.t -> bool
 val is_type_cond : Ast.typ Marked.pos -> bool
 
-val add_def_local_var : context -> ident -> context * Desugared.Ast.expr Var.t
+val add_def_local_var : context -> ident -> context * Desugared.Ast.naked_expr Var.t
 (** Adds a binding to the context *)
 
 val get_def_key :

--- a/compiler/surface/name_resolution.mli
+++ b/compiler/surface/name_resolution.mli
@@ -45,14 +45,14 @@ type scope_context = {
 }
 (** Inside a scope, we distinguish between the variables and the subscopes. *)
 
-type struct_context = typ Marked.pos StructFieldMap.t
+type struct_context = typ StructFieldMap.t
 (** Types of the fields of a struct *)
 
-type enum_context = typ Marked.pos EnumConstructorMap.t
+type enum_context = typ EnumConstructorMap.t
 (** Types of the payloads of the cases of an enum *)
 
 type var_sig = {
-  var_sig_typ : typ Marked.pos;
+  var_sig_typ : typ;
   var_sig_is_condition : bool;
   var_sig_io : Ast.scope_decl_context_io;
   var_sig_states_idmap : StateName.t Desugared.Ast.IdentMap.t;
@@ -94,7 +94,7 @@ val raise_unknown_identifier : string -> ident Marked.pos -> 'a
 (** Function to call whenever an identifier used somewhere has not been declared
     in the program previously *)
 
-val get_var_typ : context -> ScopeVar.t -> typ Marked.pos
+val get_var_typ : context -> ScopeVar.t -> typ
 (** Gets the type associated to an uid *)
 
 val is_var_cond : context -> ScopeVar.t -> bool
@@ -114,11 +114,11 @@ val is_subscope_uid : ScopeName.t -> context -> ident -> bool
 val belongs_to : context -> ScopeVar.t -> ScopeName.t -> bool
 (** Checks if the var_uid belongs to the scope scope_uid *)
 
-val get_def_typ : context -> Desugared.Ast.ScopeDef.t -> typ Marked.pos
+val get_def_typ : context -> Desugared.Ast.ScopeDef.t -> typ
 (** Retrieves the type of a scope definition from the context *)
 
 val is_def_cond : context -> Desugared.Ast.ScopeDef.t -> bool
-val is_type_cond : Ast.typ Marked.pos -> bool
+val is_type_cond : Ast.typ -> bool
 
 val add_def_local_var : context -> ident -> context * Desugared.Ast.naked_expr Var.t
 (** Adds a binding to the context *)

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -22,15 +22,15 @@ open Ast
 
 (** {1 Helpers and type definitions}*)
 
-type vc_return = typed expr * (typed naked_expr, typ) Var.Map.t
+type vc_return = typed expr * (typed expr, typ) Var.Map.t
 (** The return type of VC generators is the VC expression plus the types of any
     locally free variable inside that expression. *)
 
 type ctx = {
   current_scope_name : ScopeName.t;
   decl : decl_ctx;
-  input_vars : typed naked_expr Var.t list;
-  scope_variables_typs : (typed naked_expr, typ) Var.Map.t;
+  input_vars : typed expr Var.t list;
+  scope_variables_typs : (typed expr, typ) Var.Map.t;
 }
 
 let conjunction (args : vc_return list) (mark : typed mark) : vc_return =
@@ -74,8 +74,8 @@ let half_product (l1 : 'a list) (l2 : 'b list) : ('a * 'b) list =
     variables, or [fun () -> e1] for subscope variables. But what we really want
     to analyze is only [e1], so we match this outermost structure explicitely
     and have a clean verification condition generator that only runs on [e1] *)
-let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed expr)
-    : typed expr =
+let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed expr) :
+    typed expr =
   match Marked.unmark e with
   | ErrorOnEmpty
       ( EDefault
@@ -200,8 +200,8 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
     [b] such that if [b] is true, then [e] will never return a conflict error.
     It also returns a map of all the types of locally free variables inside the
     expression. *)
-let rec generate_vs_must_not_return_confict (ctx : ctx) (e : typed expr)
-    : vc_return =
+let rec generate_vs_must_not_return_confict (ctx : ctx) (e : typed expr) :
+    vc_return =
   let out =
     (* See the code of [generate_vc_must_not_return_empty] for a list of invariants on which this
        function relies on. *)
@@ -287,13 +287,13 @@ type verification_condition = {
   (* should have type bool *)
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
-  vc_variable : typed naked_expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed naked_expr, typ) Var.Map.t;
+  vc_variable : typed expr Var.t Marked.pos;
+  vc_free_vars_typ : (typed expr, typ) Var.Map.t;
 }
 
 let rec generate_verification_conditions_scope_body_expr
     (ctx : ctx)
-    (scope_body_expr : 'm naked_expr scope_body_expr) :
+    (scope_body_expr : 'm expr scope_body_expr) :
     ctx * verification_condition list =
   match scope_body_expr with
   | Result _ -> ctx, []
@@ -378,7 +378,7 @@ let rec generate_verification_conditions_scope_body_expr
 
 let rec generate_verification_conditions_scopes
     (decl_ctx : decl_ctx)
-    (scopes : 'm naked_expr scopes)
+    (scopes : 'm expr scopes)
     (s : ScopeName.t option) : verification_condition list =
   match scopes with
   | Nil -> []

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -22,7 +22,7 @@ open Ast
 
 (** {1 Helpers and type definitions}*)
 
-type vc_return = typed expr * (typed naked_expr, typ Marked.pos) Var.Map.t
+type vc_return = typed expr * (typed naked_expr, typ) Var.Map.t
 (** The return type of VC generators is the VC expression plus the types of any
     locally free variable inside that expression. *)
 
@@ -30,7 +30,7 @@ type ctx = {
   current_scope_name : ScopeName.t;
   decl : decl_ctx;
   input_vars : typed naked_expr Var.t list;
-  scope_variables_typs : (typed naked_expr, typ Marked.pos) Var.Map.t;
+  scope_variables_typs : (typed naked_expr, typ) Var.Map.t;
 }
 
 let conjunction (args : vc_return list) (mark : typed mark) : vc_return =
@@ -288,7 +288,7 @@ type verification_condition = {
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
   vc_variable : typed naked_expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed naked_expr, typ Marked.pos) Var.Map.t;
+  vc_free_vars_typ : (typed naked_expr, typ) Var.Map.t;
 }
 
 let rec generate_verification_conditions_scope_body_expr

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -22,15 +22,15 @@ open Ast
 
 (** {1 Helpers and type definitions}*)
 
-type vc_return = typed marked_expr * (typed expr, typ Marked.pos) Var.Map.t
+type vc_return = typed expr * (typed naked_expr, typ Marked.pos) Var.Map.t
 (** The return type of VC generators is the VC expression plus the types of any
     locally free variable inside that expression. *)
 
 type ctx = {
   current_scope_name : ScopeName.t;
   decl : decl_ctx;
-  input_vars : typed expr Var.t list;
-  scope_variables_typs : (typed expr, typ Marked.pos) Var.Map.t;
+  input_vars : typed naked_expr Var.t list;
+  scope_variables_typs : (typed naked_expr, typ Marked.pos) Var.Map.t;
 }
 
 let conjunction (args : vc_return list) (mark : typed mark) : vc_return =
@@ -74,8 +74,8 @@ let half_product (l1 : 'a list) (l2 : 'b list) : ('a * 'b) list =
     variables, or [fun () -> e1] for subscope variables. But what we really want
     to analyze is only [e1], so we match this outermost structure explicitely
     and have a clean verification condition generator that only runs on [e1] *)
-let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed marked_expr)
-    : typed marked_expr =
+let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed expr)
+    : typed expr =
   match Marked.unmark e with
   | ErrorOnEmpty
       ( EDefault
@@ -106,7 +106,7 @@ let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed marked_expr)
     [b] such that if [b] is true, then [e] will never return an empty error. It
     also returns a map of all the types of locally free variables inside the
     expression. *)
-let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed marked_expr) :
+let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
     vc_return =
   let out =
     match Marked.unmark e with
@@ -200,7 +200,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed marked_expr) :
     [b] such that if [b] is true, then [e] will never return a conflict error.
     It also returns a map of all the types of locally free variables inside the
     expression. *)
-let rec generate_vs_must_not_return_confict (ctx : ctx) (e : typed marked_expr)
+let rec generate_vs_must_not_return_confict (ctx : ctx) (e : typed expr)
     : vc_return =
   let out =
     (* See the code of [generate_vc_must_not_return_empty] for a list of invariants on which this
@@ -283,17 +283,17 @@ let rec generate_vs_must_not_return_confict (ctx : ctx) (e : typed marked_expr)
 type verification_condition_kind = NoEmptyError | NoOverlappingExceptions
 
 type verification_condition = {
-  vc_guard : typed marked_expr;
+  vc_guard : typed expr;
   (* should have type bool *)
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
-  vc_variable : typed expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed expr, typ Marked.pos) Var.Map.t;
+  vc_variable : typed naked_expr Var.t Marked.pos;
+  vc_free_vars_typ : (typed naked_expr, typ Marked.pos) Var.Map.t;
 }
 
 let rec generate_verification_conditions_scope_body_expr
     (ctx : ctx)
-    (scope_body_expr : 'm expr scope_body_expr) :
+    (scope_body_expr : 'm naked_expr scope_body_expr) :
     ctx * verification_condition list =
   match scope_body_expr with
   | Result _ -> ctx, []
@@ -378,7 +378,7 @@ let rec generate_verification_conditions_scope_body_expr
 
 let rec generate_verification_conditions_scopes
     (decl_ctx : decl_ctx)
-    (scopes : 'm expr scopes)
+    (scopes : 'm naked_expr scopes)
     (s : ScopeName.t option) : verification_condition list =
   match scopes with
   | Nil -> []

--- a/compiler/verification/conditions.mli
+++ b/compiler/verification/conditions.mli
@@ -33,8 +33,8 @@ type verification_condition = {
       (** This expression should have type [bool]*)
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
-  vc_variable : typed Dcalc.Ast.naked_expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed Dcalc.Ast.naked_expr, typ) Var.Map.t;
+  vc_variable : typed Dcalc.Ast.expr Var.t Marked.pos;
+  vc_free_vars_typ : (typed Dcalc.Ast.expr, typ) Var.Map.t;
       (** Types of the locally free variables in [vc_guard]. The types of other
           free variables linked to scope variables can be obtained with
           [Dcalc.Ast.variable_types]. *)

--- a/compiler/verification/conditions.mli
+++ b/compiler/verification/conditions.mli
@@ -29,12 +29,12 @@ type verification_condition_kind =
           a conflict error *)
 
 type verification_condition = {
-  vc_guard : typed Dcalc.Ast.marked_expr;
+  vc_guard : typed Dcalc.Ast.expr;
       (** This expression should have type [bool]*)
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
-  vc_variable : typed Dcalc.Ast.expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed Dcalc.Ast.expr, typ Marked.pos) Var.Map.t;
+  vc_variable : typed Dcalc.Ast.naked_expr Var.t Marked.pos;
+  vc_free_vars_typ : (typed Dcalc.Ast.naked_expr, typ Marked.pos) Var.Map.t;
       (** Types of the locally free variables in [vc_guard]. The types of other
           free variables linked to scope variables can be obtained with
           [Dcalc.Ast.variable_types]. *)

--- a/compiler/verification/conditions.mli
+++ b/compiler/verification/conditions.mli
@@ -34,7 +34,7 @@ type verification_condition = {
   vc_kind : verification_condition_kind;
   vc_scope : ScopeName.t;
   vc_variable : typed Dcalc.Ast.naked_expr Var.t Marked.pos;
-  vc_free_vars_typ : (typed Dcalc.Ast.naked_expr, typ Marked.pos) Var.Map.t;
+  vc_free_vars_typ : (typed Dcalc.Ast.naked_expr, typ) Var.Map.t;
       (** Types of the locally free variables in [vc_guard]. The types of other
           free variables linked to scope variables can be obtained with
           [Dcalc.Ast.variable_types]. *)

--- a/compiler/verification/io.ml
+++ b/compiler/verification/io.ml
@@ -25,7 +25,7 @@ module type Backend = sig
   type backend_context
 
   val make_context :
-    decl_ctx -> (typed naked_expr, typ Marked.pos) Var.Map.t -> backend_context
+    decl_ctx -> (typed naked_expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 
@@ -50,7 +50,7 @@ module type BackendIO = sig
   type backend_context
 
   val make_context :
-    decl_ctx -> (typed naked_expr, typ Marked.pos) Var.Map.t -> backend_context
+    decl_ctx -> (typed naked_expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 

--- a/compiler/verification/io.ml
+++ b/compiler/verification/io.ml
@@ -25,7 +25,7 @@ module type Backend = sig
   type backend_context
 
   val make_context :
-    decl_ctx -> (typed expr, typ Marked.pos) Var.Map.t -> backend_context
+    decl_ctx -> (typed naked_expr, typ Marked.pos) Var.Map.t -> backend_context
 
   type vc_encoding
 
@@ -40,7 +40,7 @@ module type Backend = sig
 
   val translate_expr :
     backend_context ->
-    typed Dcalc.Ast.marked_expr ->
+    typed Dcalc.Ast.expr ->
     backend_context * vc_encoding
 end
 
@@ -50,13 +50,13 @@ module type BackendIO = sig
   type backend_context
 
   val make_context :
-    decl_ctx -> (typed expr, typ Marked.pos) Var.Map.t -> backend_context
+    decl_ctx -> (typed naked_expr, typ Marked.pos) Var.Map.t -> backend_context
 
   type vc_encoding
 
   val translate_expr :
     backend_context ->
-    typed Dcalc.Ast.marked_expr ->
+    typed Dcalc.Ast.expr ->
     backend_context * vc_encoding
 
   type model

--- a/compiler/verification/io.ml
+++ b/compiler/verification/io.ml
@@ -24,8 +24,7 @@ module type Backend = sig
 
   type backend_context
 
-  val make_context :
-    decl_ctx -> (typed naked_expr, typ) Var.Map.t -> backend_context
+  val make_context : decl_ctx -> (typed expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 
@@ -39,9 +38,7 @@ module type Backend = sig
   val is_model_empty : model -> bool
 
   val translate_expr :
-    backend_context ->
-    typed Dcalc.Ast.expr ->
-    backend_context * vc_encoding
+    backend_context -> typed Dcalc.Ast.expr -> backend_context * vc_encoding
 end
 
 module type BackendIO = sig
@@ -49,15 +46,12 @@ module type BackendIO = sig
 
   type backend_context
 
-  val make_context :
-    decl_ctx -> (typed naked_expr, typ) Var.Map.t -> backend_context
+  val make_context : decl_ctx -> (typed expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 
   val translate_expr :
-    backend_context ->
-    typed Dcalc.Ast.expr ->
-    backend_context * vc_encoding
+    backend_context -> typed Dcalc.Ast.expr -> backend_context * vc_encoding
 
   type model
 

--- a/compiler/verification/io.mli
+++ b/compiler/verification/io.mli
@@ -26,7 +26,7 @@ module type Backend = sig
 
   val make_context :
     decl_ctx ->
-    (typed Dcalc.Ast.naked_expr, typ Utils.Marked.pos) Var.Map.t ->
+    (typed Dcalc.Ast.naked_expr, typ) Var.Map.t ->
     backend_context
 
   type vc_encoding
@@ -53,7 +53,7 @@ module type BackendIO = sig
 
   val make_context :
     decl_ctx ->
-    (typed Dcalc.Ast.naked_expr, typ Utils.Marked.pos) Var.Map.t ->
+    (typed Dcalc.Ast.naked_expr, typ) Var.Map.t ->
     backend_context
 
   type vc_encoding

--- a/compiler/verification/io.mli
+++ b/compiler/verification/io.mli
@@ -26,7 +26,7 @@ module type Backend = sig
 
   val make_context :
     decl_ctx ->
-    (typed Dcalc.Ast.expr, typ Utils.Marked.pos) Var.Map.t ->
+    (typed Dcalc.Ast.naked_expr, typ Utils.Marked.pos) Var.Map.t ->
     backend_context
 
   type vc_encoding
@@ -42,7 +42,7 @@ module type Backend = sig
 
   val translate_expr :
     backend_context ->
-    typed Dcalc.Ast.marked_expr ->
+    typed Dcalc.Ast.expr ->
     backend_context * vc_encoding
 end
 
@@ -53,14 +53,14 @@ module type BackendIO = sig
 
   val make_context :
     decl_ctx ->
-    (typed Dcalc.Ast.expr, typ Utils.Marked.pos) Var.Map.t ->
+    (typed Dcalc.Ast.naked_expr, typ Utils.Marked.pos) Var.Map.t ->
     backend_context
 
   type vc_encoding
 
   val translate_expr :
     backend_context ->
-    typed Dcalc.Ast.marked_expr ->
+    typed Dcalc.Ast.expr ->
     backend_context * vc_encoding
 
   type model

--- a/compiler/verification/io.mli
+++ b/compiler/verification/io.mli
@@ -25,9 +25,7 @@ module type Backend = sig
   type backend_context
 
   val make_context :
-    decl_ctx ->
-    (typed Dcalc.Ast.naked_expr, typ) Var.Map.t ->
-    backend_context
+    decl_ctx -> (typed Dcalc.Ast.expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 
@@ -41,9 +39,7 @@ module type Backend = sig
   val is_model_empty : model -> bool
 
   val translate_expr :
-    backend_context ->
-    typed Dcalc.Ast.expr ->
-    backend_context * vc_encoding
+    backend_context -> typed Dcalc.Ast.expr -> backend_context * vc_encoding
 end
 
 module type BackendIO = sig
@@ -52,16 +48,12 @@ module type BackendIO = sig
   type backend_context
 
   val make_context :
-    decl_ctx ->
-    (typed Dcalc.Ast.naked_expr, typ) Var.Map.t ->
-    backend_context
+    decl_ctx -> (typed Dcalc.Ast.expr, typ) Var.Map.t -> backend_context
 
   type vc_encoding
 
   val translate_expr :
-    backend_context ->
-    typed Dcalc.Ast.expr ->
-    backend_context * vc_encoding
+    backend_context -> typed Dcalc.Ast.expr -> backend_context * vc_encoding
 
   type model
 


### PR DESCRIPTION
Ok this one seems big but it's mostly just `sed` calls. It's very optional. It's based on #321 so that should definitely be merged first.

For handling marks we usually have two mutually recursive types `foo` and `marked_foo`. Types, expressions, etc.

Now, throughout, I found that we use `marked_foo` much more often than `foo` when using the type. Which is good.

But I feel the naming pushes in favor of using the base `foo` type. So this proposal does a little inversion:

- `marked_foo` → is renamed to → `foo` for use throughout
- `foo` → is renamed to → `naked_foo` for clarity