### PR TITLE
Updates the specified repo for pandoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM ocamlpro/ocaml:4.14-2022-07-17 AS dev-build-context
 
 # pandoc is not in alpine stable yet, install it manually with an explicit repository
-RUN sudo apk add pandoc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/
+RUN sudo apk add pandoc --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community/
 
 RUN mkdir catala
 WORKDIR catala


### PR DESCRIPTION
The `pandoc` package can no longer be found in the `testing` repo and is now located in the `community` repo.

Omitting the `--repository` option throws an error that the `pandoc` package cannot be found, so this option appears to still be required.

Signed-off-by: zach wick <zach@zachwick.com>