### PR TITLE
Install Catala plugins

### DIFF
--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -890,10 +890,18 @@ let driver
     let files_or_folders = List.sort_uniq String.compare files_or_folders
     and catala_exe = Option.fold ~none:"catala" ~some:Fun.id catala_exe
     and catala_opts = Option.fold ~none:"" ~some:Fun.id catala_opts
-    and ninja_output =
-      Option.fold
-        ~none:(Filename.temp_file "clerk_build_" ".ninja")
-        ~some:Fun.id ninja_output
+    and with_ninja_output k =
+      match ninja_output with
+      | Some f -> k f
+      | None -> (
+        let f = Filename.temp_file "clerk_build_" ".ninja" in
+        match k f with
+        | exception e ->
+          if not debug then Sys.remove f;
+          raise e
+        | r ->
+          Sys.remove f;
+          r)
     in
     match String.lowercase_ascii command with
     | "test" -> (
@@ -919,20 +927,22 @@ let driver
       if 0 = List.compare_lengths ctx.all_failed_names files_or_folders then
         return_ok
       else
-        try
-          File.with_formatter_of_file ninja_output (fun fmt ->
-              Cli.debug_print "writing %s..." ninja_output;
+        with_ninja_output
+        @@ fun nin ->
+        match
+          File.with_formatter_of_file nin (fun fmt ->
+              Cli.debug_print "writing %s..." nin;
               Nj.format fmt
                 (add_root_test_build ninja ctx.all_file_names
-                   ctx.all_test_builds));
+                   ctx.all_test_builds))
+        with
+        | () ->
           let ninja_cmd =
-            "ninja -k 0 -f " ^ ninja_output ^ " " ^ ninja_flags ^ " test"
+            "ninja -k 0 -f " ^ nin ^ " " ^ ninja_flags ^ " test"
           in
           Cli.debug_print "executing '%s'..." ninja_cmd;
-          let return = Sys.command ninja_cmd in
-          if not debug then Sys.remove ninja_output;
-          return
-        with Sys_error e ->
+          Sys.command ninja_cmd
+        | exception Sys_error e ->
           Cli.error_print "can not write in %s" e;
           return_err)
     | "run" -> (

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -172,7 +172,7 @@ let plugins_dirs =
   let default =
     let ( / ) = Filename.concat in
     [
-      Sys.executable_name
+      Filename.dirname Sys.executable_name
       / Filename.parent_dir_name
       / "lib"
       / "catala"

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -73,7 +73,15 @@ let driver source_file (options : Cli.options) : int =
         try `Plugin (Plugin.find s)
         with Not_found ->
           Errors.raise_error
-            "The selected backend (%s) is not supported by Catala" backend)
+            "The selected backend (%s) is not supported by Catala, nor was a \
+             plugin by this name found under %a"
+            backend
+            (Format.pp_print_list
+               ~pp_sep:(fun ppf () -> Format.fprintf ppf "@ or @ ")
+               (fun ppf dir ->
+                 Format.pp_print_string ppf
+                   (try Unix.readlink dir with _ -> dir)))
+            options.plugins_dirs)
     in
     let prgm =
       Surface.Parser_driver.parse_top_level_file source_file language

--- a/compiler/plugin.ml
+++ b/compiler/plugin.ml
@@ -58,12 +58,16 @@ let load_file f =
     Errors.format_warning "Could not load plugin %S: %s" f
       (Printexc.to_string e)
 
-let load_dir d =
+let rec load_dir d =
   let dynlink_exts =
     if Dynlink.is_native then [".cmxs"] else [".cmo"; ".cma"]
   in
   Array.iter
     (fun f ->
-      if List.exists (Filename.check_suffix f) dynlink_exts then
-        load_file (Filename.concat d f))
+      if f.[0] = '.' then ()
+      else
+        let f = Filename.concat d f in
+        if Sys.is_directory f then load_dir f
+        else if List.exists (Filename.check_suffix f) dynlink_exts then
+          load_file f)
     (Sys.readdir d)

--- a/compiler/plugins/dune
+++ b/compiler/plugins/dune
@@ -1,18 +1,22 @@
-(executable
+(library
  (name python)
- (modes plugin)
+ (public_name catala.plugins.python)
+ (synopsis
+  "Demonstration Catala plugin that reproduces the behaviour of the built-in python backend")
  (modules python)
  (libraries catala.driver))
 
-(executable
+(library
  (name api_web)
- (modes plugin)
+ (public_name catala.plugins.api_web)
+ (synopsis "Catala plugin for interaction with a web interface")
  (modules api_web)
  (libraries catala.driver))
 
-(executable
+(library
  (name json_schema)
- (modes plugin)
+ (public_name catala.plugins.json_schema)
+ (synopsis "Catala plugin generating JSON schemas useful to build web-forms")
  (modules json_schema)
  (libraries catala.driver))
 


### PR DESCRIPTION
Fixes #378

- the plugins are compiled as libraries rather than with `executable`, so
  that dune is able to install them
- they get installed to
  `lib/catala/plugins/<plugin-name>/<plugin-name>.cmxs`
- the lookup for plugins is now recursive to cope with the plugin
  subdirectories in the point above