### PR TITLE
Python backend: Use true division

### DIFF
--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -78,8 +78,8 @@ let format_op
     Format.pp_print_string fmt "-"
   | Mult_int_int | Mult_rat_rat | Mult_mon_rat | Mult_dur_int ->
     Format.pp_print_string fmt "*"
-  | Div_int_int -> Format.pp_print_string fmt "//"
-  | Div_rat_rat | Div_mon_mon | Div_mon_rat -> Format.pp_print_string fmt "/"
+  | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat ->
+    Format.pp_print_string fmt "/"
   | And -> Format.pp_print_string fmt "and"
   | Or -> Format.pp_print_string fmt "or"
   | Eq -> Format.pp_print_string fmt "=="


### PR DESCRIPTION
Hey all! I recently came across Catala (cool project!) and have been playing around with the Python backend.

I believe this PR fixes a regression after the change in #368, which converted all integer division to return a decimal. The code generation backend was still using the integer division operand `//`, which is not overloaded by class `Integer` in the catala runtime.

Before this fix:
```python
# Assuming $PATH and $PYTHONENV set to appropriate _build dirs
$ catala Python tests/test_arithmetic/good/priorities.catala_en
$ python3 -i tests/test_arithmetic/good/priorities.py
>>> print(a(AIn()))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/catala/tests/test_arithmetic/good/priorities.py", line 106, in a
    temp_z_2 = handle_default(SourcePosition(filename="tests/test_arithmetic/good/priorities.catala_en",
  File "/path/to/catala/_build/default/runtimes/python/catala/src/catala/runtime.py", line 611, in handle_default
    return cons(Unit())
  File "/path/to/catala/tests/test_arithmetic/good/priorities.py", line 100, in temp_z
    return (((integer_of_string("200") // integer_of_string("2")) *
TypeError: unsupported operand type(s) for //: 'Integer' and 'Integer'
```

After this fix:

```python
# Assuming $PATH and $PYTHONENV set to appropriate _build dirs
$ catala Python tests/test_arithmetic/good/priorities.catala_en
$ python3 -i tests/test_arithmetic/good/priorities.py
>>> print(a(AIn()))
A(w=0,x=4,y=4,z=390.000000)

```

It does make `z` a decimal in this example, but I think that is intentional with the current semantics (correct me if I am wrong).

Feel free to edit for formatting, etc.