### PR TITLE
Do not hardfail when pretty-printing unknown Z3 variables

### DIFF
--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -212,7 +212,7 @@ let print_model (ctx : context) (model : Model.model) : string =
   let decls = Model.get_decls model in
   Format.asprintf "%a"
     (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt "\n")
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt "")
        (fun fmt d ->
          if FuncDecl.get_arity d = 0 then
            (* Constant case *)
@@ -222,13 +222,15 @@ let print_model (ctx : context) (model : Model.model) : string =
              failwith
                "[Z3 model]: A variable does not have an associated Z3 solution"
            (* Print "name : value\n" *)
-           | Some e ->
+           | Some e -> (
              let symbol_name = Symbol.to_string (FuncDecl.get_name d) in
-             let v = StringMap.find symbol_name ctx.ctx_z3vars in
-             Format.fprintf fmt "%s %s : %s"
-               (Cli.with_style [ANSITerminal.blue] "%s" "-->")
-               (Cli.with_style [ANSITerminal.yellow] "%s" (Bindlib.name_of v))
-               (print_z3model_expr ctx (Var.Map.find v ctx.ctx_var) e)
+             match StringMap.find_opt symbol_name ctx.ctx_z3vars with
+             | None -> ()
+             | Some v ->
+               Format.fprintf fmt "%s %s : %s\n"
+                 (Cli.with_style [ANSITerminal.blue] "%s" "-->")
+                 (Cli.with_style [ANSITerminal.yellow] "%s" (Bindlib.name_of v))
+                 (print_z3model_expr ctx (Var.Map.find v ctx.ctx_var) e))
          else
            (* Declaration d is a function *)
            match Model.get_func_interp model d with

--- a/tests/test_proof/bad/enums-nonbool-empty.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-empty.catala_en
@@ -1,0 +1,24 @@
+## Test
+
+```catala
+declaration enumeration T:
+   -- C content boolean
+   -- D content integer
+
+declaration enumeration S:
+    -- A content integer
+    -- B content T
+
+declaration scope A:
+  context x content integer
+  context y content S
+
+scope A:
+  definition y equals B content (D content 1)
+  definition x under condition (match y with pattern -- A of a: 1 -- B of b: 2) > 1 consequence equals 0
+  definition x under condition match y with pattern -- A of a: a < 0 -- B of b: false consequence equals 1
+```
+
+```catala-test {id="Proof"}
+catala Proof --disable_counterexamples
+```

--- a/tests/test_proof/bad/enums-nonbool-overlap.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-overlap.catala_en
@@ -1,0 +1,24 @@
+## Test
+
+```catala
+declaration enumeration T:
+   -- C content boolean
+   -- D content integer
+
+declaration enumeration S:
+    -- A content integer
+    -- B content T
+
+declaration scope A:
+  context x content integer
+  context y content S
+
+scope A:
+  definition y equals B content (D content 1)
+  definition x under condition (match y with pattern -- A of a: 1 -- B of b: 2) < 2 consequence equals 0
+  definition x under condition match y with pattern -- A of a: a < 0 -- B of b: true consequence equals 1
+```
+
+```catala-test {id="Proof"}
+catala Proof --disable_counterexamples
+```

--- a/tests/test_proof/bad/output/enums-nonbool-empty.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums-nonbool-empty.catala_en.Proof
@@ -1,0 +1,7 @@
+[ERROR] [A.x] This variable might return an empty error:
+  --> tests/test_proof/bad/enums-nonbool-empty.catala_en
+   |
+13 |   context x content integer
+   |           ^
+   + Test
+Counterexample generation is disabled so none was generated.

--- a/tests/test_proof/bad/output/enums-nonbool-overlap.catala_en.Proof
+++ b/tests/test_proof/bad/output/enums-nonbool-overlap.catala_en.Proof
@@ -1,0 +1,7 @@
+[ERROR] [A.x] At least two exceptions overlap for this variable:
+  --> tests/test_proof/bad/enums-nonbool-overlap.catala_en
+   |
+13 |   context x content integer
+   |           ^
+   + Test
+Counterexample generation is disabled so none was generated.

--- a/tests/test_proof/good/enums-nonbool.catala_en
+++ b/tests/test_proof/good/enums-nonbool.catala_en
@@ -1,0 +1,24 @@
+## Test
+
+```catala
+declaration enumeration T:
+   -- C content boolean
+   -- D content integer
+
+declaration enumeration S:
+    -- A content integer
+    -- B content T
+
+declaration scope A:
+  context x content integer
+  context y content S
+
+scope A:
+  definition y equals B content (D content 1)
+  definition x under condition (match y with pattern -- A of a: 1 -- B of b: 2) < 2 consequence equals 0
+  definition x under condition match y with pattern -- A of a: false -- B of b: true consequence equals 1
+```
+
+```catala-test {id="Proof"}
+catala Proof --disable_counterexamples
+```

--- a/tests/test_proof/good/output/enums-nonbool.catala_en.Proof
+++ b/tests/test_proof/good/output/enums-nonbool.catala_en.Proof
@@ -1,0 +1,1 @@
+[RESULT] No errors found during the proof mode run.


### PR DESCRIPTION
This PR extends PR #331, by avoiding hard failures when pretty-printing a Z3 model when generating a counterexample.
#331 added some Z3 variables to encode EMatch nodes that are only used internally in the encoding, and do not correspond to any source variable. When trying to retrieve the source variable corresponding to this Z3 variable for pretty-printing purposes (stored in a map in the context, called ctx.z3_vars), we thus had a hard OCaml failure due to a Not_found exception.

This PR fixes this by ignoring internal variables during pretty-printing of the counterexample. It also adds some unit tests for #331, although, since counterexample generation is disabled in tests/, this specific issue would not have been caught.

Fixes #332