### PR TITLE
Uniformise naming of conversion modules across compilation passes

### DIFF
--- a/compiler/dcalc/dune
+++ b/compiler/dcalc/dune
@@ -1,7 +1,15 @@
 (library
  (name dcalc)
  (public_name catala.dcalc)
- (libraries bindlib unionFind utils re ubase catala.runtime_ocaml shared_ast)
+ (libraries
+  bindlib
+  unionFind
+  utils
+  re
+  ubase
+  catala.runtime_ocaml
+  shared_ast
+  scopelang)
  (preprocess
   (pps visitors.ppx)))
 

--- a/compiler/dcalc/from_scopelang.mli
+++ b/compiler/dcalc/from_scopelang.mli
@@ -1,7 +1,6 @@
 (* This file is part of the Catala compiler, a specification language for tax
    and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
-   Nicolas Chataing <nicolas.chataing@ens.fr> Denis Merigoux
-   <denis.merigoux@inria.fr>
+   Denis Merigoux <denis.merigoux@inria.fr>
 
    Licensed under the Apache License, Version 2.0 (the "License"); you may not
    use this file except in compliance with the License. You may obtain a copy of
@@ -15,11 +14,6 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Translation from {!module: Surface.Ast} to {!module: Desugared.Ast}.
+(** Scope language to default calculus translator *)
 
-    - Removes syntactic sugars
-    - Separate code from legislation *)
-
-val desugar_program :
-  Name_resolution.context -> Ast.program -> Desugared.Ast.program
-(** Main function of this module *)
+val translate_program : 'm Scopelang.Ast.program -> 'm Ast.program

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -21,20 +21,6 @@ open Shared_ast
 
 (** {1 Names, Maps and Keys} *)
 
-module IdentMap : Map.S with type key = String.t = Map.Make (String)
-
-module RuleName : Uid.Id with type info = Uid.MarkedString.info =
-  Uid.Make (Uid.MarkedString) ()
-
-module RuleMap : Map.S with type key = RuleName.t = Map.Make (RuleName)
-module RuleSet : Set.S with type elt = RuleName.t = Set.Make (RuleName)
-
-module LabelName : Uid.Id with type info = Uid.MarkedString.info =
-  Uid.Make (Uid.MarkedString) ()
-
-module LabelMap : Map.S with type key = LabelName.t = Map.Make (LabelName)
-module LabelSet : Set.S with type elt = LabelName.t = Set.Make (LabelName)
-
 (** Inside a scope, a definition can refer either to a scope def, or a subscope
     def *)
 module ScopeDef = struct
@@ -102,6 +88,9 @@ module ExprMap = Map.Make (struct
 
   let compare = Expr.compare
 end)
+
+type io_input = NoInput | OnlyInput | Reentrant
+type io = { io_output : bool Marked.pos; io_input : io_input Marked.pos }
 
 type exception_situation =
   | BaseCase
@@ -192,7 +181,7 @@ type scope_def = {
   scope_def_rules : rule RuleMap.t;
   scope_def_typ : typ;
   scope_def_is_condition : bool;
-  scope_def_io : Scopelang.Ast.io;
+  scope_def_io : io;
 }
 
 type var_or_states = WholeVar | States of StateName.t list

--- a/compiler/desugared/dependency.ml
+++ b/compiler/desugared/dependency.ml
@@ -229,10 +229,10 @@ let build_scope_dependencies (scope : Ast.scope) : ScopeDependencies.t =
 (** {2 Graph declaration} *)
 
 module ExceptionVertex = struct
-  include Ast.RuleSet
+  include RuleSet
 
   let hash (x : t) : int =
-    Ast.RuleSet.fold (fun r acc -> Int.logxor (Ast.RuleName.hash r) acc) x 0
+    RuleSet.fold (fun r acc -> Int.logxor (RuleName.hash r) acc) x 0
 
   let equal x y = compare x y = 0
 end
