### PR TITLE
Fancier error messages

### DIFF
--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -23,7 +23,7 @@ let struc
     (fmt : Format.formatter)
     (name : StructName.t)
     (fields : (StructFieldName.t * typ) list) : unit =
-  Format.fprintf fmt "%a %a %a %a@\n@[<hov 2>  %a@]@\n%a" Print.keyword "type"
+  Format.fprintf fmt "%a %a %a %a@\n@[<hov 2>  %a@]@\n%a" Print.keyword "struct"
     StructName.format_t name Print.punctuation "=" Print.punctuation "{"
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
@@ -37,7 +37,7 @@ let enum
     (fmt : Format.formatter)
     (name : EnumName.t)
     (cases : (EnumConstructor.t * typ) list) : unit =
-  Format.fprintf fmt "%a %a %a @\n@[<hov 2>  %a@]" Print.keyword "type"
+  Format.fprintf fmt "%a %a %a @\n@[<hov 2>  %a@]" Print.keyword "enum"
     EnumName.format_t name Print.punctuation "="
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")

--- a/compiler/utils/cli.ml
+++ b/compiler/utils/cli.ml
@@ -454,20 +454,15 @@ let concat_with_line_depending_prefix_and_suffix
     (suffix : int -> string)
     (ss : string list) =
   match ss with
-  | hd :: rest ->
-    let out, _ =
-      List.fold_left
-        (fun (acc, i) s ->
-          ( (acc
-            ^ prefix i
-            ^ s
-            ^ if i = List.length ss - 1 then "" else suffix i),
-            i + 1 ))
-        ((prefix 0 ^ hd ^ if 0 = List.length ss - 1 then "" else suffix 0), 1)
-        rest
-    in
-    out
   | [] -> prefix 0
+  | _ :: _ ->
+    let len = List.length ss in
+    let suffix i = if i < len - 1 then suffix i else "" in
+    String.concat ""
+    @@ List.concat
+    @@ List.mapi
+         (fun i s -> [prefix i; (if s = "" then "" else " "); s; suffix i])
+         ss
 
 (** The int argument of the prefix corresponds to the line number, starting at 0 *)
 let add_prefix_to_each_line (s : string) (prefix : int -> string) =

--- a/compiler/utils/pos.ml
+++ b/compiler/utils/pos.ml
@@ -179,18 +179,18 @@ let retrieve_loc_text (pos : t) : string =
                && cur_line <= sline + (2 * (eline - sline))
                && cur_line mod 2 = sline mod 2
              then
-               Cli.with_style blue_style "%*d | " spaces
+               Cli.with_style blue_style "%*d |" spaces
                  (sline + ((cur_line - sline) / 2))
              else if cur_line >= sline - include_extra_count && cur_line < sline
-             then Cli.with_style blue_style "%*d | " spaces cur_line
+             then Cli.with_style blue_style "%*d |" spaces (cur_line + 1)
              else if
                cur_line
                <= sline + (2 * (eline - sline)) + 1 + include_extra_count
                && cur_line > sline + (2 * (eline - sline)) + 1
              then
-               Cli.with_style blue_style "%*d | " spaces
+               Cli.with_style blue_style "%*d |" spaces
                  (cur_line - (eline - sline + 1))
-             else Cli.with_style blue_style "%*s | " spaces ""))
+             else Cli.with_style blue_style "%*s |" spaces ""))
         (Cli.add_prefix_to_each_line
            (Printf.sprintf "%s"
               (String.concat "\n"
@@ -199,8 +199,8 @@ let retrieve_loc_text (pos : t) : string =
                     legal_pos_lines)))
            (fun i ->
              if i = 0 then
-               Cli.with_style blue_style "%*s + " (spaces + (2 * i)) ""
-             else Cli.with_style blue_style "%*s+-+ " (spaces + (2 * i) - 1) ""))
+               Cli.with_style blue_style "%*s +" (spaces + (2 * i)) ""
+             else Cli.with_style blue_style "%*s+-+" (spaces + (2 * i) - 1) ""))
   with Sys_error _ -> "Location:" ^ to_string pos
 
 let no_pos : t =

--- a/compiler/utils/pos.ml
+++ b/compiler/utils/pos.ml
@@ -72,16 +72,21 @@ let to_string (pos : t) : string =
   let s, e = pos.code_pos in
   Printf.sprintf "in file %s, from %d:%d to %d:%d" s.Lexing.pos_fname
     s.Lexing.pos_lnum
-    (s.Lexing.pos_cnum - s.Lexing.pos_bol + 1)
+    (s.Lexing.pos_cnum - s.Lexing.pos_bol)
     e.Lexing.pos_lnum
-    (e.Lexing.pos_cnum - e.Lexing.pos_bol + 1)
+    (e.Lexing.pos_cnum - e.Lexing.pos_bol)
 
 let to_string_short (pos : t) : string =
   let s, e = pos.code_pos in
-  Printf.sprintf "%s;%d:%d--%d:%d" s.Lexing.pos_fname s.Lexing.pos_lnum
-    (s.Lexing.pos_cnum - s.Lexing.pos_bol + 1)
-    e.Lexing.pos_lnum
-    (e.Lexing.pos_cnum - e.Lexing.pos_bol + 1)
+  if e.Lexing.pos_lnum = s.Lexing.pos_lnum then
+    Printf.sprintf "%s:%d.%d-%d" s.Lexing.pos_fname s.Lexing.pos_lnum
+      (s.Lexing.pos_cnum - s.Lexing.pos_bol)
+      (e.Lexing.pos_cnum - e.Lexing.pos_bol)
+  else
+    Printf.sprintf "%s:%d.%d-%d.%d" s.Lexing.pos_fname s.Lexing.pos_lnum
+      (s.Lexing.pos_cnum - s.Lexing.pos_bol)
+      e.Lexing.pos_lnum
+      (e.Lexing.pos_cnum - e.Lexing.pos_bol)
 
 let indent_number (s : string) : int =
   try
@@ -169,7 +174,8 @@ let retrieve_loc_text (pos : t) : string =
              pos.law_pos)
       in
       (match oc with None -> () | Some oc -> close_in oc);
