### PR TITLE
Python runtime: Fix source positions linked to run-time errors

### DIFF
--- a/runtimes/python/catala/src/catala/runtime.py
+++ b/runtimes/python/catala/src/catala/runtime.py
@@ -368,22 +368,22 @@ class EmptyError(Exception):
 
 class AssertionFailed(Exception):
     def __init__(self, source_position: SourcePosition) -> None:
-        self.source_position = SourcePosition
+        self.source_position = source_position
 
 
 class ConflictError(Exception):
     def __init__(self, source_position: SourcePosition) -> None:
-        self.source_position = SourcePosition
+        self.source_position = source_position
 
 
 class NoValueProvided(Exception):
     def __init__(self, source_position: SourcePosition) -> None:
-        self.source_position = SourcePosition
+        self.source_position = source_position
 
 
 class AssertionFailure(Exception):
     def __init__(self, source_position: SourcePosition) -> None:
-        self.source_position = SourcePosition
+        self.source_position = source_position
 
 
 # ============================


### PR DESCRIPTION
Fixes a typo-like bug where the `source_position` field of error objects was assigned the class `SourcePosition` instead of the actual position passed in as an argument.