@@ -257,13 +257,13 @@ module ExceptionsSCC = Graph.Components.Make (ExceptionsDependencies)
 (** {2 Graph computations} *)
 
 type exception_edge = {
-  label_from : Ast.LabelName.t;
-  label_to : Ast.LabelName.t;
+  label_from : LabelName.t;
+  label_to : LabelName.t;
   edge_positions : Pos.t list;
 }
 
 let build_exceptions_graph
-    (def : Ast.rule Ast.RuleMap.t)
+    (def : Ast.rule RuleMap.t)
     (def_info : Ast.ScopeDef.t) : ExceptionsDependencies.t =
   (* First we partition the definitions into groups bearing the same label. To
      handle the rules that were not labeled by the user, we create implicit
@@ -271,63 +271,57 @@ let build_exceptions_graph
 
   (* All the rules of the form [definition x ...] are base case with no explicit
      label, so they should share this implicit label. *)
-  let base_case_implicit_label =
-    Ast.LabelName.fresh ("base_case", Pos.no_pos)
-  in
+  let base_case_implicit_label = LabelName.fresh ("base_case", Pos.no_pos) in
   (* When declaring [exception definition x ...], it means there is a unique
      rule [R] to which this can be an exception to. So we give a unique label to
      all the rules that are implicitly exceptions to rule [R]. *)
-  let exception_to_rule_implicit_labels : Ast.LabelName.t Ast.RuleMap.t =
-    Ast.RuleMap.fold
+  let exception_to_rule_implicit_labels : LabelName.t RuleMap.t =
+    RuleMap.fold
       (fun _ rule_from exception_to_rule_implicit_labels ->
         match rule_from.Ast.rule_exception with
         | Ast.ExceptionToRule (rule_to, _) -> (
-          match
-            Ast.RuleMap.find_opt rule_to exception_to_rule_implicit_labels
-          with
+          match RuleMap.find_opt rule_to exception_to_rule_implicit_labels with
           | Some _ ->
             (* we already created the label *) exception_to_rule_implicit_labels
           | None ->
-            Ast.RuleMap.add rule_to
-              (Ast.LabelName.fresh
-                 ( "exception_to_"
-                   ^ Marked.unmark (Ast.RuleName.get_info rule_to),
+            RuleMap.add rule_to
+              (LabelName.fresh
+                 ( "exception_to_" ^ Marked.unmark (RuleName.get_info rule_to),
                    Pos.no_pos ))
               exception_to_rule_implicit_labels)
         | _ -> exception_to_rule_implicit_labels)
-      def Ast.RuleMap.empty
+      def RuleMap.empty
   in
   (* When declaring [exception foo_l definition x ...], the rule is exception to
      all the rules sharing label [foo_l]. So we give a unique label to all the
      rules that are implicitly exceptions to rule [foo_l]. *)
-  let exception_to_label_implicit_labels : Ast.LabelName.t Ast.LabelMap.t =
-    Ast.RuleMap.fold
+  let exception_to_label_implicit_labels : LabelName.t LabelMap.t =
+    RuleMap.fold
       (fun _ rule_from
-           (exception_to_label_implicit_labels : Ast.LabelName.t Ast.LabelMap.t) ->
+           (exception_to_label_implicit_labels : LabelName.t LabelMap.t) ->
         match rule_from.Ast.rule_exception with
         | Ast.ExceptionToLabel (label_to, _) -> (
           match
-            Ast.LabelMap.find_opt label_to exception_to_label_implicit_labels
+            LabelMap.find_opt label_to exception_to_label_implicit_labels
           with
           | Some _ ->
             (* we already created the label *)
             exception_to_label_implicit_labels
           | None ->
-            Ast.LabelMap.add label_to
-              (Ast.LabelName.fresh
-                 ( "exception_to_"
-                   ^ Marked.unmark (Ast.LabelName.get_info label_to),
+            LabelMap.add label_to
+              (LabelName.fresh
+                 ( "exception_to_" ^ Marked.unmark (LabelName.get_info label_to),
                    Pos.no_pos ))
               exception_to_label_implicit_labels)
         | _ -> exception_to_label_implicit_labels)
-      def Ast.LabelMap.empty
+      def LabelMap.empty
   in
 
   (* Now we have all the labels necessary to partition our rules into sets, each
      one corresponding to a label relating to the structure of the exception
      DAG. *)
   let label_to_rule_sets =
-    Ast.RuleMap.fold
+    RuleMap.fold
       (fun rule_name rule rule_sets ->
         let label_of_rule =
           match rule.Ast.rule_label with
@@ -336,23 +330,23 @@ let build_exceptions_graph
             match rule.Ast.rule_exception with
             | BaseCase -> base_case_implicit_label
             | ExceptionToRule (r, _) ->
-              Ast.RuleMap.find r exception_to_rule_implicit_labels
+              RuleMap.find r exception_to_rule_implicit_labels
             | ExceptionToLabel (l', _) ->
-              Ast.LabelMap.find l' exception_to_label_implicit_labels)
+              LabelMap.find l' exception_to_label_implicit_labels)
         in
-        Ast.LabelMap.update label_of_rule
+        LabelMap.update label_of_rule
           (fun rule_set ->
             match rule_set with
-            | None -> Some (Ast.RuleSet.singleton rule_name)
-            | Some rule_set -> Some (Ast.RuleSet.add rule_name rule_set))
+            | None -> Some (RuleSet.singleton rule_name)
+            | Some rule_set -> Some (RuleSet.add rule_name rule_set))
           rule_sets)
-      def Ast.LabelMap.empty
+      def LabelMap.empty
   in
-  let find_label_of_rule (r : Ast.RuleName.t) : Ast.LabelName.t =
+  let find_label_of_rule (r : RuleName.t) : LabelName.t =
     fst
-      (Ast.LabelMap.choose
-         (Ast.LabelMap.filter
-            (fun _ rule_set -> Ast.RuleSet.mem r rule_set)
+      (LabelMap.choose
+         (LabelMap.filter
+            (fun _ rule_set -> RuleSet.mem r rule_set)
             label_to_rule_sets))
   in
   (* Next, we collect the exception edges between those groups of rules referred
@@ -360,7 +354,7 @@ let build_exceptions_graph
      edges as they are declared at each rule but should be the same for all the
      rules of the same group. *)
   let exception_edges : exception_edge list =
-    Ast.RuleMap.fold
+    RuleMap.fold
       (fun rule_name rule exception_edges ->
         let label_from = find_label_of_rule rule_name in
         let label_to_and_pos =
@@ -374,16 +368,16 @@ let build_exceptions_graph
         | Some (label_to, edge_pos) -> (
           let other_edges_originating_from_same_label =
             List.filter
-              (fun edge -> Ast.LabelName.compare edge.label_from label_from = 0)
+              (fun edge -> LabelName.compare edge.label_from label_from = 0)
               exception_edges
           in
           (* We check the consistency*)
-          if Ast.LabelName.compare label_from label_to = 0 then
+          if LabelName.compare label_from label_to = 0 then
             Errors.raise_spanned_error edge_pos
               "Cannot define rule as an exception to itself";
           List.iter
             (fun edge ->
-              if Ast.LabelName.compare edge.label_to label_to <> 0 then
+              if LabelName.compare edge.label_to label_to <> 0 then
                 Errors.raise_multispanned_error
                   (( Some
                        "This declaration contradicts another exception \
@@ -401,8 +395,8 @@ let build_exceptions_graph
           let existing_edge =
             List.find_opt
               (fun edge ->
-                Ast.LabelName.compare edge.label_from label_from = 0
-                && Ast.LabelName.compare edge.label_to label_to = 0)
+                LabelName.compare edge.label_from label_from = 0
+                && LabelName.compare edge.label_to label_to = 0)
               exception_edges
           in
           match existing_edge with
@@ -420,7 +414,7 @@ let build_exceptions_graph
   in
   (* We've got the vertices and the edges, let's build the graph! *)
   let g =
-    Ast.LabelMap.fold
+    LabelMap.fold
       (fun _label rule_set g -> ExceptionsDependencies.add_vertex g rule_set)
       label_to_rule_sets ExceptionsDependencies.empty
   in
@@ -429,11 +423,9 @@ let build_exceptions_graph
     List.fold_left
       (fun g edge ->
         let rule_group_from =
-          Ast.LabelMap.find edge.label_from label_to_rule_sets
+          LabelMap.find edge.label_from label_to_rule_sets
         in
-        let rule_group_to =
-          Ast.LabelMap.find edge.label_to label_to_rule_sets
-        in
+        let rule_group_to = LabelMap.find edge.label_to label_to_rule_sets in
         let edge =
           ExceptionsDependencies.E.create rule_group_from edge.edge_positions
             rule_group_to
@@ -453,11 +445,10 @@ let check_for_exception_cycle (g : ExceptionsDependencies.t) : unit =
     let spans =
       List.flatten
         (List.map
-           (fun (vs : Ast.RuleSet.t) ->
-             let v = Ast.RuleSet.choose vs in
+           (fun (vs : RuleSet.t) ->
+             let v = RuleSet.choose vs in
              let var_str, var_info =
-               ( Format.asprintf "%a" Ast.RuleName.format_t v,
-                 Ast.RuleName.get_info v )
+               Format.asprintf "%a" RuleName.format_t v, RuleName.get_info v
              in
              let succs = ExceptionsDependencies.succ_e g vs in
              let _, edge_pos, _ =

--- a/compiler/desugared/dependency.mli
+++ b/compiler/desugared/dependency.mli
@@ -18,6 +18,7 @@
     OCamlgraph} *)
 
 open Utils
+open Shared_ast
 
 (** {1 Scope variables dependency graph} *)
 
@@ -71,9 +72,9 @@ val build_scope_dependencies : Ast.scope -> ScopeDependencies.t
 module EdgeExceptions : Graph.Sig.ORDERED_TYPE_DFT with type t = Pos.t list
 
 module ExceptionsDependencies :
-  Graph.Sig.P with type V.t = Ast.RuleSet.t and type E.label = EdgeExceptions.t
+  Graph.Sig.P with type V.t = RuleSet.t and type E.label = EdgeExceptions.t
 
 val build_exceptions_graph :
-  Ast.rule Ast.RuleMap.t -> Ast.ScopeDef.t -> ExceptionsDependencies.t
+  Ast.rule RuleMap.t -> Ast.ScopeDef.t -> ExceptionsDependencies.t
 
 val check_for_exception_cycle : ExceptionsDependencies.t -> unit

--- a/compiler/desugared/dune
+++ b/compiler/desugared/dune
@@ -1,7 +1,7 @@
 (library
  (name desugared)
  (public_name catala.desugared)
- (libraries utils dcalc scopelang ocamlgraph))
+ (libraries ocamlgraph utils shared_ast surface))
 
 (documentation
  (package catala)

--- a/compiler/desugared/from_surface.mli
+++ b/compiler/desugared/from_surface.mli
@@ -1,0 +1,25 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
+   Nicolas Chataing <nicolas.chataing@ens.fr> Denis Merigoux
+   <denis.merigoux@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+(** Translation from {!module: Surface.Ast} to {!module: Desugared.Ast}.
+
+    - Removes syntactic sugars
+    - Separate code from legislation *)
+
+val translate_program :
+  Name_resolution.context -> Surface.Ast.program -> Ast.program
+(** Main function of this module *)

--- a/compiler/lcalc/from_dcalc.ml
+++ b/compiler/lcalc/from_dcalc.ml
@@ -1,0 +1,21 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
+   Denis Merigoux <denis.merigoux@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+let translate_program_with_exceptions =
+  Compile_with_exceptions.translate_program
+
+let translate_program_without_exceptions =
+  Compile_without_exceptions.translate_program

--- a/compiler/lcalc/from_dcalc.mli
+++ b/compiler/lcalc/from_dcalc.mli
@@ -14,6 +14,13 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Scope language to default calculus translator *)
+val translate_program_with_exceptions : 'm Dcalc.Ast.program -> 'm Ast.program
+(** Translation from the default calculus to the lambda calculus. This
+    translation uses exceptions to handle empty default terms. *)
 
-val translate_program : 'm Ast.program -> 'm Dcalc.Ast.program
+val translate_program_without_exceptions :
+  'm Dcalc.Ast.program -> 'm Ast.program
+(** Translation from the default calculus to the lambda calculus. This
+    translation uses an option monad to handle empty defaults terms. This
+    transformation is one piece to permit to compile toward legacy languages
+    that does not contains exceptions. *)

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -39,17 +39,14 @@ let rec locations_used (e : 'm expr) : LocationSet.t =
       (fun e -> LocationSet.union (locations_used e))
       e LocationSet.empty
 
-type io_input = NoInput | OnlyInput | Reentrant
-type io = { io_output : bool Marked.pos; io_input : io_input Marked.pos }
-
 type 'm rule =
-  | Definition of location Marked.pos * typ * io * 'm expr
+  | Definition of location Marked.pos * typ * Desugared.Ast.io * 'm expr
   | Assertion of 'm expr
   | Call of ScopeName.t * SubScopeName.t * 'm mark
 
 type 'm scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (typ * io) ScopeVarMap.t;
+  scope_sig : (typ * Desugared.Ast.io) ScopeVarMap.t;
   scope_decl_rules : 'm rule list;
   scope_mark : 'm mark;
 }

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -31,35 +31,14 @@ type 'm expr = (scopelang, 'm mark) gexpr
 
 val locations_used : 'm expr -> LocationSet.t
 
-(** This type characterizes the three levels of visibility for a given scope
-    variable with regards to the scope's input and possible redefinitions inside
-    the scope.. *)
-type io_input =
-  | NoInput
-      (** For an internal variable defined only in the scope, and does not
-          appear in the input. *)
-  | OnlyInput
-      (** For variables that should not be redefined in the scope, because they
-          appear in the input. *)
-  | Reentrant
-      (** For variables defined in the scope that can also be redefined by the
-          caller as they appear in the input. *)
-
-type io = {
-  io_output : bool Marked.pos;
-      (** [true] is present in the output of the scope. *)
-  io_input : io_input Marked.pos;
-}
-(** Characterization of the input/output status of a scope variable. *)
-
 type 'm rule =
-  | Definition of location Marked.pos * typ * io * 'm expr
+  | Definition of location Marked.pos * typ * Desugared.Ast.io * 'm expr
   | Assertion of 'm expr
   | Call of ScopeName.t * SubScopeName.t * 'm mark
 
 type 'm scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (typ * io) ScopeVarMap.t;
+  scope_sig : (typ * Desugared.Ast.io) ScopeVarMap.t;
   scope_decl_rules : 'm rule list;
   scope_mark : 'm mark;
 }

--- a/compiler/scopelang/dune
+++ b/compiler/scopelang/dune
@@ -1,7 +1,7 @@
 (library
  (name scopelang)
  (public_name catala.scopelang)
- (libraries utils dcalc ocamlgraph)
+ (libraries utils ocamlgraph desugared)
  (flags
   (:standard -short-paths)))
 

--- a/compiler/scopelang/from_desugared.mli
+++ b/compiler/scopelang/from_desugared.mli
@@ -16,4 +16,4 @@
 
 (** Translation from {!module: Desugared.Ast} to {!module: Scopelang.Ast} *)
 
-val translate_program : Ast.program -> Shared_ast.untyped Scopelang.Ast.program
+val translate_program : Desugared.Ast.program -> Shared_ast.untyped Ast.program

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -56,11 +56,11 @@ let scope ?(debug = false) ctx fmt (name, decl) =
          Format.fprintf fmt "%a%a%a %a%a%a%a%a" Print.punctuation "("
            ScopeVar.format_t scope_var Print.punctuation ":" (Print.typ ctx) typ
            Print.punctuation "|" Print.keyword
-           (match Marked.unmark vis.io_input with
+           (match Marked.unmark vis.Desugared.Ast.io_input with
            | NoInput -> "internal"
            | OnlyInput -> "input"
            | Reentrant -> "context")
-           (if Marked.unmark vis.io_output then fun fmt () ->
+           (if Marked.unmark vis.Desugared.Ast.io_output then fun fmt () ->
             Format.fprintf fmt "%a@,%a" Print.punctuation "|" Print.keyword
               "output"
            else fun fmt () -> Format.fprintf fmt "@<0>")

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -45,6 +45,20 @@ module EnumConstructor : Uid.Id with type info = Uid.MarkedString.info =
 
 module EnumMap : Map.S with type key = EnumName.t = Map.Make (EnumName)
 
+(** Only used by surface *)
+
+module RuleName : Uid.Id with type info = Uid.MarkedString.info =
+  Uid.Make (Uid.MarkedString) ()
+
+module RuleMap : Map.S with type key = RuleName.t = Map.Make (RuleName)
+module RuleSet : Set.S with type elt = RuleName.t = Set.Make (RuleName)
+
+module LabelName : Uid.Id with type info = Uid.MarkedString.info =
+  Uid.Make (Uid.MarkedString) ()
+
+module LabelMap : Map.S with type key = LabelName.t = Map.Make (LabelName)
+module LabelSet : Set.S with type elt = LabelName.t = Set.Make (LabelName)
+
 (** Only used by desugared/scopelang *)
 
 module ScopeVar : Uid.Id with type info = Uid.MarkedString.info =

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -493,7 +493,7 @@ type rule = {
   rule_parameter : ident Marked.pos option;
   rule_condition : expression Marked.pos option;
   rule_name : qident Marked.pos;
-  rule_id : Desugared.Ast.RuleName.t; [@opaque]
+  rule_id : Shared_ast.RuleName.t; [@opaque]
   rule_consequence : (bool[@opaque]) Marked.pos;
   rule_state : ident Marked.pos option;
 }
@@ -517,7 +517,7 @@ type definition = {
   definition_name : qident Marked.pos;
   definition_parameter : ident Marked.pos option;
   definition_condition : expression Marked.pos option;
-  definition_id : Desugared.Ast.RuleName.t; [@opaque]
+  definition_id : Shared_ast.RuleName.t; [@opaque]
   definition_expr : expression Marked.pos;
   definition_state : ident Marked.pos option;
 }

--- a/compiler/surface/dune
+++ b/compiler/surface/dune
@@ -6,11 +6,10 @@
   menhirLib
   sedlex
   re
-  desugared
-  scopelang
   zarith
   zarith_stubs_js
-  dates_calc)
+  dates_calc
+  shared_ast)
  (preprocess
   (pps sedlex.ppx visitors.ppx)))
 

--- a/compiler/surface/parser.mly
+++ b/compiler/surface/parser.mly
@@ -392,7 +392,7 @@ rule:
       rule_parameter = param_applied;
       rule_condition = cond;
       rule_name = name;
-      rule_id = Desugared.Ast.RuleName.fresh
+      rule_id = Shared_ast.RuleName.fresh
         (String.concat "." (List.map (fun i -> Marked.unmark i) (Marked.unmark name)),
           Pos.from_lpos $sloc);
       rule_consequence = cons;
@@ -429,7 +429,7 @@ definition:
       definition_parameter = param;
       definition_condition = cond;
       definition_id =
-        Desugared.Ast.RuleName.fresh
+        Shared_ast.RuleName.fresh
           (String.concat "." (List.map (fun i -> Marked.unmark i) (Marked.unmark name)),
             Pos.from_lpos $sloc);
       definition_expr = e;


### PR DESCRIPTION
This is just a proposal for an administrative renaming across libraries encoding the passes of the compiler. There should be no functional changes.

Basically, each pass defines its library with an `Ast` module, but translations used to be defined either as `from_*` for some (`Lcalc.From_dcalc`) and `to_*` for some others (`Scopelang.To_dcalc`). Besides, naming was diverse (`Desugared.Desugaring.desugar_program`).

Now that we are less constrained by mutual dependencies (common definitions being gatherd in the `Shared_ast` lib), this patch proposes to uniformise all passes with `PassB.From_passA.translate_program` modules and functions. It also implies that every pass only depends on the previous one, which results in a more pleasant dependency order.

~~Note: based on top of #356 for now, see [the actual diff](https://github.com/AltGr/catala/compare/struct-maps...CatalaLang:catala:uniform-pass?expand=1)~~