### PR TITLE
Python runtime: Money division should remain rational

### DIFF
--- a/runtimes/python/catala/src/catala/runtime.py
+++ b/runtimes/python/catala/src/catala/runtime.py
@@ -151,7 +151,7 @@ class Money:
 
     def __truediv__(self, other: 'Money') -> Decimal:
         if isinstance(other, Money):
-            return Decimal(mpq(self.value.value / other.value.value))
+            return Decimal(mpq(self.value.value, other.value.value))
         elif isinstance(other, Decimal):
             return self * (1. / other.value)
         else:

--- a/runtimes/python/catala/src/catala/runtime.py
+++ b/runtimes/python/catala/src/catala/runtime.py
@@ -151,7 +151,7 @@ class Money:
 
     def __truediv__(self, other: 'Money') -> Decimal:
         if isinstance(other, Money):
-            return Decimal(mpq(self.value.value, other.value.value))
+            return self.value / other.value
         elif isinstance(other, Decimal):
             return self * (1. / other.value)
         else:


### PR DESCRIPTION
Money-by-money division was being computed with a true division between integers, which results in a floating-point value. This causes discrepancies with rationals that are used everywhere else in `Decimal` objects, and leads to imprecision and failed comparisons (see #402). 

The fix is to compute money division by separately giving `mpq` an integer numerator and denominator, so that the result remains rational and amenable to proper comparison.