### PR TITLE
Better Z3 encoding of EMatch nodes

### DIFF
--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -626,7 +626,7 @@ let rec translate_op (ctx : context) (op : operator) (args : 'm expr list) :
 
 (** [translate_expr] translate the expression [vc] to its corresponding Z3
     expression **)
-and translate_expr (ctx : context) (vc : 'm expr) : context * Expr.expr =
+and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
   let translate_match_arm
       (head : Expr.expr)
       (ctx : context)
@@ -817,7 +817,7 @@ module Backend = struct
 
   let is_model_empty (m : model) : bool = List.length (Z3.Model.get_decls m) = 0
 
-  let translate_expr (ctx : backend_context) (e : 'm expr) =
+  let translate_expr (ctx : backend_context) (e : typed expr) =
     translate_expr ctx e
 
   let init_backend () =

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -713,7 +713,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
        fresh, and thus will not clash in Z3 *)
     let fresh_v = Var.make "z3!match_tmp" in
     let name = unique_name fresh_v in
-    let match_ty = failwith "GET TYPE" in
+    let Typed {ty = match_ty; _ } = Marked.get_mark vc in
     let ctx, z3_ty = translate_typ ctx (Marked.unmark match_ty) in
     let z3_var = Expr.mk_const_s ctx.ctx_z3 name z3_ty in
 

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -705,15 +705,15 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     let ctr = List.nth ctrs idx in
     ctx, Expr.mk_app ctx.ctx_z3 ctr [z3_arg]
   | EMatch (arg, arms, enum) ->
-    (* We will encode a match as a new variable, tmp_v, and add to the hypotheses
-       that this variable is equal to the conjunction of all `A? arg ==> tmp_v == body`,
-       where `A? arg ==> body` is an arm of the match *)
+    (* We will encode a match as a new variable, tmp_v, and add to the
+       hypotheses that this variable is equal to the conjunction of all `A? arg
+       ==> tmp_v == body`, where `A? arg ==> body` is an arm of the match *)
 
-    (* We use the Var module to ensure that all names for temporary variables will be
-       fresh, and thus will not clash in Z3 *)
+    (* We use the Var module to ensure that all names for temporary variables
+       will be fresh, and thus will not clash in Z3 *)
     let fresh_v = Var.make "z3!match_tmp" in
     let name = unique_name fresh_v in
-    let Typed {ty = match_ty; _ } = Marked.get_mark vc in
+    let (Typed { ty = match_ty; _ }) = Marked.get_mark vc in
     let ctx, z3_ty = translate_typ ctx (Marked.unmark match_ty) in
     let z3_var = Expr.mk_const_s ctx.ctx_z3 name z3_ty in
 
@@ -739,7 +739,6 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     (* Add the definition of z3_var to the hypotheses *)
     let ctx = add_z3constraint (Boolean.mk_and ctx.ctx_z3 z3_arms) ctx in
     ctx, z3_var
-
   | EArray _ -> failwith "[Z3 encoding] EArray unsupported"
   | ELit l -> ctx, translate_lit ctx l
   | EAbs _ -> failwith "[Z3 encoding] EAbs unsupported"


### PR DESCRIPTION
Now that #272 was merged and that type information is available at every AST node, this PR improves the Z3 encoding of pattern matching in the verification backend. To do so, it implements the second solution presented in #241. 

Fixes #241 