### PR TITLE
Fix nix build

### DIFF
--- a/.nix/catala.nix
+++ b/.nix/catala.nix
@@ -34,7 +34,7 @@ buildDunePackage rec {
 
   src = ../.;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     alcotest

--- a/.nix/clerk.nix
+++ b/.nix/clerk.nix
@@ -17,7 +17,7 @@ buildDunePackage rec {
 
   src = ../.;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     odoc

--- a/.nix/ninja_utils.nix
+++ b/.nix/ninja_utils.nix
@@ -12,7 +12,7 @@ buildDunePackage rec {
 
   src = ../.;
 
-  useDune2 = true;
+  duneVersion = "3";
 
   propagatedBuildInputs = [
     odoc

--- a/.nix/packages.nix
+++ b/.nix/packages.nix
@@ -13,10 +13,19 @@ ocamlPackages.overrideScope' (self: super: {
   }).overrideAttrs (_: {
     doCheck = false;
   });
+  # Use a more recent version of `re` than the one packaged in nixpkgs
+  re = super.re.overrideAttrs (o: rec {
+    version = "1.10.4";
+    src = fetchurl {
+      url = "https://github.com/ocaml/ocaml-${o.pname}/releases/download/${version}/${o.pname}-${version}.tbz";
+      sha256 = "sha256-g+s+QwCqmx3HggdJAQ9DYuqDUkdCEwUk14wgzpnKdHw=";
+    };
+  });
   catala = self.callPackage ./catala.nix { };
   bindlib = self.callPackage ./bindlib.nix { };
   unionfind = self.callPackage ./unionfind.nix { };
   ninja_utils = self.callPackage ./ninja_utils.nix { };
   clerk = self.callPackage ./clerk.nix { };
   ppx_yojson_conv = self.callPackage ./ppx_yojson_conv.nix { };
+  ubase = self.callPackage ./ubase.nix { };
 })

--- a/.nix/ubase.nix
+++ b/.nix/ubase.nix
@@ -1,0 +1,20 @@
+{ lib, fetchurl, buildDunePackage, uutf }:
+
+buildDunePackage rec {
+  pname = "ubase";
+  version = "0.05";
+
+  minimumOCamlVersion = "4.05.0";
+
+  useDune2 = true;
+
+  propagatedBuildInputs = [
+    uutf
+  ];
+
+  src = fetchurl
+    {
+      url = "https://github.com/sanette/${pname}/archive/${version}.tar.gz";
+      sha256 = "sha256-D7/aCobZDS9/e5hLxd6pO9MJ4xXaSTACUXeQU4j5u0E=";
+    };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659219666,
-        "narHash": "sha256-pzYr5fokQPHv7CmUXioOhhzDy/XyWOIXP4LZvv/T7Mk=",
+        "lastModified": 1662019588,
+        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7b9be38c7250b22d829ab6effdee90d5e40c6e5c",
+        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes #310.

While doing it, I noticed that the `re` version in `catala.opam` is wrong: currently it is `"re" {>= "1.9.0"}`, however Catala doesn't compile with `re` version `1.9.0`.