### PR TITLE
Python backend: Date difference should always return duration in days

### DIFF
--- a/runtimes/python/catala/src/catala/runtime.py
+++ b/runtimes/python/catala/src/catala/runtime.py
@@ -200,7 +200,7 @@ class Date:
 
     def __sub__(self, other: object) -> object:
         if isinstance(other, Date):
-          return Duration(dateutil.relativedelta.relativedelta(self.value, other.value))
+          return Duration(dateutil.relativedelta.relativedelta(days=(self.value - other.value).days))
         elif isinstance(other, Duration):
           return Date(self.value - other.value)
         else:


### PR DESCRIPTION
When I use the Python backend to run any of the tests for the US Tax Code Section 121, I get an error regarding date durations.

```python
# Assuming $PATH and $PYTHONENV set to appropriate _build dirs
$ catala Python examples/us_tax_code/tests/test_section_121.py
$ python -i examples/us_tax_code/tests/test_section_121.py
>>> test1(Test1())

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/catala/./examples/us_tax_code/tests/test_section_121.py", line 2251, in test1
    result_10 = section121_single_person(Section121SinglePersonIn(date_of_sale_or_exchange_in = scope121a_dot_date_of_sale_or_exchange_3,
  File "/path/to/catala/./examples/us_tax_code/tests/test_section_121.py", line 825, in section121_single_person
    temp_requirements_usage_met_5 = handle_default(SourcePosition(filename="./examples/us_tax_code/tests/../section_121.catala_en",
  File "/path/to/catala/_build/default/runtimes/python/catala/src/catala/runtime.py", line 600, in handle_default
    new_val = exception(Unit())
  File "/path/to/catala/./examples/us_tax_code/tests/test_section_121.py", line 819, in temp_requirements_usage_met_2
    return handle_default(SourcePosition(filename="./examples/us_tax_code/tests/../section_121.catala_en",
  File "/path/to/catala/_build/default/runtimes/python/catala/src/catala/runtime.py", line 610, in handle_default
    if just(Unit()):
  File "/path/to/catala/./examples/us_tax_code/tests/test_section_121.py", line 817, in temp_requirements_usage_met_4
    return (aggregate_periods_from_last_five_years(property_usage_as_principal_residence) >=
  File "/path/to/catala/_build/default/runtimes/python/catala/src/catala/runtime.py", line 295, in __ge__
    raise Exception("Can only compare durations expressed in days")
Exception: Can only compare durations expressed in days
```

I spent some time diagnosing the issue, and my understanding is as follows:

- Durations can only be compared if expressed in days, because the notion of "1 year" or "1 month" is context-specific.
- Catala still wants to support durations involving years and months since some legal specs use these terms. This is fine when adding dates with durations as done in Section 121 of the US tax code: https://github.com/CatalaLang/catala/blob/d92ae2ccfd6c9d025034043cc1efbbd6131e7d4b/examples/us_tax_code/section_121.catala_en#L180
- The Python backend uses [dateutil.relativedelta](https://dateutil.readthedocs.io/en/stable/relativedelta.html) instead of [datetime.timedelta](https://docs.python.org/3/library/datetime.html#datetime.timedelta) to represent durations, since the former supports year and month arithmetic, while the latter only supports days. This makes sense for addition like above.
- However, in Section 121, when durations are computed using date subtraction: https://github.com/CatalaLang/catala/blob/d92ae2ccfd6c9d025034043cc1efbbd6131e7d4b/examples/us_tax_code/section_121.catala_en#L181 they are stored as `relativedelta` objects which contain year and month information (I think the tests create objects like `relativedelta(years=+4)`). They are then compared with days: https://github.com/CatalaLang/catala/blob/d92ae2ccfd6c9d025034043cc1efbbd6131e7d4b/examples/us_tax_code/section_121.catala_en#L192 but we run into a problem because the runtime does not support comparing `4 years` with `730 days`: https://github.com/CatalaLang/catala/blob/d92ae2ccfd6c9d025034043cc1efbbd6131e7d4b/runtimes/python/catala/src/catala/runtime.py#L291-L295
- The Catala interpreter gets around this by using a date subtraction function that returns a period which [is always expressed as a number of days](https://github.com/CatalaLang/dates-calc/blob/0.0.4/lib/dates.ml#L237-L238).

So, my solution to this problem in the Python backend is to make sure that the result of `catala.runtime.Date - catala.runtime.Date` is always a `relativedelta` object having only the number of days set. This can be done by first just computing the difference between the underlying `datetime.date` values, which returns a `datetime.timedelta` object representing the date difference in days, and then using this day count to construct the `relativedelta` value for a `catala.runtime.Duration` object. That's what this PR does.

After the fix:

```python

# Assuming $PATH and $PYTHONENV set to appropriate _build dirs
$ catala Python examples/us_tax_code/tests/test_section_121.py
$ python -i examples/us_tax_code/tests/test_section_121.py
>>> print(test1(Test1()))

Test1()  # Yay
```