### PR TITLE
Printer: less verbose variables printing

### DIFF
--- a/tests/test_bool/good/test_bool.catala_en
+++ b/tests/test_bool/good/test_bool.catala_en
@@ -13,21 +13,21 @@ scope TestBool:
 
 ```catala-test-inline
 $ catala Dcalc 
-let TestBool_22 :
+let TestBool :
   TestBool_in{"foo_in": unit → bool; "bar_in": unit → integer} →
     TestBool_out{"foo_out": bool; "bar_out": integer} =
-  λ (TestBool_in_23: TestBool_in{"foo_in": unit → bool; "bar_in":
-                        unit → integer}) →
-    let foo_24 : unit → bool = TestBool_in_23."foo_in" in
-    let bar_25 : unit → integer = TestBool_in_23."bar_in" in
-    let bar_26 : integer = error_empty
-      ⟨bar_25 () | true ⊢ ⟨true ⊢ 1⟩⟩ in
-    let foo_27 : bool = error_empty
-      ⟨foo_24 () | true ⊢
-        ⟨⟨bar_26 >= 0 ⊢ true⟩, ⟨bar_26 < 0 ⊢ false⟩ | false ⊢
+  λ (TestBool_in: TestBool_in{"foo_in": unit → bool; "bar_in":
+                     unit → integer}) →
+    let foo : unit → bool = TestBool_in."foo_in" in
+    let bar : unit → integer = TestBool_in."bar_in" in
+    let bar1 : integer = error_empty ⟨bar () | true ⊢ ⟨true ⊢ 1⟩⟩
+      in
+    let foo1 : bool = error_empty
+      ⟨foo () | true ⊢
+        ⟨⟨bar1 >= 0 ⊢ true⟩, ⟨bar1 < 0 ⊢ false⟩ | false ⊢
           ∅ ⟩⟩ in
-    TestBool_out {"foo_out"= foo_27; "bar_out"= bar_26} in
-TestBool_22
+    TestBool_out {"foo_out"= foo1; "bar_out"= bar1} in
+TestBool
 ```
 
 ```catala-test-inline

--- a/tests/test_io/good/all_io.catala_en
+++ b/tests/test_io/good/all_io.catala_en
@@ -20,19 +20,19 @@ scope A:
 ```catala-test-inline
 $ catala Dcalc -s A
 let A =
-  λ (A_in_29: A_in{"c_in": integer; "d_in": integer; "e_in":
-                 unit → integer; "f_in": unit → integer}) →
-    let c_30 : integer = A_in_29."c_in" in
-    let d_31 : integer = A_in_29."d_in" in
-    let e_32 : unit → integer = A_in_29."e_in" in
-    let f_33 : unit → integer = A_in_29."f_in" in
-    let a_34 : integer = error_empty ⟨true ⊢ 0⟩ in
-    let b_35 : integer = error_empty ⟨true ⊢ a_34 + 1⟩ in
-    let e_36 : integer = error_empty
-      ⟨e_32 () | true ⊢ ⟨true ⊢ b_35 + c_30 + d_31 + 1⟩⟩ in
-    let f_37 : integer = error_empty
-      ⟨f_33 () | true ⊢ ⟨true ⊢ e_36 + 1⟩⟩ in
-    A_out {"b_out"= b_35; "d_out"= d_31; "f_out"= f_37}
+  λ (A_in: A_in{"c_in": integer; "d_in": integer; "e_in": unit → integer;
+              "f_in": unit → integer}) →
+    let c : integer = A_in."c_in" in
+    let d : integer = A_in."d_in" in
+    let e : unit → integer = A_in."e_in" in
+    let f : unit → integer = A_in."f_in" in
+    let a : integer = error_empty ⟨true ⊢ 0⟩ in
+    let b : integer = error_empty ⟨true ⊢ a + 1⟩ in
+    let e1 : integer = error_empty
+      ⟨e () | true ⊢ ⟨true ⊢ b + c + d + 1⟩⟩ in
+    let f1 : integer = error_empty
+      ⟨f () | true ⊢ ⟨true ⊢ e1 + 1⟩⟩ in
+    A_out {"b_out"= b; "d_out"= d; "f_out"= f1}
 ```
 
 ```catala-test-inline

--- a/tests/test_io/good/condition_only_input.catala_en
+++ b/tests/test_io/good/condition_only_input.catala_en
@@ -17,11 +17,11 @@ scope B:
 ```catala-test-inline
 $ catala Dcalc -s B
 let B =
-  λ (B_in_25: B_in{}) →
-    let a.x_26 : bool = error_empty ⟨true ⊢ false⟩ in
-    let result_27 : A_out{"y_out": integer} = A_13 (A_in {"x_in"= a.x_26}) in
-    let a.y_28 : integer = result_27."y_out" in
-    let __29 : unit = assert (error_empty a.y_28 = 1) in
+  λ (B_in: B_in{}) →
+    let a.x : bool = error_empty ⟨true ⊢ false⟩ in
+    let result : A_out{"y_out": integer} = A (A_in {"x_in"= a.x}) in
+    let a.y : integer = result."y_out" in
+    let _ : unit = assert (error_empty a.y = 1) in
     B_out {}
 ```
 

--- a/tests/test_io/good/subscope.catala_en
+++ b/tests/test_io/good/subscope.catala_en
@@ -23,13 +23,13 @@ scope B:
 ```catala-test-inline
 $ catala Dcalc -s B
 let B =
-  λ (B_in_32: B_in{}) →
-    let a.a_33 : unit → integer = λ (__34: unit) → ∅  in
-    let a.b_35 : integer = error_empty ⟨true ⊢ 2⟩ in
-    let result_36 : A_out{"c_out": integer} =
-      A_17 (A_in {"a_in"= a.a_33; "b_in"= a.b_35}) in
-    let a.c_37 : integer = result_36."c_out" in
-    let __38 : unit = assert (error_empty a.c_37 = 1) in
+  λ (B_in: B_in{}) →
+    let a.a : unit → integer = λ (_: unit) → ∅  in
+    let a.b : integer = error_empty ⟨true ⊢ 2⟩ in
+    let result : A_out{"c_out": integer} =
+      A (A_in {"a_in"= a.a; "b_in"= a.b}) in
+    let a.c : integer = result."c_out" in
+    let _ : unit = assert (error_empty a.c = 1) in
     B_out {}
 ```
 

--- a/tests/test_scope/good/simple.catala_en
+++ b/tests/test_scope/good/simple.catala_en
@@ -11,10 +11,9 @@ scope Foo:
 ```catala-test-inline
 $ catala Lcalc -s Foo
 let Foo =
-  λ (Foo_in_28: Foo_in{}) →
-    let bar_29 : integer =
-      try
-        handle_default_0 [] (λ (__30: unit) → true)
-          (λ (__31: unit) → 0) with EmptyError -> raise NoValueProvided in
-    Foo_out {"bar_out"= bar_29}
+  λ (Foo_in: Foo_in{}) →
+    let bar : integer =
+      try handle_default [] (λ (_: unit) → true) (λ (_: unit) → 0) with
+        EmptyError -> raise NoValueProvided in
+    Foo_out {"bar_out"= bar}
 ```


### PR DESCRIPTION
Pass along a bindlib context to allow the variable names to be altered only when
disambiguation is needed. Partial fix to #240 (doesn't affect the backends, only
the printer for the intermediate ASTs).

This also has the benefit of making the output of the tests much more stable.