### PR TITLE
Fix flake update mechanism

### DIFF
--- a/.github/workflows/run-builds.yml
+++ b/.github/workflows/run-builds.yml
@@ -11,5 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: cachix/install-nix-action@v15
-      - run: nix build
       - run: nix develop -c echo ok
+      - run: nix build
+      - run: nix build .#clerk

--- a/.github/workflows/run-builds.yml
+++ b/.github/workflows/run-builds.yml
@@ -1,16 +1,38 @@
-name: Builds
-
+name: "nix CI"
 on:
   push:
     branches: [master]
   workflow_dispatch:
-
 jobs:
-  build-nix-flake:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: cachix/install-nix-action@v15
-      - run: nix develop -c echo ok
-      - run: nix build
-      - run: nix build .#clerk
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - id: cache-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: nix-store.nar
+        key: nix-store-nar-${{ hashFiles('flake.lock') }}
+    - if: steps.cache-restore.outputs.cache-hit == 'true'
+      run: |
+        nix-store --import < nix-store.nar
+        rm nix-store.nar
+
+    - run: nix develop
+    - run: nix build
+    - run: nix build .#clerk
+
+    - name: dump store
+      if: steps.cache-restore.outputs.cache-hit == 'false'
+      run: nix-store --export $(nix-store -qR $(nix print-dev-env --json | jq .variables.prefix.value -r)) > nix-store.nar
+    - name: save current cache
+      if: steps.cache-restore.outputs.cache-hit == 'false'
+      uses: actions/cache/save@v3
+      id: cache
+      with:
+        path: nix-store.nar
+        key: nix-store-nar-${{ hashFiles('flake.lock') }}
+

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -16,12 +16,15 @@ jobs:
       - name: update flake.lock
         run: |
           nix flake update
-      - name: check it builds
+      - name: check catala builds
         run: |
           nix build
+      - name: check clerk builds and catala test-suite passes
+        run:  |
+          nix build .#clerk
       - name: commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          author_name: Catala nix updated
-          author_email: nixer@catala
-          message: "update lock files"
+          author_name: adelaett
+          author_email: 90894311+adelaett@users.noreply.github.com
+          message: "Update lock files"

--- a/.nix/catala.nix
+++ b/.nix/catala.nix
@@ -12,7 +12,7 @@
 , js_of_ocaml
 , js_of_ocaml-ppx
 , menhir
-, menhirLib ? null #for nixos-unstable compatibility.
+, menhirLib
 , ocamlgraph
 , pkgs
 , ppx_deriving
@@ -27,7 +27,7 @@
 , zarith_stubs_js
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "catala";
   version = "0.7.0"; # TODO parse `catala.opam` with opam2json
 
@@ -37,17 +37,17 @@ buildDunePackage rec {
 
   duneVersion = "3";
 
+  nativeBuildInputs = [ cppo menhir ];
+
   propagatedBuildInputs = [
     alcotest
     ansiterminal
     benchmark
     bindlib
     cmdliner
-    cppo
     dates_calc
     js_of_ocaml
     js_of_ocaml-ppx
-    menhir
     menhirLib
     ocamlgraph
     pkgs.z3
@@ -61,8 +61,10 @@ buildDunePackage rec {
     z3
     zarith
     zarith_stubs_js
-  ] ++ (if isNull menhirLib then [ ] else [ menhirLib ]);
-  doCheck = true;
+  ];
+
+  # Currently there is no unit tests in catala and Cram tests are handled by clerk
+  doCheck = false;
 
   meta = with lib; {
     homepage = "https://catala-lang.org";

--- a/.nix/clerk.nix
+++ b/.nix/clerk.nix
@@ -3,13 +3,15 @@
 , odoc
 , re
 , ansiterminal
-, cmdliner_1_1_0
+, cmdliner
 , ninja_utils
 , alcotest
 , catala
+, ninja
+, colordiff
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "clerk";
   version = "0.7.0"; # TODO parse `catala.opam` with opam2json
 
@@ -23,12 +25,15 @@ buildDunePackage rec {
     odoc
     re
     ansiterminal
-    cmdliner_1_1_0
+    cmdliner
     ninja_utils
     alcotest
     catala
   ];
-  doCheck = false;
+
+  # todo: the current colordiff in nixpkgs always prints the banner. This make the logs totally unreadable.
+  nativeBuildInputs = [ catala ninja colordiff ];
+  doCheck = true;
 
   meta = with lib; {
     homepage = "https://github.com/CatalaLang/catala";


### PR DESCRIPTION
The update mecanism was broken from a few weeks. Even if the flake.nix still build with respect to the flake.lock in the repo, it was lagging being the lastest nixpkgs updates. This fixes the issue. 

Moreother, i took the liberty to check why nix build don't catala's test suite. The reason was to run tests, buildDunePackages runs `dune build -p catala`, and this do nothing because there is no test registered with catala, everything is registered with clerk. Hence I've fixed clerk's nix package to run tests and added to both regular CI and flake-update CI.