-      Cli.with_style blue_style "%*s--> %s\n%s\n%s" spaces "" filename
+      Cli.with_style blue_style "%*s--> %s\n%s\n%s" spaces ""
+        (to_string_short pos)
         (Cli.add_prefix_to_each_line
            (Printf.sprintf "\n%s" (String.concat "\n" pos_lines))
            (fun i ->

--- a/examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+++ b/examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
@@ -33,14 +33,14 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
    |
 11 |   context my_gaming scope GamingAuthorized
    |                     ^^^^^
    +
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
    |
 11 |   context my_gaming scope GamingAuthorized
    |           ^^^^^^^^^
@@ -77,14 +77,14 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
    |
 11 |   context my_gaming scope GamingAuthorized
    |                     ^^^^^
    +
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
    |
 11 |   context my_gaming scope GamingAuthorized
    |           ^^^^^^^^^
@@ -121,14 +121,14 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
    |
 11 |   context my_gaming scope GamingAuthorized
    |                     ^^^^^
    +
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
    |
 11 |   context my_gaming scope GamingAuthorized
    |           ^^^^^^^^^
@@ -167,14 +167,14 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
    |
 11 |   context my_gaming scope GamingAuthorized
    |                     ^^^^^
    +
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
    |
 11 |   context my_gaming scope GamingAuthorized
    |           ^^^^^^^^^

--- a/examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
+++ b/examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en
@@ -33,18 +33,20 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |                     ^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │                     ‾‾‾‾‾
+
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |           ^^^^^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │           ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```
 
@@ -77,18 +79,20 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |                     ^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │                     ‾‾‾‾‾
+
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |           ^^^^^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │           ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```
 
@@ -121,18 +125,20 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |                     ^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │                     ‾‾‾‾‾
+
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |           ^^^^^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │           ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```
 
@@ -167,17 +173,19 @@ Message: unexpected token
 Autosuggestion: did you mean "content", or maybe "condition"?
 
 Error token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |                     ^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.20-25
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │                     ‾‾‾‾‾
+
 
 Last good token:
-  --> examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
-   |
-11 |   context my_gaming scope GamingAuthorized
-   |           ^^^^^^^^^
-   +
+┌─⯈ examples/NSW_community_gaming/tests/test_nsw_social_housie.catala_en:11.10-19
+└──┐
+   │
+11 │   context my_gaming scope GamingAuthorized
+   │           ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_arithmetic/bad/division_by_zero.catala_en
+++ b/tests/test_arithmetic/bad/division_by_zero.catala_en
@@ -36,7 +36,7 @@ $ catala Interpret -s Dec
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:20.22-30
    |
 20 |   definition i equals 1. /. 0.
    |                       ^^^^^^^^
@@ -44,7 +44,7 @@ The division operator:
    +-+ with decimals
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:20.28-30
    |
 20 |   definition i equals 1. /. 0.
    |                             ^^
@@ -58,7 +58,7 @@ $ catala Interpret -s Int
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:10.22-27
    |
 10 |   definition i equals 1 / 0
    |                       ^^^^^
@@ -66,7 +66,7 @@ The division operator:
    +-+ with integers
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:10.26-27
    |
 10 |   definition i equals 1 / 0
    |                           ^
@@ -80,7 +80,7 @@ $ catala Interpret -s Money
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:30.22-35
    |
 30 |   definition i equals $10.0 /$ $0.0
    |                       ^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ The division operator:
    +-+ with money
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en
+  --> tests/test_arithmetic/bad/division_by_zero.catala_en:30.31-35
    |
 30 |   definition i equals $10.0 /$ $0.0
    |                                ^^^^

--- a/tests/test_arithmetic/bad/division_by_zero.catala_en
+++ b/tests/test_arithmetic/bad/division_by_zero.catala_en
@@ -36,20 +36,22 @@ $ catala Interpret -s Dec
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:20.22-30
-   |
-20 |   definition i equals 1. /. 0.
-   |                       ^^^^^^^^
-   + `Division_by_zero` exception management
-   +-+ with decimals
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:20.22-30
+└──┐
+   │
+20 │   definition i equals 1. /. 0.
+   │                       ‾‾‾‾‾‾‾‾
+   └┬ `Division_by_zero` exception management
+    └─ with decimals
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:20.28-30
-   |
-20 |   definition i equals 1. /. 0.
-   |                             ^^
-   + `Division_by_zero` exception management
-   +-+ with decimals
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:20.28-30
+└──┐
+   │
+20 │   definition i equals 1. /. 0.
+   │                             ‾‾
+   └┬ `Division_by_zero` exception management
+    └─ with decimals
 #return code 255#
 ```
 
@@ -58,20 +60,22 @@ $ catala Interpret -s Int
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:10.22-27
-   |
-10 |   definition i equals 1 / 0
-   |                       ^^^^^
-   + `Division_by_zero` exception management
-   +-+ with integers
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:10.22-27
+└──┐
+   │
+10 │   definition i equals 1 / 0
+   │                       ‾‾‾‾‾
+   └┬ `Division_by_zero` exception management
+    └─ with integers
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:10.26-27
-   |
-10 |   definition i equals 1 / 0
-   |                           ^
-   + `Division_by_zero` exception management
-   +-+ with integers
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:10.26-27
+└──┐
+   │
+10 │   definition i equals 1 / 0
+   │                           ‾
+   └┬ `Division_by_zero` exception management
+    └─ with integers
 #return code 255#
 ```
 
@@ -80,19 +84,21 @@ $ catala Interpret -s Money
 [ERROR] division by zero at runtime
 
 The division operator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:30.22-35
-   |
-30 |   definition i equals $10.0 /$ $0.0
-   |                       ^^^^^^^^^^^^^
-   + `Division_by_zero` exception management
-   +-+ with money
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:30.22-35
+└──┐
+   │
+30 │   definition i equals $10.0 /$ $0.0
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └┬ `Division_by_zero` exception management
+    └─ with money
 
 The null denominator:
-  --> tests/test_arithmetic/bad/division_by_zero.catala_en:30.31-35
-   |
-30 |   definition i equals $10.0 /$ $0.0
-   |                                ^^^^
-   + `Division_by_zero` exception management
-   +-+ with money
+┌─⯈ tests/test_arithmetic/bad/division_by_zero.catala_en:30.31-35
+└──┐
+   │
+30 │   definition i equals $10.0 /$ $0.0
+   │                                ‾‾‾‾
+   └┬ `Division_by_zero` exception management
+    └─ with money
 #return code 255#
 ```

--- a/tests/test_array/bad/fold_error.catala_en
+++ b/tests/test_array/bad/fold_error.catala_en
@@ -17,21 +17,21 @@ $ catala Interpret -s A
 --> money
 
 Error coming from typechecking the following expression:
-  --> tests/test_array/bad/fold_error.catala_en
+  --> tests/test_array/bad/fold_error.catala_en:10.52-56
    |
 10 |   definition list_high_count equals number for m in list of (m >=$ $7)
    |                                                     ^^^^
    + Article
 
 Type integer coming from expression:
- --> tests/test_array/bad/fold_error.catala_en
+ --> tests/test_array/bad/fold_error.catala_en:5.34-41
   |
 5 |   context list content collection integer
   |                                   ^^^^^^^
   + Article
 
 Type money coming from expression:
-  --> tests/test_array/bad/fold_error.catala_en
+  --> tests/test_array/bad/fold_error.catala_en:10.63-66
    |
 10 |   definition list_high_count equals number for m in list of (m >=$ $7)
    |                                                                ^^^

--- a/tests/test_array/bad/fold_error.catala_en
+++ b/tests/test_array/bad/fold_error.catala_en
@@ -17,24 +17,27 @@ $ catala Interpret -s A
 --> money
 
 Error coming from typechecking the following expression:
-  --> tests/test_array/bad/fold_error.catala_en:10.52-56
-   |
-10 |   definition list_high_count equals number for m in list of (m >=$ $7)
-   |                                                     ^^^^
-   + Article
+┌─⯈ tests/test_array/bad/fold_error.catala_en:10.52-56
+└──┐
+   │
+10 │   definition list_high_count equals number for m in list of (m >=$ $7)
+   │                                                     ‾‾‾‾
+   └─ Article
 
 Type integer coming from expression:
- --> tests/test_array/bad/fold_error.catala_en:5.34-41
-  |
-5 |   context list content collection integer
-  |                                   ^^^^^^^
-  + Article
+┌─⯈ tests/test_array/bad/fold_error.catala_en:5.34-41
+└─┐
+  │
+5 │   context list content collection integer
+  │                                   ‾‾‾‾‾‾‾
+  └─ Article
 
 Type money coming from expression:
-  --> tests/test_array/bad/fold_error.catala_en:10.63-66
-   |
-10 |   definition list_high_count equals number for m in list of (m >=$ $7)
-   |                                                                ^^^
-   + Article
+┌─⯈ tests/test_array/bad/fold_error.catala_en:10.63-66
+└──┐
+   │
+10 │   definition list_high_count equals number for m in list of (m >=$ $7)
+   │                                                                ‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_bool/bad/bad_assert.catala_en
+++ b/tests/test_bool/bad/bad_assert.catala_en
@@ -17,21 +17,21 @@ $ catala Interpret -s Foo
 --> bool
 
 Error coming from typechecking the following expression:
- --> tests/test_bool/bad/bad_assert.catala_en
+ --> tests/test_bool/bad/bad_assert.catala_en:9.12-13
   |
 9 |   assertion x
   |             ^
   + Test
 
 Type integer coming from expression:
- --> tests/test_bool/bad/bad_assert.catala_en
+ --> tests/test_bool/bad/bad_assert.catala_en:5.21-28
   |
 5 |   internal x content integer
   |                      ^^^^^^^
   + Test
 
 Type bool coming from expression:
- --> tests/test_bool/bad/bad_assert.catala_en
+ --> tests/test_bool/bad/bad_assert.catala_en:9.12-13
   |
 9 |   assertion x
   |             ^

--- a/tests/test_bool/bad/bad_assert.catala_en
+++ b/tests/test_bool/bad/bad_assert.catala_en
@@ -17,24 +17,27 @@ $ catala Interpret -s Foo
 --> bool
 
 Error coming from typechecking the following expression:
- --> tests/test_bool/bad/bad_assert.catala_en:9.12-13
-  |
-9 |   assertion x
-  |             ^
-  + Test
+┌─⯈ tests/test_bool/bad/bad_assert.catala_en:9.12-13
+└─┐
+  │
+9 │   assertion x
+  │             ‾
+  └─ Test
 
 Type integer coming from expression:
- --> tests/test_bool/bad/bad_assert.catala_en:5.21-28
-  |
-5 |   internal x content integer
-  |                      ^^^^^^^
-  + Test
+┌─⯈ tests/test_bool/bad/bad_assert.catala_en:5.21-28
+└─┐
+  │
+5 │   internal x content integer
+  │                      ‾‾‾‾‾‾‾
+  └─ Test
 
 Type bool coming from expression:
- --> tests/test_bool/bad/bad_assert.catala_en:9.12-13
-  |
-9 |   assertion x
-  |             ^
-  + Test
+┌─⯈ tests/test_bool/bad/bad_assert.catala_en:9.12-13
+└─┐
+  │
+9 │   assertion x
+  │             ‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_bool/bad/test_xor_with_int.catala_en
+++ b/tests/test_bool/bad/test_xor_with_int.catala_en
@@ -15,21 +15,21 @@ $ catala Typecheck
 --> integer
 
 Error coming from typechecking the following expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en
+ --> tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
   |
 8 |   definition test_var equals 10 xor 20
   |                                 ^^^
   + 'xor' should be a boolean operator
 
 Type bool coming from expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en
+ --> tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
   |
 8 |   definition test_var equals 10 xor 20
   |                                 ^^^
   + 'xor' should be a boolean operator
 
 Type integer coming from expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en
+ --> tests/test_bool/bad/test_xor_with_int.catala_en:5.27-34
   |
 5 |   context test_var content integer
   |                            ^^^^^^^

--- a/tests/test_bool/bad/test_xor_with_int.catala_en
+++ b/tests/test_bool/bad/test_xor_with_int.catala_en
@@ -15,24 +15,27 @@ $ catala Typecheck
 --> integer
 
 Error coming from typechecking the following expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
-  |
-8 |   definition test_var equals 10 xor 20
-  |                                 ^^^
-  + 'xor' should be a boolean operator
+┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
+└─┐
+  │
+8 │   definition test_var equals 10 xor 20
+  │                                 ‾‾‾
+  └─ 'xor' should be a boolean operator
 
 Type bool coming from expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
-  |
-8 |   definition test_var equals 10 xor 20
-  |                                 ^^^
-  + 'xor' should be a boolean operator
+┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:8.32-35
+└─┐
+  │
+8 │   definition test_var equals 10 xor 20
+  │                                 ‾‾‾
+  └─ 'xor' should be a boolean operator
 
 Type integer coming from expression:
- --> tests/test_bool/bad/test_xor_with_int.catala_en:5.27-34
-  |
-5 |   context test_var content integer
-  |                            ^^^^^^^
-  + 'xor' should be a boolean operator
+┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:5.27-34
+└─┐
+  │
+5 │   context test_var content integer
+  │                            ‾‾‾‾‾‾‾
+  └─ 'xor' should be a boolean operator
 #return code 255#
 ```

--- a/tests/test_bool/good/test_bool.catala_en
+++ b/tests/test_bool/good/test_bool.catala_en
@@ -39,7 +39,7 @@ $ catala Interpret -s TestBool
 
 ```catala-test-inline
 $ catala Scopelang 
-type TestBool = {
+struct TestBool = {
   foo: bool
   bar: integer
 }

--- a/tests/test_date/bad/uncomparable_duration.catala_en
+++ b/tests/test_date/bad/uncomparable_duration.catala_en
@@ -44,14 +44,14 @@ scope Ge:
 $ catala Interpret -s Ge
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:40.22-29
    |
 40 |   definition d equals 1 month >=^ 2 day
    |                       ^^^^^^^
    + `UncomparableDurations` exception management
    +-+ `>=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:40.34-39
    |
 40 |   definition d equals 1 month >=^ 2 day
    |                                   ^^^^^
@@ -64,14 +64,14 @@ $ catala Interpret -s Ge
 $ catala Interpret -s Gt
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:30.22-29
    |
 30 |   definition d equals 1 month >^ 2 day
    |                       ^^^^^^^
    + `UncomparableDurations` exception management
    +-+ `<=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:30.33-38
    |
 30 |   definition d equals 1 month >^ 2 day
    |                                  ^^^^^
@@ -84,14 +84,14 @@ $ catala Interpret -s Gt
 $ catala Interpret -s Le
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:20.22-29
    |
 20 |   definition d equals 1 month <=^ 2 day
    |                       ^^^^^^^
    + `UncomparableDurations` exception management
    +-+ `<=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:20.34-39
    |
 20 |   definition d equals 1 month <=^ 2 day
    |                                   ^^^^^
@@ -104,14 +104,14 @@ $ catala Interpret -s Le
 $ catala Interpret -s Lt
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:10.22-29
    |
 10 |   definition d equals 1 month <^ 2 day
    |                       ^^^^^^^
    + `UncomparableDurations` exception management
    +-+ `<^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en
+  --> tests/test_date/bad/uncomparable_duration.catala_en:10.33-38
    |
 10 |   definition d equals 1 month <^ 2 day
    |                                  ^^^^^

--- a/tests/test_date/bad/uncomparable_duration.catala_en
+++ b/tests/test_date/bad/uncomparable_duration.catala_en
@@ -44,19 +44,21 @@ scope Ge:
 $ catala Interpret -s Ge
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:40.22-29
-   |
-40 |   definition d equals 1 month >=^ 2 day
-   |                       ^^^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `>=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:40.22-29
+└──┐
+   │
+40 │   definition d equals 1 month >=^ 2 day
+   │                       ‾‾‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `>=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:40.34-39
-   |
-40 |   definition d equals 1 month >=^ 2 day
-   |                                   ^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `>=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:40.34-39
+└──┐
+   │
+40 │   definition d equals 1 month >=^ 2 day
+   │                                   ‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `>=^` operator
 #return code 255#
 ```
 
@@ -64,19 +66,21 @@ $ catala Interpret -s Ge
 $ catala Interpret -s Gt
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:30.22-29
-   |
-30 |   definition d equals 1 month >^ 2 day
-   |                       ^^^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:30.22-29
+└──┐
+   │
+30 │   definition d equals 1 month >^ 2 day
+   │                       ‾‾‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:30.33-38
-   |
-30 |   definition d equals 1 month >^ 2 day
-   |                                  ^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:30.33-38
+└──┐
+   │
+30 │   definition d equals 1 month >^ 2 day
+   │                                  ‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<=^` operator
 #return code 255#
 ```
 
@@ -84,19 +88,21 @@ $ catala Interpret -s Gt
 $ catala Interpret -s Le
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:20.22-29
-   |
-20 |   definition d equals 1 month <=^ 2 day
-   |                       ^^^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:20.22-29
+└──┐
+   │
+20 │   definition d equals 1 month <=^ 2 day
+   │                       ‾‾‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<=^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:20.34-39
-   |
-20 |   definition d equals 1 month <=^ 2 day
-   |                                   ^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<=^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:20.34-39
+└──┐
+   │
+20 │   definition d equals 1 month <=^ 2 day
+   │                                   ‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<=^` operator
 #return code 255#
 ```
 
@@ -104,18 +110,20 @@ $ catala Interpret -s Le
 $ catala Interpret -s Lt
 [ERROR] Cannot compare together durations that cannot be converted to a precise number of days
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:10.22-29
-   |
-10 |   definition d equals 1 month <^ 2 day
-   |                       ^^^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:10.22-29
+└──┐
+   │
+10 │   definition d equals 1 month <^ 2 day
+   │                       ‾‾‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<^` operator
 
-  --> tests/test_date/bad/uncomparable_duration.catala_en:10.33-38
-   |
-10 |   definition d equals 1 month <^ 2 day
-   |                                  ^^^^^
-   + `UncomparableDurations` exception management
-   +-+ `<^` operator
+┌─⯈ tests/test_date/bad/uncomparable_duration.catala_en:10.33-38
+└──┐
+   │
+10 │   definition d equals 1 month <^ 2 day
+   │                                  ‾‾‾‾‾
+   └┬ `UncomparableDurations` exception management
+    └─ `<^` operator
 #return code 255#
 ```

--- a/tests/test_default/bad/conflict.catala_en
+++ b/tests/test_default/bad/conflict.catala_en
@@ -14,17 +14,19 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
- --> tests/test_default/bad/conflict.catala_en:8.55-56
-  |
-8 |   definition x under condition true consequence equals 1
-  |                                                        ^
-  + Article
+┌─⯈ tests/test_default/bad/conflict.catala_en:8.55-56
+└─┐
+  │
+8 │   definition x under condition true consequence equals 1
+  │                                                        ‾
+  └─ Article
 
 This consequence has a valid justification:
- --> tests/test_default/bad/conflict.catala_en:9.55-56
-  |
-9 |   definition x under condition true consequence equals 0
-  |                                                        ^
-  + Article
+┌─⯈ tests/test_default/bad/conflict.catala_en:9.55-56
+└─┐
+  │
+9 │   definition x under condition true consequence equals 0
+  │                                                        ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_default/bad/conflict.catala_en
+++ b/tests/test_default/bad/conflict.catala_en
@@ -14,14 +14,14 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
- --> tests/test_default/bad/conflict.catala_en
+ --> tests/test_default/bad/conflict.catala_en:8.55-56
   |
 8 |   definition x under condition true consequence equals 1
   |                                                        ^
   + Article
 
 This consequence has a valid justification:
- --> tests/test_default/bad/conflict.catala_en
+ --> tests/test_default/bad/conflict.catala_en:9.55-56
   |
 9 |   definition x under condition true consequence equals 0
   |                                                        ^

--- a/tests/test_default/bad/empty.catala_en
+++ b/tests/test_default/bad/empty.catala_en
@@ -13,10 +13,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This variable evaluated to an empty term (no rule that defined it applied in this situation)
 
- --> tests/test_default/bad/empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Article
+┌─⯈ tests/test_default/bad/empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_default/bad/empty.catala_en
+++ b/tests/test_default/bad/empty.catala_en
@@ -13,7 +13,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This variable evaluated to an empty term (no rule that defined it applied in this situation)
 
- --> tests/test_default/bad/empty.catala_en
+ --> tests/test_default/bad/empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_default/bad/empty_with_rules.catala_en
+++ b/tests/test_default/bad/empty_with_rules.catala_en
@@ -16,10 +16,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This variable evaluated to an empty term (no rule that defined it applied in this situation)
 
- --> tests/test_default/bad/empty_with_rules.catala_en:5.10-11
-  |
-5 |   context x content integer
-  |           ^
-  + Article
+┌─⯈ tests/test_default/bad/empty_with_rules.catala_en:5.10-11
+└─┐
+  │
+5 │   context x content integer
+  │           ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_default/bad/empty_with_rules.catala_en
+++ b/tests/test_default/bad/empty_with_rules.catala_en
@@ -16,7 +16,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This variable evaluated to an empty term (no rule that defined it applied in this situation)
 
- --> tests/test_default/bad/empty_with_rules.catala_en
+ --> tests/test_default/bad/empty_with_rules.catala_en:5.10-11
   |
 5 |   context x content integer
   |           ^

--- a/tests/test_enum/bad/ambiguous_cases.catala_en
+++ b/tests/test_enum/bad/ambiguous_cases.catala_en
@@ -18,10 +18,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This constructor name is ambiguous, it can belong to E or F. Desambiguate it by prefixing it with the enum name.
 
-  --> tests/test_enum/bad/ambiguous_cases.catala_en:14.22-27
-   |
-14 |   definition e equals Case1
-   |                       ^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/ambiguous_cases.catala_en:14.22-27
+└──┐
+   │
+14 │   definition e equals Case1
+   │                       ‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/ambiguous_cases.catala_en
+++ b/tests/test_enum/bad/ambiguous_cases.catala_en
@@ -18,7 +18,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This constructor name is ambiguous, it can belong to E or F. Desambiguate it by prefixing it with the enum name.
 
-  --> tests/test_enum/bad/ambiguous_cases.catala_en
+  --> tests/test_enum/bad/ambiguous_cases.catala_en:14.22-27
    |
 14 |   definition e equals Case1
    |                       ^^^^^

--- a/tests/test_enum/bad/ambiguous_wildcard.catala_en
+++ b/tests/test_enum/bad/ambiguous_wildcard.catala_en
@@ -19,7 +19,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Couldn't infer the enumeration name from lonely wildcard (wildcard cannot be used as single match case)
 
-  --> tests/test_enum/bad/ambiguous_wildcard.catala_en
+  --> tests/test_enum/bad/ambiguous_wildcard.catala_en:15.7-20
    |
 15 |     -- anything : 31
    |        ^^^^^^^^^^^^^

--- a/tests/test_enum/bad/ambiguous_wildcard.catala_en
+++ b/tests/test_enum/bad/ambiguous_wildcard.catala_en
@@ -19,10 +19,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Couldn't infer the enumeration name from lonely wildcard (wildcard cannot be used as single match case)
 
-  --> tests/test_enum/bad/ambiguous_wildcard.catala_en:15.7-20
-   |
-15 |     -- anything : 31
-   |        ^^^^^^^^^^^^^
-   + Wildcard cannot be used as single match case
+┌─⯈ tests/test_enum/bad/ambiguous_wildcard.catala_en:15.7-20
+└──┐
+   │
+15 │     -- anything : 31
+   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Wildcard cannot be used as single match case
 #return code 255#
 ```

--- a/tests/test_enum/bad/duplicate_case.catala_en
+++ b/tests/test_enum/bad/duplicate_case.catala_en
@@ -22,13 +22,13 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The constructor Case3 has been matched twice:
 
-  --> tests/test_enum/bad/duplicate_case.catala_en
+  --> tests/test_enum/bad/duplicate_case.catala_en:18.15-19
    |
 18 |     -- Case3 : true
    |                ^^^^
    + Article
 
-  --> tests/test_enum/bad/duplicate_case.catala_en
+  --> tests/test_enum/bad/duplicate_case.catala_en:17.15-20
    |
 17 |     -- Case3 : false
    |                ^^^^^

--- a/tests/test_enum/bad/duplicate_case.catala_en
+++ b/tests/test_enum/bad/duplicate_case.catala_en
@@ -22,16 +22,18 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The constructor Case3 has been matched twice:
 
-  --> tests/test_enum/bad/duplicate_case.catala_en:18.15-19
-   |
-18 |     -- Case3 : true
-   |                ^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/duplicate_case.catala_en:18.15-19
+└──┐
+   │
+18 │     -- Case3 : true
+   │                ‾‾‾‾
+   └─ Article
 
-  --> tests/test_enum/bad/duplicate_case.catala_en:17.15-20
-   |
-17 |     -- Case3 : false
-   |                ^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/duplicate_case.catala_en:17.15-20
+└──┐
+   │
+17 │     -- Case3 : false
+   │                ‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/empty.catala_en
+++ b/tests/test_enum/bad/empty.catala_en
@@ -11,7 +11,7 @@ declaration scope Bar:
 $ catala Typecheck 
 [ERROR] The enum Foo does not have any cases; give it some for Catala to be able to accept it.
 
- --> tests/test_enum/bad/empty.catala_en
+ --> tests/test_enum/bad/empty.catala_en:4.24-27
   |
 4 | declaration enumeration Foo:
   |                         ^^^

--- a/tests/test_enum/bad/empty.catala_en
+++ b/tests/test_enum/bad/empty.catala_en
@@ -11,10 +11,11 @@ declaration scope Bar:
 $ catala Typecheck 
 [ERROR] The enum Foo does not have any cases; give it some for Catala to be able to accept it.
 
- --> tests/test_enum/bad/empty.catala_en:4.24-27
-  |
-4 | declaration enumeration Foo:
-  |                         ^^^
-  + Test
+┌─⯈ tests/test_enum/bad/empty.catala_en:4.24-27
+└─┐
+  │
+4 │ declaration enumeration Foo:
+  │                         ‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_enum/bad/missing_case.catala_en
+++ b/tests/test_enum/bad/missing_case.catala_en
@@ -20,14 +20,15 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The constructor Case3 of enum E is missing from this pattern matching
 
-  --> tests/test_enum/bad/missing_case.catala_en:14.24-16.21
-   |
-14 |   definition out equals match e with pattern
-   |                         ^^^^^^^^^^^^^^^^^^^
-15 |     -- Case1 of i : i = 0
-   |     ^^^^^^^^^^^^^^^^^^^^^
-16 |     -- Case2 of b : b
-   |     ^^^^^^^^^^^^^^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/missing_case.catala_en:14.24-16.21
+└──┐
+   │
+14 │   definition out equals match e with pattern
+   │                         ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+15 │     -- Case1 of i : i = 0
+   │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+16 │     -- Case2 of b : b
+   │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/missing_case.catala_en
+++ b/tests/test_enum/bad/missing_case.catala_en
@@ -20,7 +20,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The constructor Case3 of enum E is missing from this pattern matching
 
-  --> tests/test_enum/bad/missing_case.catala_en
+  --> tests/test_enum/bad/missing_case.catala_en:14.24-16.21
    |
 14 |   definition out equals match e with pattern
    |                         ^^^^^^^^^^^^^^^^^^^

--- a/tests/test_enum/bad/not_ending_wildcard.catala_en
+++ b/tests/test_enum/bad/not_ending_wildcard.catala_en
@@ -41,20 +41,22 @@ $ catala Interpret -s First_case
 [ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
-   |
-19 |     -- anything : 31
-   |        ^^^^^^^^^^^^^
-   + Wildcard must be the last case
-   +-+ Wildcard can't be the first case
+┌─⯈ tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
+└──┐
+   │
+19 │     -- anything : 31
+   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └┬ Wildcard must be the last case
+    └─ Wildcard can't be the first case
 
 Next reachable case:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
-   |
-20 |     -- Case2 : 42
-   |        ^^^^^^^^^^
-   + Wildcard must be the last case
-   +-+ Wildcard can't be the first case
+┌─⯈ tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
+└──┐
+   │
+20 │     -- Case2 : 42
+   │        ‾‾‾‾‾‾‾‾‾‾
+   └┬ Wildcard must be the last case
+    └─ Wildcard can't be the first case
 #return code 255#
 ```
 
@@ -63,19 +65,21 @@ $ catala Interpret -s Middle_case
 [ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
-   |
-19 |     -- anything : 31
-   |        ^^^^^^^^^^^^^
-   + Wildcard must be the last case
-   +-+ Wildcard can't be the first case
+┌─⯈ tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
+└──┐
+   │
+19 │     -- anything : 31
+   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └┬ Wildcard must be the last case
+    └─ Wildcard can't be the first case
 
 Next reachable case:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
-   |
-20 |     -- Case2 : 42
-   |        ^^^^^^^^^^
-   + Wildcard must be the last case
-   +-+ Wildcard can't be the first case
+┌─⯈ tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
+└──┐
+   │
+20 │     -- Case2 : 42
+   │        ‾‾‾‾‾‾‾‾‾‾
+   └┬ Wildcard must be the last case
+    └─ Wildcard can't be the first case
 #return code 255#
 ```

--- a/tests/test_enum/bad/not_ending_wildcard.catala_en
+++ b/tests/test_enum/bad/not_ending_wildcard.catala_en
@@ -41,7 +41,7 @@ $ catala Interpret -s First_case
 [ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en
+  --> tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
    |
 19 |     -- anything : 31
    |        ^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ Not ending wildcard:
    +-+ Wildcard can't be the first case
 
 Next reachable case:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en
+  --> tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
    |
 20 |     -- Case2 : 42
    |        ^^^^^^^^^^
@@ -63,7 +63,7 @@ $ catala Interpret -s Middle_case
 [ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en
+  --> tests/test_enum/bad/not_ending_wildcard.catala_en:19.7-20
    |
 19 |     -- anything : 31
    |        ^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ Not ending wildcard:
    +-+ Wildcard can't be the first case
 
 Next reachable case:
-  --> tests/test_enum/bad/not_ending_wildcard.catala_en
+  --> tests/test_enum/bad/not_ending_wildcard.catala_en:20.7-17
    |
 20 |     -- Case2 : 42
    |        ^^^^^^^^^^

--- a/tests/test_enum/bad/quick_pattern_2.catala_en
+++ b/tests/test_enum/bad/quick_pattern_2.catala_en
@@ -35,24 +35,27 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en:28.22-23
-   |
-28 |   definition y equals x with pattern Case3
-   |                       ^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:28.22-23
+└──┐
+   │
+28 │   definition y equals x with pattern Case3
+   │                       ‾
+   └─ Article
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en:17.20-21
-   |
-17 |   context x content E
-   |                     ^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:17.20-21
+└──┐
+   │
+17 │   context x content E
+   │                     ‾
+   └─ Article
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en:28.22-42
-   |
-28 |   definition y equals x with pattern Case3
-   |                       ^^^^^^^^^^^^^^^^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:28.22-42
+└──┐
+   │
+28 │   definition y equals x with pattern Case3
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/quick_pattern_2.catala_en
+++ b/tests/test_enum/bad/quick_pattern_2.catala_en
@@ -35,21 +35,21 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en
+  --> tests/test_enum/bad/quick_pattern_2.catala_en:28.22-23
    |
 28 |   definition y equals x with pattern Case3
    |                       ^
    + Article
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en
+  --> tests/test_enum/bad/quick_pattern_2.catala_en:17.20-21
    |
 17 |   context x content E
    |                     ^
    + Article
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_2.catala_en
+  --> tests/test_enum/bad/quick_pattern_2.catala_en:28.22-42
    |
 28 |   definition y equals x with pattern Case3
    |                       ^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_enum/bad/quick_pattern_3.catala_en
+++ b/tests/test_enum/bad/quick_pattern_3.catala_en
@@ -25,21 +25,21 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en
+  --> tests/test_enum/bad/quick_pattern_3.catala_en:18.20-21
    |
 18 | definition y equals x with pattern Case3
    |                     ^
    + Article
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en
+  --> tests/test_enum/bad/quick_pattern_3.catala_en:13.18-19
    |
 13 | context x content E
    |                   ^
    + Article
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en
+  --> tests/test_enum/bad/quick_pattern_3.catala_en:18.20-40
    |
 18 | definition y equals x with pattern Case3
    |                     ^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_enum/bad/quick_pattern_3.catala_en
+++ b/tests/test_enum/bad/quick_pattern_3.catala_en
@@ -25,24 +25,27 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en:18.20-21
-   |
-18 | definition y equals x with pattern Case3
-   |                     ^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:18.20-21
+└──┐
+   │
+18 │ definition y equals x with pattern Case3
+   │                     ‾
+   └─ Article
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en:13.18-19
-   |
-13 | context x content E
-   |                   ^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:13.18-19
+└──┐
+   │
+13 │ context x content E
+   │                   ‾
+   └─ Article
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_3.catala_en:18.20-40
-   |
-18 | definition y equals x with pattern Case3
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:18.20-40
+└──┐
+   │
+18 │ definition y equals x with pattern Case3
+   │                     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/quick_pattern_4.catala_en
+++ b/tests/test_enum/bad/quick_pattern_4.catala_en
@@ -24,24 +24,27 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en:17.20-21
-   |
-17 | definition y equals x with pattern Case3
-   |                     ^
-   + Test
+┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:17.20-21
+└──┐
+   │
+17 │ definition y equals x with pattern Case3
+   │                     ‾
+   └─ Test
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en:12.18-19
-   |
-12 | context x content E
-   |                   ^
-   + Test
+┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:12.18-19
+└──┐
+   │
+12 │ context x content E
+   │                   ‾
+   └─ Test
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en:17.20-40
-   |
-17 | definition y equals x with pattern Case3
-   |                     ^^^^^^^^^^^^^^^^^^^^
-   + Test
+┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:17.20-40
+└──┐
+   │
+17 │ definition y equals x with pattern Case3
+   │                     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_enum/bad/quick_pattern_4.catala_en
+++ b/tests/test_enum/bad/quick_pattern_4.catala_en
@@ -24,21 +24,21 @@ $ catala Interpret -s A
 --> F
 
 Error coming from typechecking the following expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en
+  --> tests/test_enum/bad/quick_pattern_4.catala_en:17.20-21
    |
 17 | definition y equals x with pattern Case3
    |                     ^
    + Test
 
 Type E coming from expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en
+  --> tests/test_enum/bad/quick_pattern_4.catala_en:12.18-19
    |
 12 | context x content E
    |                   ^
    + Test
 
 Type F coming from expression:
-  --> tests/test_enum/bad/quick_pattern_4.catala_en
+  --> tests/test_enum/bad/quick_pattern_4.catala_en:17.20-40
    |
 17 | definition y equals x with pattern Case3
    |                     ^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_enum/bad/quick_pattern_fail.catala_en
+++ b/tests/test_enum/bad/quick_pattern_fail.catala_en
@@ -19,10 +19,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The name of this constructor has not been defined before, maybe it is a typo?
 
-  --> tests/test_enum/bad/quick_pattern_fail.catala_en:15.37-42
-   |
-15 |   definition y equals x with pattern Case3
-   |                                      ^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/quick_pattern_fail.catala_en:15.37-42
+└──┐
+   │
+15 │   definition y equals x with pattern Case3
+   │                                      ‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/quick_pattern_fail.catala_en
+++ b/tests/test_enum/bad/quick_pattern_fail.catala_en
@@ -19,7 +19,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The name of this constructor has not been defined before, maybe it is a typo?
 
-  --> tests/test_enum/bad/quick_pattern_fail.catala_en
+  --> tests/test_enum/bad/quick_pattern_fail.catala_en:15.37-42
    |
 15 |   definition y equals x with pattern Case3
    |                                      ^^^^^

--- a/tests/test_enum/bad/too_many_cases.catala_en
+++ b/tests/test_enum/bad/too_many_cases.catala_en
@@ -25,7 +25,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This case matches a constructor of enumeration E but previous case were matching constructors of enumeration F
 
-  --> tests/test_enum/bad/too_many_cases.catala_en
+  --> tests/test_enum/bad/too_many_cases.catala_en:21.7-19
    |
 21 |     -- Case4 : true
    |        ^^^^^^^^^^^^

--- a/tests/test_enum/bad/too_many_cases.catala_en
+++ b/tests/test_enum/bad/too_many_cases.catala_en
@@ -25,10 +25,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This case matches a constructor of enumeration E but previous case were matching constructors of enumeration F
 
-  --> tests/test_enum/bad/too_many_cases.catala_en:21.7-19
-   |
-21 |     -- Case4 : true
-   |        ^^^^^^^^^^^^
-   + Article
+┌─⯈ tests/test_enum/bad/too_many_cases.catala_en:21.7-19
+└──┐
+   │
+21 │     -- Case4 : true
+   │        ‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_enum/bad/useless_wildcard.catala_en
+++ b/tests/test_enum/bad/useless_wildcard.catala_en
@@ -21,11 +21,12 @@ scope A:
 $ catala Interpret -s A
 [WARNING] Unreachable match case, all constructors of the enumeration E are already specified
 
-  --> tests/test_enum/bad/useless_wildcard.catala_en:17.7-20
-   |
-17 |     -- anything : 31
-   |        ^^^^^^^^^^^^^
-   + Useless wildcard
+┌─⯈ tests/test_enum/bad/useless_wildcard.catala_en:17.7-20
+└──┐
+   │
+17 │     -- anything : 31
+   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Useless wildcard
 [RESULT] Computation successful! Results:
 [RESULT] x = Case1 ()
 [RESULT] y = 42

--- a/tests/test_enum/bad/useless_wildcard.catala_en
+++ b/tests/test_enum/bad/useless_wildcard.catala_en
@@ -21,7 +21,7 @@ scope A:
 $ catala Interpret -s A
 [WARNING] Unreachable match case, all constructors of the enumeration E are already specified
 
-  --> tests/test_enum/bad/useless_wildcard.catala_en
+  --> tests/test_enum/bad/useless_wildcard.catala_en:17.7-20
    |
 17 |     -- anything : 31
    |        ^^^^^^^^^^^^^

--- a/tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
+++ b/tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
@@ -18,30 +18,33 @@ $ catala Interpret -s A
 [ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 
 Ambiguous exception
-  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.23-13.23
-   |
-10 |   definition x equals 1
-   |
-11 |
-   |
-12 |   exception
-   |   ^^^^^^^^^
-13 |   definition x equals 2
-   |   ^^^^^^^^^^^^^^^^^^^^^^
-   + Test
+┌─⯈ tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.23-13.23
+└──┐
+   │
+10 │   definition x equals 1
+   │
+11 │
+   │
+12 │   exception
+   │   ‾‾‾‾‾‾‾‾‾
+13 │   definition x equals 2
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Test
 
 Candidate definition
-  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.13-14
-   |
-10 |   definition x equals 1
-   |              ^
-   + Test
+┌─⯈ tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.13-14
+└──┐
+   │
+10 │   definition x equals 1
+   │              ‾
+   └─ Test
 
 Candidate definition
- --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:8.13-14
-  |
-8 |   definition x equals 0
-  |              ^
-  + Test
+┌─⯈ tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:8.13-14
+└─┐
+  │
+8 │   definition x equals 0
+  │              ‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
+++ b/tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
@@ -18,7 +18,7 @@ $ catala Interpret -s A
 [ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 
 Ambiguous exception
-  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
+  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.23-13.23
    |
 10 |   definition x equals 1
    |
@@ -31,14 +31,14 @@ Ambiguous exception
    + Test
 
 Candidate definition
-  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
+  --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:10.13-14
    |
 10 |   definition x equals 1
    |              ^
    + Test
 
 Candidate definition
- --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en
+ --> tests/test_exception/bad/ambiguous_unlabeled_exception.catala_en:8.13-14
   |
 8 |   definition x equals 0
   |              ^

--- a/tests/test_exception/bad/dangling_exception.catala_en
+++ b/tests/test_exception/bad/dangling_exception.catala_en
@@ -17,7 +17,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Unknown label for the scope variable x: "base_y"
 
-  --> tests/test_exception/bad/dangling_exception.catala_en
+  --> tests/test_exception/bad/dangling_exception.catala_en:12.12-18
    |
 12 |   exception base_y
    |             ^^^^^^

--- a/tests/test_exception/bad/dangling_exception.catala_en
+++ b/tests/test_exception/bad/dangling_exception.catala_en
@@ -17,10 +17,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Unknown label for the scope variable x: "base_y"
 
-  --> tests/test_exception/bad/dangling_exception.catala_en:12.12-18
-   |
-12 |   exception base_y
-   |             ^^^^^^
-   + Test
+┌─⯈ tests/test_exception/bad/dangling_exception.catala_en:12.12-18
+└──┐
+   │
+12 │   exception base_y
+   │             ‾‾‾‾‾‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/exceptions_cycle.catala_en
+++ b/tests/test_exception/bad/exceptions_cycle.catala_en
@@ -23,7 +23,7 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between exceptions!
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en
+  --> tests/test_exception/bad/exceptions_cycle.catala_en:16.2-18.23
    |
 16 |   label exception_exception_x
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,14 +34,14 @@ Cyclic exception for definition of variable "x", declared here:
    +
 
 Used here in the definition of another cyclic exception for defining "x":
-  --> tests/test_exception/bad/exceptions_cycle.catala_en
+  --> tests/test_exception/bad/exceptions_cycle.catala_en:17.12-23
    |
 17 |   exception exception_x
    |             ^^^^^^^^^^^
    + Test
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en
+  --> tests/test_exception/bad/exceptions_cycle.catala_en:12.2-14.23
    |
 12 |   label exception_x
    |   ^^^^^^^^^^^^^^^^
@@ -52,14 +52,14 @@ Cyclic exception for definition of variable "x", declared here:
    +
 
 Used here in the definition of another cyclic exception for defining "x":
-  --> tests/test_exception/bad/exceptions_cycle.catala_en
+  --> tests/test_exception/bad/exceptions_cycle.catala_en:13.12-18
    |
 13 |   exception base_x
    |             ^^^^^^
    + Test
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en
+  --> tests/test_exception/bad/exceptions_cycle.catala_en:8.2-10.23
    |
  8 |   label base_x
    |   ^^^^^^^^^^^
@@ -70,7 +70,7 @@ Cyclic exception for definition of variable "x", declared here:
    +
 
 Used here in the definition of another cyclic exception for defining "x":
- --> tests/test_exception/bad/exceptions_cycle.catala_en
+ --> tests/test_exception/bad/exceptions_cycle.catala_en:9.12-33
   |
 9 |   exception exception_exception_x
   |             ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_exception/bad/exceptions_cycle.catala_en
+++ b/tests/test_exception/bad/exceptions_cycle.catala_en
@@ -23,57 +23,63 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between exceptions!
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en:16.2-18.23
-   |
-16 |   label exception_exception_x
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-17 |   exception exception_x
-   |   ^^^^^^^^^^^^^^^^^^^^^
-18 |   definition x equals 2
-   |   ^^^^^^^^^^^^^^^^^^^^^^
-   +
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:16.2-18.23
+└──┐
+   │
+16 │   label exception_exception_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+17 │   exception exception_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+18 │   definition x equals 2
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Used here in the definition of another cyclic exception for defining "x":
-  --> tests/test_exception/bad/exceptions_cycle.catala_en:17.12-23
-   |
-17 |   exception exception_x
-   |             ^^^^^^^^^^^
-   + Test
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:17.12-23
+└──┐
+   │
+17 │   exception exception_x
+   │             ‾‾‾‾‾‾‾‾‾‾‾
+   └─ Test
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en:12.2-14.23
-   |
-12 |   label exception_x
-   |   ^^^^^^^^^^^^^^^^
-13 |   exception base_x
-   |   ^^^^^^^^^^^^^^^^
-14 |   definition x equals 1
-   |   ^^^^^^^^^^^^^^^^^^^^^^
-   +
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:12.2-14.23
+└──┐
+   │
+12 │   label exception_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+13 │   exception base_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+14 │   definition x equals 1
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Used here in the definition of another cyclic exception for defining "x":
-  --> tests/test_exception/bad/exceptions_cycle.catala_en:13.12-18
-   |
-13 |   exception base_x
-   |             ^^^^^^
-   + Test
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:13.12-18
+└──┐
+   │
+13 │   exception base_x
+   │             ‾‾‾‾‾‾
+   └─ Test
 
 Cyclic exception for definition of variable "x", declared here:
-  --> tests/test_exception/bad/exceptions_cycle.catala_en:8.2-10.23
-   |
- 8 |   label base_x
-   |   ^^^^^^^^^^^
- 9 |   exception exception_exception_x
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-10 |   definition x equals 0
-   |   ^^^^^^^^^^^^^^^^^^^^^^
-   +
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:8.2-10.23
+└──┐
+   │
+ 8 │   label base_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾
+ 9 │   exception exception_exception_x
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+10 │   definition x equals 0
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Used here in the definition of another cyclic exception for defining "x":
- --> tests/test_exception/bad/exceptions_cycle.catala_en:9.12-33
-  |
-9 |   exception exception_exception_x
-  |             ^^^^^^^^^^^^^^^^^^^^^
-  + Test
+┌─⯈ tests/test_exception/bad/exceptions_cycle.catala_en:9.12-33
+└─┐
+  │
+9 │   exception exception_exception_x
+  │             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/missing_unlabeled_definition.catala_en
+++ b/tests/test_exception/bad/missing_unlabeled_definition.catala_en
@@ -13,14 +13,15 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This exception does not have a corresponding definition
 
- --> tests/test_exception/bad/missing_unlabeled_definition.catala_en:7.8-9.23
-  |
-7 | scope A:
-  |
-8 |   exception
-  |   ^^^^^^^^^
-9 |   definition x equals 1
-  |   ^^^^^^^^^^^^^^^^^^^^^^
-  + Test
+┌─⯈ tests/test_exception/bad/missing_unlabeled_definition.catala_en:7.8-9.23
+└─┐
+  │
+7 │ scope A:
+  │
+8 │   exception
+  │   ‾‾‾‾‾‾‾‾‾
+9 │   definition x equals 1
+  │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/missing_unlabeled_definition.catala_en
+++ b/tests/test_exception/bad/missing_unlabeled_definition.catala_en
@@ -13,7 +13,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This exception does not have a corresponding definition
 
- --> tests/test_exception/bad/missing_unlabeled_definition.catala_en
+ --> tests/test_exception/bad/missing_unlabeled_definition.catala_en:7.8-9.23
   |
 7 | scope A:
   |

--- a/tests/test_exception/bad/one_ambiguous_exception.catala_en
+++ b/tests/test_exception/bad/one_ambiguous_exception.catala_en
@@ -24,7 +24,7 @@ $ catala Interpret -s A
 [ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 
 Ambiguous exception
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en
+  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:16.23-19.23
    |
 16 |   definition y equals 4
    |
@@ -37,14 +37,14 @@ Ambiguous exception
    + Test
 
 Candidate definition
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en
+  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:16.13-14
    |
 16 |   definition y equals 4
    |              ^
    + Test
 
 Candidate definition
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en
+  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:14.13-14
    |
 14 |   definition y equals 2
    |              ^

--- a/tests/test_exception/bad/one_ambiguous_exception.catala_en
+++ b/tests/test_exception/bad/one_ambiguous_exception.catala_en
@@ -24,30 +24,33 @@ $ catala Interpret -s A
 [ERROR] This exception can refer to several definitions. Try using labels to disambiguate
 
 Ambiguous exception
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:16.23-19.23
-   |
-16 |   definition y equals 4
-   |
-17 |
-   |
-18 |   exception
-   |   ^^^^^^^^^
-19 |   definition y equals 3
-   |   ^^^^^^^^^^^^^^^^^^^^^^
-   + Test
+┌─⯈ tests/test_exception/bad/one_ambiguous_exception.catala_en:16.23-19.23
+└──┐
+   │
+16 │   definition y equals 4
+   │
+17 │
+   │
+18 │   exception
+   │   ‾‾‾‾‾‾‾‾‾
+19 │   definition y equals 3
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   └─ Test
 
 Candidate definition
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:16.13-14
-   |
-16 |   definition y equals 4
-   |              ^
-   + Test
+┌─⯈ tests/test_exception/bad/one_ambiguous_exception.catala_en:16.13-14
+└──┐
+   │
+16 │   definition y equals 4
+   │              ‾
+   └─ Test
 
 Candidate definition
-  --> tests/test_exception/bad/one_ambiguous_exception.catala_en:14.13-14
-   |
-14 |   definition y equals 2
-   |              ^
-   + Test
+┌─⯈ tests/test_exception/bad/one_ambiguous_exception.catala_en:14.13-14
+└──┐
+   │
+14 │   definition y equals 2
+   │              ‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/self_exception.catala_en
+++ b/tests/test_exception/bad/self_exception.catala_en
@@ -14,10 +14,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Cannot define rule as an exception to itself
 
- --> tests/test_exception/bad/self_exception.catala_en:9.12-18
-  |
-9 |   exception base_y
-  |             ^^^^^^
-  + Test
+┌─⯈ tests/test_exception/bad/self_exception.catala_en:9.12-18
+└─┐
+  │
+9 │   exception base_y
+  │             ‾‾‾‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/self_exception.catala_en
+++ b/tests/test_exception/bad/self_exception.catala_en
@@ -14,7 +14,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Cannot define rule as an exception to itself
 
- --> tests/test_exception/bad/self_exception.catala_en
+ --> tests/test_exception/bad/self_exception.catala_en:9.12-18
   |
 9 |   exception base_y
   |             ^^^^^^

--- a/tests/test_exception/bad/two_exceptions.catala_en
+++ b/tests/test_exception/bad/two_exceptions.catala_en
@@ -20,17 +20,19 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_exception/bad/two_exceptions.catala_en:12.22-23
-   |
-12 |   definition x equals 1
-   |                       ^
-   + Test
+┌─⯈ tests/test_exception/bad/two_exceptions.catala_en:12.22-23
+└──┐
+   │
+12 │   definition x equals 1
+   │                       ‾
+   └─ Test
 
 This consequence has a valid justification:
-  --> tests/test_exception/bad/two_exceptions.catala_en:15.22-23
-   |
-15 |   definition x equals 2
-   |                       ^
-   + Test
+┌─⯈ tests/test_exception/bad/two_exceptions.catala_en:15.22-23
+└──┐
+   │
+15 │   definition x equals 2
+   │                       ‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_exception/bad/two_exceptions.catala_en
+++ b/tests/test_exception/bad/two_exceptions.catala_en
@@ -20,14 +20,14 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_exception/bad/two_exceptions.catala_en
+  --> tests/test_exception/bad/two_exceptions.catala_en:12.22-23
    |
 12 |   definition x equals 1
    |                       ^
    + Test
 
 This consequence has a valid justification:
-  --> tests/test_exception/bad/two_exceptions.catala_en
+  --> tests/test_exception/bad/two_exceptions.catala_en:15.22-23
    |
 15 |   definition x equals 2
    |                       ^

--- a/tests/test_exception/good/groups_of_exceptions.catala_en
+++ b/tests/test_exception/good/groups_of_exceptions.catala_en
@@ -33,7 +33,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Scopelang
-type Foo = {
+struct Foo = {
   x: integer
 }
 

--- a/tests/test_func/bad/bad_func.catala_en
+++ b/tests/test_func/bad/bad_func.catala_en
@@ -32,17 +32,19 @@ $ catala Interpret -s S
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_func/bad/bad_func.catala_en:14.64-69
-   |
-14 |   definition f of x under condition (x >= x) consequence equals x + x
-   |                                                                 ^^^^^
-   + Article
+┌─⯈ tests/test_func/bad/bad_func.catala_en:14.64-69
+└──┐
+   │
+14 │   definition f of x under condition (x >= x) consequence equals x + x
+   │                                                                 ‾‾‾‾‾
+   └─ Article
 
 This consequence has a valid justification:
-  --> tests/test_func/bad/bad_func.catala_en:15.61-66
-   |
-15 |   definition f of x under condition not b consequence equals x * x
-   |                                                              ^^^^^
-   + Article
+┌─⯈ tests/test_func/bad/bad_func.catala_en:15.61-66
+└──┐
+   │
+15 │   definition f of x under condition not b consequence equals x * x
+   │                                                              ‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_func/bad/bad_func.catala_en
+++ b/tests/test_func/bad/bad_func.catala_en
@@ -32,14 +32,14 @@ $ catala Interpret -s S
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_func/bad/bad_func.catala_en
+  --> tests/test_func/bad/bad_func.catala_en:14.64-69
    |
 14 |   definition f of x under condition (x >= x) consequence equals x + x
    |                                                                 ^^^^^
    + Article
 
 This consequence has a valid justification:
-  --> tests/test_func/bad/bad_func.catala_en
+  --> tests/test_func/bad/bad_func.catala_en:15.61-66
    |
 15 |   definition f of x under condition not b consequence equals x * x
    |                                                              ^^^^^

--- a/tests/test_func/bad/recursive.catala_en
+++ b/tests/test_func/bad/recursive.catala_en
@@ -12,10 +12,11 @@ scope RecursiveFunc:
 $ catala Interpret -s RecursiveFunc
 [ERROR] The variable f is used in one of its definitions, but recursion is forbidden in Catala
 
- --> tests/test_func/bad/recursive.catala_en:8.27-28
-  |
-8 |   definition f of x equals f of x + 1
-  |                            ^
-  + Article
+┌─⯈ tests/test_func/bad/recursive.catala_en:8.27-28
+└─┐
+  │
+8 │   definition f of x equals f of x + 1
+  │                            ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_func/bad/recursive.catala_en
+++ b/tests/test_func/bad/recursive.catala_en
@@ -12,7 +12,7 @@ scope RecursiveFunc:
 $ catala Interpret -s RecursiveFunc
 [ERROR] The variable f is used in one of its definitions, but recursion is forbidden in Catala
 
- --> tests/test_func/bad/recursive.catala_en
+ --> tests/test_func/bad/recursive.catala_en:8.27-28
   |
 8 |   definition f of x equals f of x + 1
   |                            ^

--- a/tests/test_io/bad/forgot_input.catala_en
+++ b/tests/test_io/bad/forgot_input.catala_en
@@ -19,14 +19,14 @@ $ catala Typecheck
 [ERROR] This subscope variable is a mandatory input but no definition was provided.
 
 Incriminated subscope:
- --> tests/test_io/bad/forgot_input.catala_en
+ --> tests/test_io/bad/forgot_input.catala_en:9.2-3
   |
 9 |   a scope A
   |   ^
   + Test
 
 Incriminated variable:
- --> tests/test_io/bad/forgot_input.catala_en
+ --> tests/test_io/bad/forgot_input.catala_en:6.8-9
   |
 6 |   input x content integer
   |         ^

--- a/tests/test_io/bad/forgot_input.catala_en
+++ b/tests/test_io/bad/forgot_input.catala_en
@@ -19,17 +19,19 @@ $ catala Typecheck
 [ERROR] This subscope variable is a mandatory input but no definition was provided.
 
 Incriminated subscope:
- --> tests/test_io/bad/forgot_input.catala_en:9.2-3
-  |
-9 |   a scope A
-  |   ^
-  + Test
+┌─⯈ tests/test_io/bad/forgot_input.catala_en:9.2-3
+└─┐
+  │
+9 │   a scope A
+  │   ‾
+  └─ Test
 
 Incriminated variable:
- --> tests/test_io/bad/forgot_input.catala_en:6.8-9
-  |
-6 |   input x content integer
-  |         ^
-  + Test
+┌─⯈ tests/test_io/bad/forgot_input.catala_en:6.8-9
+└─┐
+  │
+6 │   input x content integer
+  │         ‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_io/bad/inputing_to_not_input.catala_en
+++ b/tests/test_io/bad/inputing_to_not_input.catala_en
@@ -19,24 +19,27 @@ $ catala Typecheck
 [ERROR] It is impossible to give a definition to a subscope variable not tagged as input or context.
 
 Incriminated subscope:
- --> tests/test_io/bad/inputing_to_not_input.catala_en:8.2-3
-  |
-8 |   a scope A
-  |   ^
-  + Test
+┌─⯈ tests/test_io/bad/inputing_to_not_input.catala_en:8.2-3
+└─┐
+  │
+8 │   a scope A
+  │   ‾
+  └─ Test
 
 Incriminated variable:
- --> tests/test_io/bad/inputing_to_not_input.catala_en:5.9-10
-  |
-5 |   output a content integer
-  |          ^
-  + Test
+┌─⯈ tests/test_io/bad/inputing_to_not_input.catala_en:5.9-10
+└─┐
+  │
+5 │   output a content integer
+  │          ‾
+  └─ Test
 
 Incriminated subscope variable definition:
-  --> tests/test_io/bad/inputing_to_not_input.catala_en:14.2-25
-   |
-14 |   definition a.a equals 0
-   |   ^^^^^^^^^^^^^^^^^^^^^^^
-   +
+┌─⯈ tests/test_io/bad/inputing_to_not_input.catala_en:14.2-25
+└──┐
+   │
+14 │   definition a.a equals 0
+   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_io/bad/inputing_to_not_input.catala_en
+++ b/tests/test_io/bad/inputing_to_not_input.catala_en
@@ -19,21 +19,21 @@ $ catala Typecheck
 [ERROR] It is impossible to give a definition to a subscope variable not tagged as input or context.
 
 Incriminated subscope:
- --> tests/test_io/bad/inputing_to_not_input.catala_en
+ --> tests/test_io/bad/inputing_to_not_input.catala_en:8.2-3
   |
 8 |   a scope A
   |   ^
   + Test
 
 Incriminated variable:
- --> tests/test_io/bad/inputing_to_not_input.catala_en
+ --> tests/test_io/bad/inputing_to_not_input.catala_en:5.9-10
   |
 5 |   output a content integer
   |          ^
   + Test
 
 Incriminated subscope variable definition:
-  --> tests/test_io/bad/inputing_to_not_input.catala_en
+  --> tests/test_io/bad/inputing_to_not_input.catala_en:14.2-25
    |
 14 |   definition a.a equals 0
    |   ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_io/bad/redefining_input.catala_en
+++ b/tests/test_io/bad/redefining_input.catala_en
@@ -12,14 +12,14 @@ $ catala Typecheck
 [ERROR] It is impossible to give a definition to a scope variable tagged as input.
 
 Incriminated variable:
- --> tests/test_io/bad/redefining_input.catala_en
+ --> tests/test_io/bad/redefining_input.catala_en:5.8-9
   |
 5 |   input a content integer
   |         ^
   + Test
 
 Incriminated variable definition:
- --> tests/test_io/bad/redefining_input.catala_en
+ --> tests/test_io/bad/redefining_input.catala_en:8.2-23
   |
 8 |   definition a equals 0
   |   ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_io/bad/redefining_input.catala_en
+++ b/tests/test_io/bad/redefining_input.catala_en
@@ -12,17 +12,19 @@ $ catala Typecheck
 [ERROR] It is impossible to give a definition to a scope variable tagged as input.
 
 Incriminated variable:
- --> tests/test_io/bad/redefining_input.catala_en:5.8-9
-  |
-5 |   input a content integer
-  |         ^
-  + Test
+┌─⯈ tests/test_io/bad/redefining_input.catala_en:5.8-9
+└─┐
+  │
+5 │   input a content integer
+  │         ‾
+  └─ Test
 
 Incriminated variable definition:
- --> tests/test_io/bad/redefining_input.catala_en:8.2-23
-  |
-8 |   definition a equals 0
-  |   ^^^^^^^^^^^^^^^^^^^^^
-  +
+┌─⯈ tests/test_io/bad/redefining_input.catala_en:8.2-23
+└─┐
+  │
+8 │   definition a equals 0
+  │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_io/bad/using_non_output.catala_en
+++ b/tests/test_io/bad/using_non_output.catala_en
@@ -18,21 +18,21 @@ $ catala Typecheck
 [ERROR] The variable a.a cannot be used here, as it is not part of subscope a's results. Maybe you forgot to qualify it as an output?
 
 Incriminated variable usage:
-  --> tests/test_io/bad/using_non_output.catala_en
+  --> tests/test_io/bad/using_non_output.catala_en:14.12-15
    |
 14 |   assertion a.a = 0
    |             ^^^
    + Test
 
 Incriminated subscope variable declaration:
- --> tests/test_io/bad/using_non_output.catala_en
+ --> tests/test_io/bad/using_non_output.catala_en:5.11-12
   |
 5 |   internal a content integer
   |            ^
   + Test
 
 Incriminated subscope declaration:
- --> tests/test_io/bad/using_non_output.catala_en
+ --> tests/test_io/bad/using_non_output.catala_en:8.2-3
   |
 8 |   a scope A
   |   ^

--- a/tests/test_io/bad/using_non_output.catala_en
+++ b/tests/test_io/bad/using_non_output.catala_en
@@ -18,24 +18,27 @@ $ catala Typecheck
 [ERROR] The variable a.a cannot be used here, as it is not part of subscope a's results. Maybe you forgot to qualify it as an output?
 
 Incriminated variable usage:
-  --> tests/test_io/bad/using_non_output.catala_en:14.12-15
-   |
-14 |   assertion a.a = 0
-   |             ^^^
-   + Test
+┌─⯈ tests/test_io/bad/using_non_output.catala_en:14.12-15
+└──┐
+   │
+14 │   assertion a.a = 0
+   │             ‾‾‾
+   └─ Test
 
 Incriminated subscope variable declaration:
- --> tests/test_io/bad/using_non_output.catala_en:5.11-12
-  |
-5 |   internal a content integer
-  |            ^
-  + Test
+┌─⯈ tests/test_io/bad/using_non_output.catala_en:5.11-12
+└─┐
+  │
+5 │   internal a content integer
+  │            ‾
+  └─ Test
 
 Incriminated subscope declaration:
- --> tests/test_io/bad/using_non_output.catala_en:8.2-3
-  |
-8 |   a scope A
-  |   ^
-  + Test
+┌─⯈ tests/test_io/bad/using_non_output.catala_en:8.2-3
+└─┐
+  │
+8 │   a scope A
+  │   ‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_money/bad/no_mingle.catala_en
+++ b/tests/test_money/bad/no_mingle.catala_en
@@ -19,24 +19,27 @@ $ catala Interpret -s A
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_money/bad/no_mingle.catala_en:12.28-29
-   |
-12 |   definition z equals (x *$ y)
-   |                             ^
-   + Article
+┌─⯈ tests/test_money/bad/no_mingle.catala_en:12.28-29
+└──┐
+   │
+12 │   definition z equals (x *$ y)
+   │                             ‾
+   └─ Article
 
 Type money coming from expression:
- --> tests/test_money/bad/no_mingle.catala_en:6.20-25
-  |
-6 |   context y content money
-  |                     ^^^^^
-  + Article
+┌─⯈ tests/test_money/bad/no_mingle.catala_en:6.20-25
+└─┐
+  │
+6 │   context y content money
+  │                     ‾‾‾‾‾
+  └─ Article
 
 Type decimal coming from expression:
-  --> tests/test_money/bad/no_mingle.catala_en:12.25-27
-   |
-12 |   definition z equals (x *$ y)
-   |                          ^^
-   + Article
+┌─⯈ tests/test_money/bad/no_mingle.catala_en:12.25-27
+└──┐
+   │
+12 │   definition z equals (x *$ y)
+   │                          ‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_money/bad/no_mingle.catala_en
+++ b/tests/test_money/bad/no_mingle.catala_en
@@ -19,21 +19,21 @@ $ catala Interpret -s A
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_money/bad/no_mingle.catala_en
+  --> tests/test_money/bad/no_mingle.catala_en:12.28-29
    |
 12 |   definition z equals (x *$ y)
    |                             ^
    + Article
 
 Type money coming from expression:
- --> tests/test_money/bad/no_mingle.catala_en
+ --> tests/test_money/bad/no_mingle.catala_en:6.20-25
   |
 6 |   context y content money
   |                     ^^^^^
   + Article
 
 Type decimal coming from expression:
-  --> tests/test_money/bad/no_mingle.catala_en
+  --> tests/test_money/bad/no_mingle.catala_en:12.25-27
    |
 12 |   definition z equals (x *$ y)
    |                          ^^

--- a/tests/test_proof/bad/array_length-empty.catala_en
+++ b/tests/test_proof/bad/array_length-empty.catala_en
@@ -13,10 +13,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/array_length-empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/array_length-empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/array_length-empty.catala_en
+++ b/tests/test_proof/bad/array_length-empty.catala_en
@@ -13,7 +13,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/array_length-empty.catala_en
+ --> tests/test_proof/bad/array_length-empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/array_length-overlap.catala_en
+++ b/tests/test_proof/bad/array_length-overlap.catala_en
@@ -14,10 +14,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/array_length-overlap.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/array_length-overlap.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/array_length-overlap.catala_en
+++ b/tests/test_proof/bad/array_length-overlap.catala_en
@@ -14,7 +14,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/array_length-overlap.catala_en
+ --> tests/test_proof/bad/array_length-overlap.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/dates_get_year-empty.catala_en
+++ b/tests/test_proof/bad/dates_get_year-empty.catala_en
@@ -16,7 +16,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/dates_get_year-empty.catala_en
+ --> tests/test_proof/bad/dates_get_year-empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/dates_get_year-empty.catala_en
+++ b/tests/test_proof/bad/dates_get_year-empty.catala_en
@@ -16,10 +16,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/dates_get_year-empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/dates_get_year-empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/dates_get_year-overlap.catala_en
+++ b/tests/test_proof/bad/dates_get_year-overlap.catala_en
@@ -16,7 +16,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/dates_get_year-overlap.catala_en
+ --> tests/test_proof/bad/dates_get_year-overlap.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/dates_get_year-overlap.catala_en
+++ b/tests/test_proof/bad/dates_get_year-overlap.catala_en
@@ -16,10 +16,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/dates_get_year-overlap.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/dates_get_year-overlap.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/dates_simple-empty.catala_en
+++ b/tests/test_proof/bad/dates_simple-empty.catala_en
@@ -15,7 +15,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/dates_simple-empty.catala_en
+ --> tests/test_proof/bad/dates_simple-empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/dates_simple-empty.catala_en
+++ b/tests/test_proof/bad/dates_simple-empty.catala_en
@@ -15,10 +15,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/dates_simple-empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/dates_simple-empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/dates_simple-overlap.catala_en
+++ b/tests/test_proof/bad/dates_simple-overlap.catala_en
@@ -16,7 +16,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/dates_simple-overlap.catala_en
+ --> tests/test_proof/bad/dates_simple-overlap.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/dates_simple-overlap.catala_en
+++ b/tests/test_proof/bad/dates_simple-overlap.catala_en
@@ -16,10 +16,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/dates_simple-overlap.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/dates_simple-overlap.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/duration-empty.catala_en
+++ b/tests/test_proof/bad/duration-empty.catala_en
@@ -13,7 +13,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/duration-empty.catala_en
+ --> tests/test_proof/bad/duration-empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/duration-empty.catala_en
+++ b/tests/test_proof/bad/duration-empty.catala_en
@@ -13,10 +13,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/duration-empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/duration-empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/duration-overlap.catala_en
+++ b/tests/test_proof/bad/duration-overlap.catala_en
@@ -14,10 +14,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/duration-overlap.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/duration-overlap.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/duration-overlap.catala_en
+++ b/tests/test_proof/bad/duration-overlap.catala_en
@@ -14,7 +14,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/duration-overlap.catala_en
+ --> tests/test_proof/bad/duration-overlap.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/enums-empty.catala_en
+++ b/tests/test_proof/bad/enums-empty.catala_en
@@ -24,7 +24,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/enums-empty.catala_en
+  --> tests/test_proof/bad/enums-empty.catala_en:15.10-11
    |
 15 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/enums-empty.catala_en
+++ b/tests/test_proof/bad/enums-empty.catala_en
@@ -24,10 +24,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/enums-empty.catala_en:15.10-11
-   |
-15 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/enums-empty.catala_en:15.10-11
+└──┐
+   │
+15 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums-nonbool-empty.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-empty.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/enums-nonbool-empty.catala_en
+  --> tests/test_proof/bad/enums-nonbool-empty.catala_en:13.10-11
    |
 13 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/enums-nonbool-empty.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-empty.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/enums-nonbool-empty.catala_en:13.10-11
-   |
-13 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/enums-nonbool-empty.catala_en:13.10-11
+└──┐
+   │
+13 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums-nonbool-overlap.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-overlap.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums-nonbool-overlap.catala_en:13.10-11
-   |
-13 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/enums-nonbool-overlap.catala_en:13.10-11
+└──┐
+   │
+13 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums-nonbool-overlap.catala_en
+++ b/tests/test_proof/bad/enums-nonbool-overlap.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums-nonbool-overlap.catala_en
+  --> tests/test_proof/bad/enums-nonbool-overlap.catala_en:13.10-11
    |
 13 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/enums-overlap.catala_en
+++ b/tests/test_proof/bad/enums-overlap.catala_en
@@ -24,10 +24,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums-overlap.catala_en:15.10-11
-   |
-15 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/enums-overlap.catala_en:15.10-11
+└──┐
+   │
+15 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums-overlap.catala_en
+++ b/tests/test_proof/bad/enums-overlap.catala_en
@@ -24,7 +24,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums-overlap.catala_en
+  --> tests/test_proof/bad/enums-overlap.catala_en:15.10-11
    |
 15 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/enums_inj-empty.catala_en
+++ b/tests/test_proof/bad/enums_inj-empty.catala_en
@@ -17,10 +17,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
-  --> tests/test_proof/bad/enums_inj-empty.catala_en:10.10-11
-   |
-10 |   context y content integer
-   |           ^
-   + Article
+┌─⯈ tests/test_proof/bad/enums_inj-empty.catala_en:10.10-11
+└──┐
+   │
+10 │   context y content integer
+   │           ‾
+   └─ Article
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums_inj-empty.catala_en
+++ b/tests/test_proof/bad/enums_inj-empty.catala_en
@@ -17,7 +17,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
-  --> tests/test_proof/bad/enums_inj-empty.catala_en
+  --> tests/test_proof/bad/enums_inj-empty.catala_en:10.10-11
    |
 10 |   context y content integer
    |           ^

--- a/tests/test_proof/bad/enums_inj-overlap.catala_en
+++ b/tests/test_proof/bad/enums_inj-overlap.catala_en
@@ -19,7 +19,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums_inj-overlap.catala_en
+  --> tests/test_proof/bad/enums_inj-overlap.catala_en:10.10-11
    |
 10 |   context y content integer
    |           ^

--- a/tests/test_proof/bad/enums_inj-overlap.catala_en
+++ b/tests/test_proof/bad/enums_inj-overlap.catala_en
@@ -19,10 +19,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums_inj-overlap.catala_en:10.10-11
-   |
-10 |   context y content integer
-   |           ^
-   + Article
+┌─⯈ tests/test_proof/bad/enums_inj-overlap.catala_en:10.10-11
+└──┐
+   │
+10 │   context y content integer
+   │           ‾
+   └─ Article
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums_unit-empty.catala_en
+++ b/tests/test_proof/bad/enums_unit-empty.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
-  --> tests/test_proof/bad/enums_unit-empty.catala_en
+  --> tests/test_proof/bad/enums_unit-empty.catala_en:10.10-11
    |
 10 |   context y content integer
    |           ^

--- a/tests/test_proof/bad/enums_unit-empty.catala_en
+++ b/tests/test_proof/bad/enums_unit-empty.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
-  --> tests/test_proof/bad/enums_unit-empty.catala_en:10.10-11
-   |
-10 |   context y content integer
-   |           ^
-   + Article
+┌─⯈ tests/test_proof/bad/enums_unit-empty.catala_en:10.10-11
+└──┐
+   │
+10 │   context y content integer
+   │           ‾
+   └─ Article
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/enums_unit-overlap.catala_en
+++ b/tests/test_proof/bad/enums_unit-overlap.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums_unit-overlap.catala_en
+  --> tests/test_proof/bad/enums_unit-overlap.catala_en:10.10-11
    |
 10 |   context y content integer
    |           ^

--- a/tests/test_proof/bad/enums_unit-overlap.catala_en
+++ b/tests/test_proof/bad/enums_unit-overlap.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/enums_unit-overlap.catala_en:10.10-11
-   |
-10 |   context y content integer
-   |           ^
-   + Article
+┌─⯈ tests/test_proof/bad/enums_unit-overlap.catala_en:10.10-11
+└──┐
+   │
+10 │   context y content integer
+   │           ‾
+   └─ Article
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/money-empty.catala_en
+++ b/tests/test_proof/bad/money-empty.catala_en
@@ -17,7 +17,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/money-empty.catala_en
+ --> tests/test_proof/bad/money-empty.catala_en:8.10-11
   |
 8 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/money-empty.catala_en
+++ b/tests/test_proof/bad/money-empty.catala_en
@@ -17,10 +17,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/money-empty.catala_en:8.10-11
-  |
-8 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/money-empty.catala_en:8.10-11
+└─┐
+  │
+8 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/money-overlap.catala_en
+++ b/tests/test_proof/bad/money-overlap.catala_en
@@ -18,10 +18,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/money-overlap.catala_en:8.10-11
-  |
-8 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/money-overlap.catala_en:8.10-11
+└─┐
+  │
+8 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/money-overlap.catala_en
+++ b/tests/test_proof/bad/money-overlap.catala_en
@@ -18,7 +18,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/money-overlap.catala_en
+ --> tests/test_proof/bad/money-overlap.catala_en:8.10-11
   |
 8 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/no_vars-conflict.catala_en
+++ b/tests/test_proof/bad/no_vars-conflict.catala_en
@@ -18,10 +18,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/no_vars-conflict.catala_en:8.10-11
-  |
-8 |   context y content integer
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/no_vars-conflict.catala_en:8.10-11
+└─┐
+  │
+8 │   context y content integer
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/no_vars-conflict.catala_en
+++ b/tests/test_proof/bad/no_vars-conflict.catala_en
@@ -18,7 +18,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/no_vars-conflict.catala_en
+ --> tests/test_proof/bad/no_vars-conflict.catala_en:8.10-11
   |
 8 |   context y content integer
   |           ^

--- a/tests/test_proof/bad/no_vars-empty.catala_en
+++ b/tests/test_proof/bad/no_vars-empty.catala_en
@@ -17,7 +17,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/no_vars-empty.catala_en
+ --> tests/test_proof/bad/no_vars-empty.catala_en:7.10-11
   |
 7 |   context y content integer
   |           ^

--- a/tests/test_proof/bad/no_vars-empty.catala_en
+++ b/tests/test_proof/bad/no_vars-empty.catala_en
@@ -17,10 +17,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/no_vars-empty.catala_en:7.10-11
-  |
-7 |   context y content integer
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/no_vars-empty.catala_en:7.10-11
+└─┐
+  │
+7 │   context y content integer
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/prolala_motivating_example.catala_en
+++ b/tests/test_proof/bad/prolala_motivating_example.catala_en
@@ -124,27 +124,30 @@ scope Amount:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [Amount.amount] This variable might return an empty error:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en:60.10-16
-   |
-60 |   context amount content integer
-   |           ^^^^^^
-   + ProLaLa 2022 Super Cash Bonus
-   +-+ Amount
+┌─⯈ tests/test_proof/bad/prolala_motivating_example.catala_en:60.10-16
+└──┐
+   │
+60 │   context amount content integer
+   │           ‾‾‾‾‾‾
+   └┬ ProLaLa 2022 Super Cash Bonus
+    └─ Amount
 Counterexample generation is disabled so none was generated.
 [ERROR] [Eligibility.is_eligible] This variable might return an empty error:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
-   |
-11 |   output is_eligible content boolean
-   |          ^^^^^^^^^^^
-   + ProLaLa 2022 Super Cash Bonus
-   +-+ Eligibility
+┌─⯈ tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
+└──┐
+   │
+11 │   output is_eligible content boolean
+   │          ‾‾‾‾‾‾‾‾‾‾‾
+   └┬ ProLaLa 2022 Super Cash Bonus
+    └─ Eligibility
 Counterexample generation is disabled so none was generated.
 [ERROR] [Eligibility.is_eligible] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
-   |
-11 |   output is_eligible content boolean
-   |          ^^^^^^^^^^^
-   + ProLaLa 2022 Super Cash Bonus
-   +-+ Eligibility
+┌─⯈ tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
+└──┐
+   │
+11 │   output is_eligible content boolean
+   │          ‾‾‾‾‾‾‾‾‾‾‾
+   └┬ ProLaLa 2022 Super Cash Bonus
+    └─ Eligibility
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/prolala_motivating_example.catala_en
+++ b/tests/test_proof/bad/prolala_motivating_example.catala_en
@@ -124,7 +124,7 @@ scope Amount:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [Amount.amount] This variable might return an empty error:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en
+  --> tests/test_proof/bad/prolala_motivating_example.catala_en:60.10-16
    |
 60 |   context amount content integer
    |           ^^^^^^
@@ -132,7 +132,7 @@ $ catala Proof --disable_counterexamples
    +-+ Amount
 Counterexample generation is disabled so none was generated.
 [ERROR] [Eligibility.is_eligible] This variable might return an empty error:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en
+  --> tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
    |
 11 |   output is_eligible content boolean
    |          ^^^^^^^^^^^
@@ -140,7 +140,7 @@ Counterexample generation is disabled so none was generated.
    +-+ Eligibility
 Counterexample generation is disabled so none was generated.
 [ERROR] [Eligibility.is_eligible] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/prolala_motivating_example.catala_en
+  --> tests/test_proof/bad/prolala_motivating_example.catala_en:11.9-20
    |
 11 |   output is_eligible content boolean
    |          ^^^^^^^^^^^

--- a/tests/test_proof/bad/rationals-empty.catala_en
+++ b/tests/test_proof/bad/rationals-empty.catala_en
@@ -13,7 +13,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/rationals-empty.catala_en
+ --> tests/test_proof/bad/rationals-empty.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/rationals-empty.catala_en
+++ b/tests/test_proof/bad/rationals-empty.catala_en
@@ -13,10 +13,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] This variable might return an empty error:
- --> tests/test_proof/bad/rationals-empty.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/rationals-empty.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/rationals-overlap.catala_en
+++ b/tests/test_proof/bad/rationals-overlap.catala_en
@@ -14,10 +14,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/rationals-overlap.catala_en:6.10-11
-  |
-6 |   context y content boolean
-  |           ^
-  + Test
+┌─⯈ tests/test_proof/bad/rationals-overlap.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content boolean
+  │           ‾
+  └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/rationals-overlap.catala_en
+++ b/tests/test_proof/bad/rationals-overlap.catala_en
@@ -14,7 +14,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.y] At least two exceptions overlap for this variable:
- --> tests/test_proof/bad/rationals-overlap.catala_en
+ --> tests/test_proof/bad/rationals-overlap.catala_en:6.10-11
   |
 6 |   context y content boolean
   |           ^

--- a/tests/test_proof/bad/sat_solving.catala_en
+++ b/tests/test_proof/bad/sat_solving.catala_en
@@ -41,7 +41,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x10] This variable might return an empty error:
-  --> tests/test_proof/bad/sat_solving.catala_en
+  --> tests/test_proof/bad/sat_solving.catala_en:15.10-13
    |
 15 |   context x10 content boolean
    |           ^^^

--- a/tests/test_proof/bad/sat_solving.catala_en
+++ b/tests/test_proof/bad/sat_solving.catala_en
@@ -41,10 +41,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x10] This variable might return an empty error:
-  --> tests/test_proof/bad/sat_solving.catala_en:15.10-13
-   |
-15 |   context x10 content boolean
-   |           ^^^
-   + Test
+┌─⯈ tests/test_proof/bad/sat_solving.catala_en:15.10-13
+└──┐
+   │
+15 │   context x10 content boolean
+   │           ‾‾‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/structs-empty.catala_en
+++ b/tests/test_proof/bad/structs-empty.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/structs-empty.catala_en:13.10-11
-   |
-13 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/structs-empty.catala_en:13.10-11
+└──┐
+   │
+13 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_proof/bad/structs-empty.catala_en
+++ b/tests/test_proof/bad/structs-empty.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] This variable might return an empty error:
-  --> tests/test_proof/bad/structs-empty.catala_en
+  --> tests/test_proof/bad/structs-empty.catala_en:13.10-11
    |
 13 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/structs-overlap.catala_en
+++ b/tests/test_proof/bad/structs-overlap.catala_en
@@ -22,7 +22,7 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/structs-overlap.catala_en
+  --> tests/test_proof/bad/structs-overlap.catala_en:13.10-11
    |
 13 |   context x content integer
    |           ^

--- a/tests/test_proof/bad/structs-overlap.catala_en
+++ b/tests/test_proof/bad/structs-overlap.catala_en
@@ -22,10 +22,11 @@ scope A:
 ```catala-test-inline
 $ catala Proof --disable_counterexamples 
 [ERROR] [A.x] At least two exceptions overlap for this variable:
-  --> tests/test_proof/bad/structs-overlap.catala_en:13.10-11
-   |
-13 |   context x content integer
-   |           ^
-   + Test
+┌─⯈ tests/test_proof/bad/structs-overlap.catala_en:13.10-11
+└──┐
+   │
+13 │   context x content integer
+   │           ‾
+   └─ Test
 Counterexample generation is disabled so none was generated.
 ```

--- a/tests/test_scope/bad/cycle_in_scope.catala_en
+++ b/tests/test_scope/bad/cycle_in_scope.catala_en
@@ -19,42 +19,42 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between variables of scope A!
 
 Cycle variable z, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en
+ --> tests/test_scope/bad/cycle_in_scope.catala_en:7.10-11
   |
 7 |   context z content integer
   |           ^
   + Article
 
 Used here in the definition of another cycle variable x:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en
+  --> tests/test_scope/bad/cycle_in_scope.catala_en:14.22-23
    |
 14 |   definition x equals z
    |                       ^
    + Article
 
 Cycle variable y, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en
+ --> tests/test_scope/bad/cycle_in_scope.catala_en:6.10-11
   |
 6 |   context y content integer
   |           ^
   + Article
 
 Used here in the definition of another cycle variable z:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en
+  --> tests/test_scope/bad/cycle_in_scope.catala_en:13.31-32
    |
 13 |   definition z under condition y < 1 consequence equals y
    |                                ^
    + Article
 
 Cycle variable x, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en
+ --> tests/test_scope/bad/cycle_in_scope.catala_en:5.10-11
   |
 5 |   context x content integer
   |           ^
   + Article
 
 Used here in the definition of another cycle variable y:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en
+  --> tests/test_scope/bad/cycle_in_scope.catala_en:11.31-32
    |
 11 |   definition y under condition x >= 0 consequence equals x
    |                                ^

--- a/tests/test_scope/bad/cycle_in_scope.catala_en
+++ b/tests/test_scope/bad/cycle_in_scope.catala_en
@@ -19,45 +19,51 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between variables of scope A!
 
 Cycle variable z, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en:7.10-11
-  |
-7 |   context z content integer
-  |           ^
-  + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:7.10-11
+└─┐
+  │
+7 │   context z content integer
+  │           ‾
+  └─ Article
 
 Used here in the definition of another cycle variable x:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en:14.22-23
-   |
-14 |   definition x equals z
-   |                       ^
-   + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:14.22-23
+└──┐
+   │
+14 │   definition x equals z
+   │                       ‾
+   └─ Article
 
 Cycle variable y, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en:6.10-11
-  |
-6 |   context y content integer
-  |           ^
-  + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:6.10-11
+└─┐
+  │
+6 │   context y content integer
+  │           ‾
+  └─ Article
 
 Used here in the definition of another cycle variable z:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en:13.31-32
-   |
-13 |   definition z under condition y < 1 consequence equals y
-   |                                ^
-   + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:13.31-32
+└──┐
+   │
+13 │   definition z under condition y < 1 consequence equals y
+   │                                ‾
+   └─ Article
 
 Cycle variable x, declared:
- --> tests/test_scope/bad/cycle_in_scope.catala_en:5.10-11
-  |
-5 |   context x content integer
-  |           ^
-  + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:5.10-11
+└─┐
+  │
+5 │   context x content integer
+  │           ‾
+  └─ Article
 
 Used here in the definition of another cycle variable y:
-  --> tests/test_scope/bad/cycle_in_scope.catala_en:11.31-32
-   |
-11 |   definition y under condition x >= 0 consequence equals x
-   |                                ^
-   + Article
+┌─⯈ tests/test_scope/bad/cycle_in_scope.catala_en:11.31-32
+└──┐
+   │
+11 │   definition y under condition x >= 0 consequence equals x
+   │                                ‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_scope/bad/cyclic_scopes.catala_en
+++ b/tests/test_scope/bad/cyclic_scopes.catala_en
@@ -21,31 +21,35 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between scopes!
 
 Cycle variable B, declared:
- --> tests/test_scope/bad/cyclic_scopes.catala_en:8.18-19
-  |
-8 | declaration scope B:
-  |                   ^
-  + Article
+┌─⯈ tests/test_scope/bad/cyclic_scopes.catala_en:8.18-19
+└─┐
+  │
+8 │ declaration scope B:
+  │                   ‾
+  └─ Article
 
 Used here in the definition of another cycle variable A:
- --> tests/test_scope/bad/cyclic_scopes.catala_en:5.2-3
-  |
-5 |   b scope B
-  |   ^
-  + Article
+┌─⯈ tests/test_scope/bad/cyclic_scopes.catala_en:5.2-3
+└─┐
+  │
+5 │   b scope B
+  │   ‾
+  └─ Article
 
 Cycle variable A, declared:
- --> tests/test_scope/bad/cyclic_scopes.catala_en:4.18-19
-  |
-4 | declaration scope A:
-  |                   ^
-  + Article
+┌─⯈ tests/test_scope/bad/cyclic_scopes.catala_en:4.18-19
+└─┐
+  │
+4 │ declaration scope A:
+  │                   ‾
+  └─ Article
 
 Used here in the definition of another cycle variable B:
- --> tests/test_scope/bad/cyclic_scopes.catala_en:9.2-3
-  |
-9 |   a scope A
-  |   ^
-  + Article
+┌─⯈ tests/test_scope/bad/cyclic_scopes.catala_en:9.2-3
+└─┐
+  │
+9 │   a scope A
+  │   ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_scope/bad/cyclic_scopes.catala_en
+++ b/tests/test_scope/bad/cyclic_scopes.catala_en
@@ -21,28 +21,28 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between scopes!
 
 Cycle variable B, declared:
- --> tests/test_scope/bad/cyclic_scopes.catala_en
+ --> tests/test_scope/bad/cyclic_scopes.catala_en:8.18-19
   |
 8 | declaration scope B:
   |                   ^
   + Article
 
 Used here in the definition of another cycle variable A:
- --> tests/test_scope/bad/cyclic_scopes.catala_en
+ --> tests/test_scope/bad/cyclic_scopes.catala_en:5.2-3
   |
 5 |   b scope B
   |   ^
   + Article
 
 Cycle variable A, declared:
- --> tests/test_scope/bad/cyclic_scopes.catala_en
+ --> tests/test_scope/bad/cyclic_scopes.catala_en:4.18-19
   |
 4 | declaration scope A:
   |                   ^
   + Article
 
 Used here in the definition of another cycle variable B:
- --> tests/test_scope/bad/cyclic_scopes.catala_en
+ --> tests/test_scope/bad/cyclic_scopes.catala_en:9.2-3
   |
 9 |   a scope A
   |   ^

--- a/tests/test_scope/bad/scope.catala_en
+++ b/tests/test_scope/bad/scope.catala_en
@@ -19,17 +19,19 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_scope/bad/scope.catala_en:13.56-60
-   |
-13 |   definition b under condition not c consequence equals 1337
-   |                                                         ^^^^
-   + Article
+┌─⯈ tests/test_scope/bad/scope.catala_en:13.56-60
+└──┐
+   │
+13 │   definition b under condition not c consequence equals 1337
+   │                                                         ‾‾‾‾
+   └─ Article
 
 This consequence has a valid justification:
-  --> tests/test_scope/bad/scope.catala_en:14.56-57
-   |
-14 |   definition b under condition not c consequence equals 0
-   |                                                         ^
-   + Article
+┌─⯈ tests/test_scope/bad/scope.catala_en:14.56-57
+└──┐
+   │
+14 │   definition b under condition not c consequence equals 0
+   │                                                         ‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_scope/bad/scope.catala_en
+++ b/tests/test_scope/bad/scope.catala_en
@@ -19,14 +19,14 @@ $ catala Interpret -s A
 [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
 
 This consequence has a valid justification:
-  --> tests/test_scope/bad/scope.catala_en
+  --> tests/test_scope/bad/scope.catala_en:13.56-60
    |
 13 |   definition b under condition not c consequence equals 1337
    |                                                         ^^^^
    + Article
 
 This consequence has a valid justification:
-  --> tests/test_scope/bad/scope.catala_en
+  --> tests/test_scope/bad/scope.catala_en:14.56-57
    |
 14 |   definition b under condition not c consequence equals 0
    |                                                         ^

--- a/tests/test_scope/bad/scope_call_duplicate.catala_en
+++ b/tests/test_scope/bad/scope_call_duplicate.catala_en
@@ -18,10 +18,11 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Duplicate definition of scope input variable 'bar'
 
-  --> tests/test_scope/bad/scope_call_duplicate.catala_en:14.57-60
-   |
-14 |   definition fizz equals Toto of {--bar: 1 --baz: 2.1 -- bar: 3}
-   |                                                          ^^^
-   +
+┌─⯈ tests/test_scope/bad/scope_call_duplicate.catala_en:14.57-60
+└──┐
+   │
+14 │   definition fizz equals Toto of {--bar: 1 --baz: 2.1 -- bar: 3}
+   │                                                          ‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_scope/bad/scope_call_duplicate.catala_en
+++ b/tests/test_scope/bad/scope_call_duplicate.catala_en
@@ -18,7 +18,7 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Duplicate definition of scope input variable 'bar'
 
-  --> tests/test_scope/bad/scope_call_duplicate.catala_en
+  --> tests/test_scope/bad/scope_call_duplicate.catala_en:14.57-60
    |
 14 |   definition fizz equals Toto of {--bar: 1 --baz: 2.1 -- bar: 3}
    |                                                          ^^^

--- a/tests/test_scope/bad/scope_call_extra.catala_en
+++ b/tests/test_scope/bad/scope_call_extra.catala_en
@@ -18,14 +18,14 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Scope Toto has no input variable biz
 
-  --> tests/test_scope/bad/scope_call_extra.catala_en
+  --> tests/test_scope/bad/scope_call_extra.catala_en:14.36-39
    |
 14 |   definition fizz equals Toto of {--biz: 1}
    |                                     ^^^
    +
 
 Scope Toto declared here
- --> tests/test_scope/bad/scope_call_extra.catala_en
+ --> tests/test_scope/bad/scope_call_extra.catala_en:2.18-22
   |
 2 | declaration scope Toto:
   |                   ^^^^

--- a/tests/test_scope/bad/scope_call_extra.catala_en
+++ b/tests/test_scope/bad/scope_call_extra.catala_en
@@ -18,17 +18,19 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Scope Toto has no input variable biz
 
-  --> tests/test_scope/bad/scope_call_extra.catala_en:14.36-39
-   |
-14 |   definition fizz equals Toto of {--biz: 1}
-   |                                     ^^^
-   +
+┌─⯈ tests/test_scope/bad/scope_call_extra.catala_en:14.36-39
+└──┐
+   │
+14 │   definition fizz equals Toto of {--biz: 1}
+   │                                     ‾‾‾
+
 
 Scope Toto declared here
- --> tests/test_scope/bad/scope_call_extra.catala_en:2.18-22
-  |
-2 | declaration scope Toto:
-  |                   ^^^^
-  +
+┌─⯈ tests/test_scope/bad/scope_call_extra.catala_en:2.18-22
+└─┐
+  │
+2 │ declaration scope Toto:
+  │                   ‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_scope/bad/scope_call_missing.catala_en
+++ b/tests/test_scope/bad/scope_call_missing.catala_en
@@ -18,17 +18,19 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Definition of input variable 'baz' missing in this scope call
 
-  --> tests/test_scope/bad/scope_call_missing.catala_en:14.25-43
-   |
-14 |   definition fizz equals Toto of {--bar: 1}
-   |                          ^^^^^^^^^^^^^^^^^^
-   +
+┌─⯈ tests/test_scope/bad/scope_call_missing.catala_en:14.25-43
+└──┐
+   │
+14 │   definition fizz equals Toto of {--bar: 1}
+   │                          ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Declaration of the missing input variable
- --> tests/test_scope/bad/scope_call_missing.catala_en:4.8-11
-  |
-4 |   input baz content decimal
-  |         ^^^
-  +
+┌─⯈ tests/test_scope/bad/scope_call_missing.catala_en:4.8-11
+└─┐
+  │
+4 │   input baz content decimal
+  │         ‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_scope/bad/scope_call_missing.catala_en
+++ b/tests/test_scope/bad/scope_call_missing.catala_en
@@ -18,14 +18,14 @@ scope Titi:
 $ catala dcalc -s Titi
 [ERROR] Definition of input variable 'baz' missing in this scope call
 
-  --> tests/test_scope/bad/scope_call_missing.catala_en
+  --> tests/test_scope/bad/scope_call_missing.catala_en:14.25-43
    |
 14 |   definition fizz equals Toto of {--bar: 1}
    |                          ^^^^^^^^^^^^^^^^^^
    +
 
 Declaration of the missing input variable
- --> tests/test_scope/bad/scope_call_missing.catala_en
+ --> tests/test_scope/bad/scope_call_missing.catala_en:4.8-11
   |
 4 |   input baz content decimal
   |         ^^^

--- a/tests/test_scope/bad/sub_vars_in_sub_var.catala_en
+++ b/tests/test_scope/bad/sub_vars_in_sub_var.catala_en
@@ -17,10 +17,11 @@ scope B:
 $ catala Interpret -s A
 [ERROR] The subscope a is used when defining one of its inputs, but recursion is forbidden in Catala
 
-  --> tests/test_scope/bad/sub_vars_in_sub_var.catala_en:13.27-30
-   |
-13 |   definition a.y equals if a.x then 0 else 1
-   |                            ^^^
-   + Article
+┌─⯈ tests/test_scope/bad/sub_vars_in_sub_var.catala_en:13.27-30
+└──┐
+   │
+13 │   definition a.y equals if a.x then 0 else 1
+   │                            ‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_scope/bad/sub_vars_in_sub_var.catala_en
+++ b/tests/test_scope/bad/sub_vars_in_sub_var.catala_en
@@ -17,7 +17,7 @@ scope B:
 $ catala Interpret -s A
 [ERROR] The subscope a is used when defining one of its inputs, but recursion is forbidden in Catala
 
-  --> tests/test_scope/bad/sub_vars_in_sub_var.catala_en
+  --> tests/test_scope/bad/sub_vars_in_sub_var.catala_en:13.27-30
    |
 13 |   definition a.y equals if a.x then 0 else 1
    |                            ^^^

--- a/tests/test_struct/bad/ambiguous_fields.catala_en
+++ b/tests/test_struct/bad/ambiguous_fields.catala_en
@@ -20,7 +20,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This struct field name is ambiguous, it can belong to Foo or Bar. Disambiguate it by prefixing it with the struct name.
 
-  --> tests/test_struct/bad/ambiguous_fields.catala_en
+  --> tests/test_struct/bad/ambiguous_fields.catala_en:16.24-25
    |
 16 |   definition y equals x.f
    |                         ^

--- a/tests/test_struct/bad/ambiguous_fields.catala_en
+++ b/tests/test_struct/bad/ambiguous_fields.catala_en
@@ -20,10 +20,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] This struct field name is ambiguous, it can belong to Foo or Bar. Disambiguate it by prefixing it with the struct name.
 
-  --> tests/test_struct/bad/ambiguous_fields.catala_en:16.24-25
-   |
-16 |   definition y equals x.f
-   |                         ^
-   + Article
+┌─⯈ tests/test_struct/bad/ambiguous_fields.catala_en:16.24-25
+└──┐
+   │
+16 │   definition y equals x.f
+   │                         ‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_struct/bad/bug_107.catala_en
+++ b/tests/test_struct/bad/bug_107.catala_en
@@ -21,14 +21,14 @@ $ catala Interpret -s A
 [ERROR] struct name "S" already defined
 
 First definition:
- --> tests/test_struct/bad/bug_107.catala_en
+ --> tests/test_struct/bad/bug_107.catala_en:4.22-23
   |
 4 | declaration structure S:
   |                       ^
   + https://github.com/CatalaLang/catala/issues/107
 
 Second definition:
- --> tests/test_struct/bad/bug_107.catala_en
+ --> tests/test_struct/bad/bug_107.catala_en:8.22-23
   |
 8 | declaration structure S:
   |                       ^

--- a/tests/test_struct/bad/bug_107.catala_en
+++ b/tests/test_struct/bad/bug_107.catala_en
@@ -21,17 +21,19 @@ $ catala Interpret -s A
 [ERROR] struct name "S" already defined
 
 First definition:
- --> tests/test_struct/bad/bug_107.catala_en:4.22-23
-  |
-4 | declaration structure S:
-  |                       ^
-  + https://github.com/CatalaLang/catala/issues/107
+┌─⯈ tests/test_struct/bad/bug_107.catala_en:4.22-23
+└─┐
+  │
+4 │ declaration structure S:
+  │                       ‾
+  └─ https://github.com/CatalaLang/catala/issues/107
 
 Second definition:
- --> tests/test_struct/bad/bug_107.catala_en:8.22-23
-  |
-8 | declaration structure S:
-  |                       ^
-  + https://github.com/CatalaLang/catala/issues/107
+┌─⯈ tests/test_struct/bad/bug_107.catala_en:8.22-23
+└─┐
+  │
+8 │ declaration structure S:
+  │                       ‾
+  └─ https://github.com/CatalaLang/catala/issues/107
 #return code 255#
 ```

--- a/tests/test_struct/bad/empty_struct.catala_en
+++ b/tests/test_struct/bad/empty_struct.catala_en
@@ -11,7 +11,7 @@ declaration scope Bar:
 $ catala Typecheck 
 [ERROR] The struct Foo does not have any fields; give it some for Catala to be able to accept it.
 
- --> tests/test_struct/bad/empty_struct.catala_en
+ --> tests/test_struct/bad/empty_struct.catala_en:4.22-25
   |
 4 | declaration structure Foo:
   |                       ^^^

--- a/tests/test_struct/bad/empty_struct.catala_en
+++ b/tests/test_struct/bad/empty_struct.catala_en
@@ -11,10 +11,11 @@ declaration scope Bar:
 $ catala Typecheck 
 [ERROR] The struct Foo does not have any fields; give it some for Catala to be able to accept it.
 
- --> tests/test_struct/bad/empty_struct.catala_en:4.22-25
-  |
-4 | declaration structure Foo:
-  |                       ^^^
-  + Test
+┌─⯈ tests/test_struct/bad/empty_struct.catala_en:4.22-25
+└─┐
+  │
+4 │ declaration structure Foo:
+  │                       ‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_struct/bad/nested.catala_en
+++ b/tests/test_struct/bad/nested.catala_en
@@ -16,10 +16,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The type E is defined using itself, which is forbidden since Catala does not provide recursive types
 
- --> tests/test_struct/bad/nested.catala_en:6.17-18
-  |
-6 |   -- Rec content E
-  |                  ^
-  + Article
+┌─⯈ tests/test_struct/bad/nested.catala_en:6.17-18
+└─┐
+  │
+6 │   -- Rec content E
+  │                  ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_struct/bad/nested.catala_en
+++ b/tests/test_struct/bad/nested.catala_en
@@ -16,7 +16,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] The type E is defined using itself, which is forbidden since Catala does not provide recursive types
 
- --> tests/test_struct/bad/nested.catala_en
+ --> tests/test_struct/bad/nested.catala_en:6.17-18
   |
 6 |   -- Rec content E
   |                  ^

--- a/tests/test_struct/bad/nested2.catala_en
+++ b/tests/test_struct/bad/nested2.catala_en
@@ -18,28 +18,28 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between types!
 
 Cycle type S, declared:
- --> tests/test_struct/bad/nested2.catala_en
+ --> tests/test_struct/bad/nested2.catala_en:4.22-23
   |
 4 | declaration structure S:
   |                       ^
   + Article
 
 Used here in the definition of another cycle type E:
-  --> tests/test_struct/bad/nested2.catala_en
+  --> tests/test_struct/bad/nested2.catala_en:10.19-20
    |
 10 |   -- Case2 content S
    |                    ^
    + Article
 
 Cycle type E, declared:
- --> tests/test_struct/bad/nested2.catala_en
+ --> tests/test_struct/bad/nested2.catala_en:8.24-25
   |
 8 | declaration enumeration E:
   |                         ^
   + Article
 
 Used here in the definition of another cycle type S:
- --> tests/test_struct/bad/nested2.catala_en
+ --> tests/test_struct/bad/nested2.catala_en:5.17-18
   |
 5 |   data x content E
   |                  ^

--- a/tests/test_struct/bad/nested2.catala_en
+++ b/tests/test_struct/bad/nested2.catala_en
@@ -18,31 +18,35 @@ $ catala Interpret -s A
 [ERROR] Cyclic dependency detected between types!
 
 Cycle type S, declared:
- --> tests/test_struct/bad/nested2.catala_en:4.22-23
-  |
-4 | declaration structure S:
-  |                       ^
-  + Article
+┌─⯈ tests/test_struct/bad/nested2.catala_en:4.22-23
+└─┐
+  │
+4 │ declaration structure S:
+  │                       ‾
+  └─ Article
 
 Used here in the definition of another cycle type E:
-  --> tests/test_struct/bad/nested2.catala_en:10.19-20
-   |
-10 |   -- Case2 content S
-   |                    ^
-   + Article
+┌─⯈ tests/test_struct/bad/nested2.catala_en:10.19-20
+└──┐
+   │
+10 │   -- Case2 content S
+   │                    ‾
+   └─ Article
 
 Cycle type E, declared:
- --> tests/test_struct/bad/nested2.catala_en:8.24-25
-  |
-8 | declaration enumeration E:
-  |                         ^
-  + Article
+┌─⯈ tests/test_struct/bad/nested2.catala_en:8.24-25
+└─┐
+  │
+8 │ declaration enumeration E:
+  │                         ‾
+  └─ Article
 
 Used here in the definition of another cycle type S:
- --> tests/test_struct/bad/nested2.catala_en:5.17-18
-  |
-5 |   data x content E
-  |                  ^
-  + Article
+┌─⯈ tests/test_struct/bad/nested2.catala_en:5.17-18
+└─┐
+  │
+5 │   data x content E
+  │                  ‾
+  └─ Article
 #return code 255#
 ```

--- a/tests/test_struct/bad/nonexisting_struct.catala_en
+++ b/tests/test_struct/bad/nonexisting_struct.catala_en
@@ -17,10 +17,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] No struct named Fo found
 
-  --> tests/test_struct/bad/nonexisting_struct.catala_en:13.24-26
-   |
-13 |   definition y equals x.Fo.f
-   |                         ^^
-   + Article
+┌─⯈ tests/test_struct/bad/nonexisting_struct.catala_en:13.24-26
+└──┐
+   │
+13 │   definition y equals x.Fo.f
+   │                         ‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_struct/bad/nonexisting_struct.catala_en
+++ b/tests/test_struct/bad/nonexisting_struct.catala_en
@@ -17,7 +17,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] No struct named Fo found
 
-  --> tests/test_struct/bad/nonexisting_struct.catala_en
+  --> tests/test_struct/bad/nonexisting_struct.catala_en:13.24-26
    |
 13 |   definition y equals x.Fo.f
    |                         ^^

--- a/tests/test_struct/bad/wrong_qualified_field.catala_en
+++ b/tests/test_struct/bad/wrong_qualified_field.catala_en
@@ -21,7 +21,7 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Struct Foo does not contain field g
 
-  --> tests/test_struct/bad/wrong_qualified_field.catala_en
+  --> tests/test_struct/bad/wrong_qualified_field.catala_en:17.22-29
    |
 17 |   definition y equals x.Foo.g
    |                       ^^^^^^^

--- a/tests/test_struct/bad/wrong_qualified_field.catala_en
+++ b/tests/test_struct/bad/wrong_qualified_field.catala_en
@@ -21,10 +21,11 @@ scope A:
 $ catala Interpret -s A
 [ERROR] Struct Foo does not contain field g
 
-  --> tests/test_struct/bad/wrong_qualified_field.catala_en:17.22-29
-   |
-17 |   definition y equals x.Foo.g
-   |                       ^^^^^^^
-   + Article
+┌─⯈ tests/test_struct/bad/wrong_qualified_field.catala_en:17.22-29
+└──┐
+   │
+17 │   definition y equals x.Foo.g
+   │                       ‾‾‾‾‾‾‾
+   └─ Article
 #return code 255#
 ```

--- a/tests/test_typing/bad/err1.catala_en
+++ b/tests/test_typing/bad/err1.catala_en
@@ -17,21 +17,21 @@ $ catala Typecheck
 --> integer
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err1.catala_en
+ --> tests/test_typing/bad/err1.catala_en:7.22-25
   |
 7 |     Structure { -- i: 4.1 -- e: y };
   |                       ^^^
   +
 
 Type decimal coming from expression:
- --> tests/test_typing/bad/err1.catala_en
+ --> tests/test_typing/bad/err1.catala_en:7.22-25
   |
 7 |     Structure { -- i: 4.1 -- e: y };
   |                       ^^^
   +
 
 Type integer coming from expression:
- --> tests/test_typing/bad/common.catala_en
+ --> tests/test_typing/bad/common.catala_en:8.17-24
   |
 8 |   data i content integer
   |                  ^^^^^^^

--- a/tests/test_typing/bad/err1.catala_en
+++ b/tests/test_typing/bad/err1.catala_en
@@ -17,24 +17,27 @@ $ catala Typecheck
 --> integer
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err1.catala_en:7.22-25
-  |
-7 |     Structure { -- i: 4.1 -- e: y };
-  |                       ^^^
-  +
+┌─⯈ tests/test_typing/bad/err1.catala_en:7.22-25
+└─┐
+  │
+7 │     Structure { -- i: 4.1 -- e: y };
+  │                       ‾‾‾
+
 
 Type decimal coming from expression:
- --> tests/test_typing/bad/err1.catala_en:7.22-25
-  |
-7 |     Structure { -- i: 4.1 -- e: y };
-  |                       ^^^
-  +
+┌─⯈ tests/test_typing/bad/err1.catala_en:7.22-25
+└─┐
+  │
+7 │     Structure { -- i: 4.1 -- e: y };
+  │                       ‾‾‾
+
 
 Type integer coming from expression:
- --> tests/test_typing/bad/common.catala_en:8.17-24
-  |
-8 |   data i content integer
-  |                  ^^^^^^^
-  +
+┌─⯈ tests/test_typing/bad/common.catala_en:8.17-24
+└─┐
+  │
+8 │   data i content integer
+  │                  ‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err2.catala_en
+++ b/tests/test_typing/bad/err2.catala_en
@@ -17,21 +17,21 @@ $ catala Typecheck
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err2.catala_en
+  --> tests/test_typing/bad/err2.catala_en:10.43-44
    |
 10 |   definition a equals number of (z ++ 1.1) / 2
    |                                            ^
    +
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err2.catala_en
+  --> tests/test_typing/bad/err2.catala_en:10.43-44
    |
 10 |   definition a equals number of (z ++ 1.1) / 2
    |                                            ^
    +
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:15.19-26
    |
 15 |   output a content decimal
    |                    ^^^^^^^

--- a/tests/test_typing/bad/err2.catala_en
+++ b/tests/test_typing/bad/err2.catala_en
@@ -17,24 +17,27 @@ $ catala Typecheck
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err2.catala_en:10.43-44
-   |
-10 |   definition a equals number of (z ++ 1.1) / 2
-   |                                            ^
-   +
+┌─⯈ tests/test_typing/bad/err2.catala_en:10.43-44
+└──┐
+   │
+10 │   definition a equals number of (z ++ 1.1) / 2
+   │                                            ‾
+
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err2.catala_en:10.43-44
-   |
-10 |   definition a equals number of (z ++ 1.1) / 2
-   |                                            ^
-   +
+┌─⯈ tests/test_typing/bad/err2.catala_en:10.43-44
+└──┐
+   │
+10 │   definition a equals number of (z ++ 1.1) / 2
+   │                                            ‾
+
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en:15.19-26
-   |
-15 |   output a content decimal
-   |                    ^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:15.19-26
+└──┐
+   │
+15 │   output a content decimal
+   │                    ‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err3.catala_en
+++ b/tests/test_typing/bad/err3.catala_en
@@ -17,25 +17,28 @@ $ catala Typecheck
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err3.catala_en:10.41-42
-   |
-10 |   definition a equals number of (z ++ z) / 2
-   |                                          ^
-   +
+┌─⯈ tests/test_typing/bad/err3.catala_en:10.41-42
+└──┐
+   │
+10 │   definition a equals number of (z ++ z) / 2
+   │                                          ‾
+
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err3.catala_en:10.41-42
-   |
-10 |   definition a equals number of (z ++ z) / 2
-   |                                          ^
-   +
+┌─⯈ tests/test_typing/bad/err3.catala_en:10.41-42
+└──┐
+   │
+10 │   definition a equals number of (z ++ z) / 2
+   │                                          ‾
+
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en:15.19-26
-   |
-15 |   output a content decimal
-   |                    ^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:15.19-26
+└──┐
+   │
+15 │   output a content decimal
+   │                    ‾‾‾‾‾‾‾
+
 #return code 255#
 ```
 
@@ -48,24 +51,27 @@ $ catala ocaml
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err3.catala_en:10.41-42
-   |
-10 |   definition a equals number of (z ++ z) / 2
-   |                                          ^
-   +
+┌─⯈ tests/test_typing/bad/err3.catala_en:10.41-42
+└──┐
+   │
+10 │   definition a equals number of (z ++ z) / 2
+   │                                          ‾
+
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err3.catala_en:10.41-42
-   |
-10 |   definition a equals number of (z ++ z) / 2
-   |                                          ^
-   +
+┌─⯈ tests/test_typing/bad/err3.catala_en:10.41-42
+└──┐
+   │
+10 │   definition a equals number of (z ++ z) / 2
+   │                                          ‾
+
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en:15.19-26
-   |
-15 |   output a content decimal
-   |                    ^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:15.19-26
+└──┐
+   │
+15 │   output a content decimal
+   │                    ‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err3.catala_en
+++ b/tests/test_typing/bad/err3.catala_en
@@ -17,21 +17,21 @@ $ catala Typecheck
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err3.catala_en
+  --> tests/test_typing/bad/err3.catala_en:10.41-42
    |
 10 |   definition a equals number of (z ++ z) / 2
    |                                          ^
    +
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err3.catala_en
+  --> tests/test_typing/bad/err3.catala_en:10.41-42
    |
 10 |   definition a equals number of (z ++ z) / 2
    |                                          ^
    +
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:15.19-26
    |
 15 |   output a content decimal
    |                    ^^^^^^^
@@ -48,21 +48,21 @@ $ catala ocaml
 --> decimal
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err3.catala_en
+  --> tests/test_typing/bad/err3.catala_en:10.41-42
    |
 10 |   definition a equals number of (z ++ z) / 2
    |                                          ^
    +
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/err3.catala_en
+  --> tests/test_typing/bad/err3.catala_en:10.41-42
    |
 10 |   definition a equals number of (z ++ z) / 2
    |                                          ^
    +
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:15.19-26
    |
 15 |   output a content decimal
    |                    ^^^^^^^

--- a/tests/test_typing/bad/err4.catala_en
+++ b/tests/test_typing/bad/err4.catala_en
@@ -15,21 +15,21 @@ $ catala ocaml
 --> Structure
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err4.catala_en
+ --> tests/test_typing/bad/err4.catala_en:5.24-37
   |
 5 |   definition z equals [ Int content x ]
   |                         ^^^^^^^^^^^^^
   +
 
 Type Enum coming from expression:
- --> tests/test_typing/bad/err4.catala_en
+ --> tests/test_typing/bad/err4.catala_en:5.24-37
   |
 5 |   definition z equals [ Int content x ]
   |                         ^^^^^^^^^^^^^
   +
 
 Type Structure coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:14.30-39
    |
 14 |   output z content collection Structure
    |                               ^^^^^^^^^

--- a/tests/test_typing/bad/err4.catala_en
+++ b/tests/test_typing/bad/err4.catala_en
@@ -15,24 +15,27 @@ $ catala ocaml
 --> Structure
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err4.catala_en:5.24-37
-  |
-5 |   definition z equals [ Int content x ]
-  |                         ^^^^^^^^^^^^^
-  +
+┌─⯈ tests/test_typing/bad/err4.catala_en:5.24-37
+└─┐
+  │
+5 │   definition z equals [ Int content x ]
+  │                         ‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Type Enum coming from expression:
- --> tests/test_typing/bad/err4.catala_en:5.24-37
-  |
-5 |   definition z equals [ Int content x ]
-  |                         ^^^^^^^^^^^^^
-  +
+┌─⯈ tests/test_typing/bad/err4.catala_en:5.24-37
+└─┐
+  │
+5 │   definition z equals [ Int content x ]
+  │                         ‾‾‾‾‾‾‾‾‾‾‾‾‾
+
 
 Type Structure coming from expression:
-  --> tests/test_typing/bad/common.catala_en:14.30-39
-   |
-14 |   output z content collection Structure
-   |                               ^^^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:14.30-39
+└──┐
+   │
+14 │   output z content collection Structure
+   │                               ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err5.catala_en
+++ b/tests/test_typing/bad/err5.catala_en
@@ -17,24 +17,27 @@ $ catala Typecheck
 --> Structure
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err5.catala_en:8.4-8
-  |
-8 |     1040
-  |     ^^^^
-  +
+┌─⯈ tests/test_typing/bad/err5.catala_en:8.4-8
+└─┐
+  │
+8 │     1040
+  │     ‾‾‾‾
+
 
 Type integer coming from expression:
- --> tests/test_typing/bad/err5.catala_en:8.4-8
-  |
-8 |     1040
-  |     ^^^^
-  +
+┌─⯈ tests/test_typing/bad/err5.catala_en:8.4-8
+└─┐
+  │
+8 │     1040
+  │     ‾‾‾‾
+
 
 Type Structure coming from expression:
-  --> tests/test_typing/bad/common.catala_en:14.30-39
-   |
-14 |   output z content collection Structure
-   |                               ^^^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:14.30-39
+└──┐
+   │
+14 │   output z content collection Structure
+   │                               ‾‾‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err5.catala_en
+++ b/tests/test_typing/bad/err5.catala_en
@@ -17,21 +17,21 @@ $ catala Typecheck
 --> Structure
 
 Error coming from typechecking the following expression:
- --> tests/test_typing/bad/err5.catala_en
+ --> tests/test_typing/bad/err5.catala_en:8.4-8
   |
 8 |     1040
   |     ^^^^
   +
 
 Type integer coming from expression:
- --> tests/test_typing/bad/err5.catala_en
+ --> tests/test_typing/bad/err5.catala_en:8.4-8
   |
 8 |     1040
   |     ^^^^
   +
 
 Type Structure coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:14.30-39
    |
 14 |   output z content collection Structure
    |                               ^^^^^^^^^

--- a/tests/test_typing/bad/err6.catala_en
+++ b/tests/test_typing/bad/err6.catala_en
@@ -33,24 +33,27 @@ $ catala ocaml
 --> integer
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err6.catala_en:20.26-29
-   |
-20 |   definition sub.x equals 44.
-   |                           ^^^
-   +
+┌─⯈ tests/test_typing/bad/err6.catala_en:20.26-29
+└──┐
+   │
+20 │   definition sub.x equals 44.
+   │                           ‾‾‾
+
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/err6.catala_en:20.26-29
-   |
-20 |   definition sub.x equals 44.
-   |                           ^^^
-   +
+┌─⯈ tests/test_typing/bad/err6.catala_en:20.26-29
+└──┐
+   │
+20 │   definition sub.x equals 44.
+   │                           ‾‾‾
+
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/common.catala_en:12.18-25
-   |
-12 |   input x content integer
-   |                   ^^^^^^^
-   +
+┌─⯈ tests/test_typing/bad/common.catala_en:12.18-25
+└──┐
+   │
+12 │   input x content integer
+   │                   ‾‾‾‾‾‾‾
+
 #return code 255#
 ```

--- a/tests/test_typing/bad/err6.catala_en
+++ b/tests/test_typing/bad/err6.catala_en
@@ -33,21 +33,21 @@ $ catala ocaml
 --> integer
 
 Error coming from typechecking the following expression:
-  --> tests/test_typing/bad/err6.catala_en
+  --> tests/test_typing/bad/err6.catala_en:20.26-29
    |
 20 |   definition sub.x equals 44.
    |                           ^^^
    +
 
 Type decimal coming from expression:
-  --> tests/test_typing/bad/err6.catala_en
+  --> tests/test_typing/bad/err6.catala_en:20.26-29
    |
 20 |   definition sub.x equals 44.
    |                           ^^^
    +
 
 Type integer coming from expression:
-  --> tests/test_typing/bad/common.catala_en
+  --> tests/test_typing/bad/common.catala_en:12.18-25
    |
 12 |   input x content integer
    |                   ^^^^^^^

--- a/tests/test_variable_state/bad/def_no_state.catala_en
+++ b/tests/test_variable_state/bad/def_no_state.catala_en
@@ -14,14 +14,14 @@ scope A:
 $ catala Typecheck 
 [ERROR] This definition does not indicate which state has to be considered for variable foo.
 
-  --> tests/test_variable_state/bad/def_no_state.catala_en
+  --> tests/test_variable_state/bad/def_no_state.catala_en:10.13-16
    |
 10 |   definition foo equals 2
    |              ^^^
    + Test
 
 Variable declaration:
- --> tests/test_variable_state/bad/def_no_state.catala_en
+ --> tests/test_variable_state/bad/def_no_state.catala_en:5.9-12
   |
 5 |   output foo content integer
   |          ^^^

--- a/tests/test_variable_state/bad/def_no_state.catala_en
+++ b/tests/test_variable_state/bad/def_no_state.catala_en
@@ -14,17 +14,19 @@ scope A:
 $ catala Typecheck 
 [ERROR] This definition does not indicate which state has to be considered for variable foo.
 
-  --> tests/test_variable_state/bad/def_no_state.catala_en:10.13-16
-   |
-10 |   definition foo equals 2
-   |              ^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/def_no_state.catala_en:10.13-16
+└──┐
+   │
+10 │   definition foo equals 2
+   │              ‾‾‾
+   └─ Test
 
 Variable declaration:
- --> tests/test_variable_state/bad/def_no_state.catala_en:5.9-12
-  |
-5 |   output foo content integer
-  |          ^^^
-  + Test
+┌─⯈ tests/test_variable_state/bad/def_no_state.catala_en:5.9-12
+└─┐
+  │
+5 │   output foo content integer
+  │          ‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_variable_state/bad/no_cross_exceptions.catala_en
+++ b/tests/test_variable_state/bad/no_cross_exceptions.catala_en
@@ -18,7 +18,7 @@ scope A:
 $ catala Typecheck 
 [ERROR] Unknown label for the scope variable foo.baz: "thing"
 
-  --> tests/test_variable_state/bad/no_cross_exceptions.catala_en
+  --> tests/test_variable_state/bad/no_cross_exceptions.catala_en:14.12-17
    |
 14 |   exception thing definition foo state baz under condition true consequence equals 3
    |             ^^^^^

--- a/tests/test_variable_state/bad/no_cross_exceptions.catala_en
+++ b/tests/test_variable_state/bad/no_cross_exceptions.catala_en
@@ -18,10 +18,11 @@ scope A:
 $ catala Typecheck 
 [ERROR] Unknown label for the scope variable foo.baz: "thing"
 
-  --> tests/test_variable_state/bad/no_cross_exceptions.catala_en:14.12-17
-   |
-14 |   exception thing definition foo state baz under condition true consequence equals 3
-   |             ^^^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/no_cross_exceptions.catala_en:14.12-17
+└──┐
+   │
+14 │   exception thing definition foo state baz under condition true consequence equals 3
+   │             ‾‾‾‾‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_variable_state/bad/self_reference_first_state.catala_en
+++ b/tests/test_variable_state/bad/self_reference_first_state.catala_en
@@ -16,10 +16,11 @@ scope A:
 $ catala Typecheck 
 [ERROR] It is impossible to refer to the variable you are defining when defining its first state.
 
-  --> tests/test_variable_state/bad/self_reference_first_state.catala_en:10.34-37
-   |
-10 |   definition foo state bar equals foo + 1
-   |                                   ^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/self_reference_first_state.catala_en:10.34-37
+└──┐
+   │
+10 │   definition foo state bar equals foo + 1
+   │                                   ‾‾‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_variable_state/bad/self_reference_first_state.catala_en
+++ b/tests/test_variable_state/bad/self_reference_first_state.catala_en
@@ -16,7 +16,7 @@ scope A:
 $ catala Typecheck 
 [ERROR] It is impossible to refer to the variable you are defining when defining its first state.
 
-  --> tests/test_variable_state/bad/self_reference_first_state.catala_en
+  --> tests/test_variable_state/bad/self_reference_first_state.catala_en:10.34-37
    |
 10 |   definition foo state bar equals foo + 1
    |                                   ^^^

--- a/tests/test_variable_state/bad/state_cycle.catala_en
+++ b/tests/test_variable_state/bad/state_cycle.catala_en
@@ -24,59 +24,67 @@ $ catala Typecheck
 [ERROR] Cyclic dependency detected between variables of scope A!
 
 Cycle variable foofoo.bar, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en:9.10-13
-  |
-9 |     state bar
-  |           ^^^
-  + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:9.10-13
+└─┐
+  │
+9 │     state bar
+  │           ‾‾‾
+  └─ Test
 
 Used here in the definition of another cycle variable foofoo.baz:
-  --> tests/test_variable_state/bad/state_cycle.catala_en:19.37-43
-   |
-19 |   definition foofoo state baz equals foofoo + 1
-   |                                      ^^^^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:19.37-43
+└──┐
+   │
+19 │   definition foofoo state baz equals foofoo + 1
+   │                                      ‾‾‾‾‾‾
+   └─ Test
 
 Cycle variable foofoo.baz, declared:
-  --> tests/test_variable_state/bad/state_cycle.catala_en:10.10-13
-   |
-10 |     state baz
-   |           ^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:10.10-13
+└──┐
+   │
+10 │     state baz
+   │           ‾‾‾
+   └─ Test
 
 Used here in the definition of another cycle variable foo.bar:
-  --> tests/test_variable_state/bad/state_cycle.catala_en:13.34-40
-   |
-13 |   definition foo state bar equals foofoo
-   |                                   ^^^^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:13.34-40
+└──┐
+   │
+13 │   definition foo state bar equals foofoo
+   │                                   ‾‾‾‾‾‾
+   └─ Test
 
 Cycle variable foo.bar, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en:6.10-13
-  |
-6 |     state bar
-  |           ^^^
-  + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:6.10-13
+└─┐
+  │
+6 │     state bar
+  │           ‾‾‾
+  └─ Test
 
 Used here in the definition of another cycle variable foo.baz:
-  --> tests/test_variable_state/bad/state_cycle.catala_en:15.34-37
-   |
-15 |   definition foo state baz equals foo + 1
-   |                                   ^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:15.34-37
+└──┐
+   │
+15 │   definition foo state baz equals foo + 1
+   │                                   ‾‾‾
+   └─ Test
 
 Cycle variable foo.baz, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en:7.10-13
-  |
-7 |     state baz
-  |           ^^^
-  + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:7.10-13
+└─┐
+  │
+7 │     state baz
+  │           ‾‾‾
+  └─ Test
 
 Used here in the definition of another cycle variable foofoo.bar:
-  --> tests/test_variable_state/bad/state_cycle.catala_en:17.37-40
-   |
-17 |   definition foofoo state bar equals foo
-   |                                      ^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/state_cycle.catala_en:17.37-40
+└──┐
+   │
+17 │   definition foofoo state bar equals foo
+   │                                      ‾‾‾
+   └─ Test
 #return code 255#
 ```

--- a/tests/test_variable_state/bad/state_cycle.catala_en
+++ b/tests/test_variable_state/bad/state_cycle.catala_en
@@ -24,56 +24,56 @@ $ catala Typecheck
 [ERROR] Cyclic dependency detected between variables of scope A!
 
 Cycle variable foofoo.bar, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en
+ --> tests/test_variable_state/bad/state_cycle.catala_en:9.10-13
   |
 9 |     state bar
   |           ^^^
   + Test
 
 Used here in the definition of another cycle variable foofoo.baz:
-  --> tests/test_variable_state/bad/state_cycle.catala_en
+  --> tests/test_variable_state/bad/state_cycle.catala_en:19.37-43
    |
 19 |   definition foofoo state baz equals foofoo + 1
    |                                      ^^^^^^
    + Test
 
 Cycle variable foofoo.baz, declared:
-  --> tests/test_variable_state/bad/state_cycle.catala_en
+  --> tests/test_variable_state/bad/state_cycle.catala_en:10.10-13
    |
 10 |     state baz
    |           ^^^
    + Test
 
 Used here in the definition of another cycle variable foo.bar:
-  --> tests/test_variable_state/bad/state_cycle.catala_en
+  --> tests/test_variable_state/bad/state_cycle.catala_en:13.34-40
    |
 13 |   definition foo state bar equals foofoo
    |                                   ^^^^^^
    + Test
 
 Cycle variable foo.bar, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en
+ --> tests/test_variable_state/bad/state_cycle.catala_en:6.10-13
   |
 6 |     state bar
   |           ^^^
   + Test
 
 Used here in the definition of another cycle variable foo.baz:
-  --> tests/test_variable_state/bad/state_cycle.catala_en
+  --> tests/test_variable_state/bad/state_cycle.catala_en:15.34-37
    |
 15 |   definition foo state baz equals foo + 1
    |                                   ^^^
    + Test
 
 Cycle variable foo.baz, declared:
- --> tests/test_variable_state/bad/state_cycle.catala_en
+ --> tests/test_variable_state/bad/state_cycle.catala_en:7.10-13
   |
 7 |     state baz
   |           ^^^
   + Test
 
 Used here in the definition of another cycle variable foofoo.bar:
-  --> tests/test_variable_state/bad/state_cycle.catala_en
+  --> tests/test_variable_state/bad/state_cycle.catala_en:17.37-40
    |
 17 |   definition foofoo state bar equals foo
    |                                      ^^^

--- a/tests/test_variable_state/bad/unknown_state.catala_en
+++ b/tests/test_variable_state/bad/unknown_state.catala_en
@@ -16,17 +16,19 @@ scope A:
 $ catala Typecheck 
 [ERROR] This identifier is not a state declared for variable foo.
 
-  --> tests/test_variable_state/bad/unknown_state.catala_en:12.23-27
-   |
-12 |   definition foo state basz equals foo + 1
-   |                        ^^^^
-   + Test
+┌─⯈ tests/test_variable_state/bad/unknown_state.catala_en:12.23-27
+└──┐
+   │
+12 │   definition foo state basz equals foo + 1
+   │                        ‾‾‾‾
+   └─ Test
 
 Variable declaration:
- --> tests/test_variable_state/bad/unknown_state.catala_en:5.9-12
-  |
-5 |   output foo content integer
-  |          ^^^
-  + Test
+┌─⯈ tests/test_variable_state/bad/unknown_state.catala_en:5.9-12
+└─┐
+  │
+5 │   output foo content integer
+  │          ‾‾‾
+  └─ Test
 #return code 255#
 ```

--- a/tests/test_variable_state/bad/unknown_state.catala_en
+++ b/tests/test_variable_state/bad/unknown_state.catala_en
@@ -16,14 +16,14 @@ scope A:
 $ catala Typecheck 
 [ERROR] This identifier is not a state declared for variable foo.
 
-  --> tests/test_variable_state/bad/unknown_state.catala_en
+  --> tests/test_variable_state/bad/unknown_state.catala_en:12.23-27
    |
 12 |   definition foo state basz equals foo + 1
    |                        ^^^^
    + Test
 
 Variable declaration:
- --> tests/test_variable_state/bad/unknown_state.catala_en
+ --> tests/test_variable_state/bad/unknown_state.catala_en:5.9-12
   |
 5 |   output foo content integer
   |          ^^^


### PR DESCRIPTION
(this is low priority, but since I have it laying around better post it)

* Adds parseable positions to error messages (handy to make them clickable in emacs¹)
* Avoids trailing whitespaces
* Uses some fancy unicode chars for outlines