### PR TITLE
Adelaett fix arrowlist

### DIFF
--- a/french_law/ocaml/bench.ml
+++ b/french_law/ocaml/bench.ml
@@ -224,6 +224,16 @@ let run_test_aides_logement () =
     exit (-1)
   | Runtime.AssertionFailed _ -> ()
 
+let _test =
+  let _ = run_test_aides_logement () in
+  let raw_events = Runtime.retrieve_log () in
+  Runtime.EventParser.parse_raw_events raw_events
+
+let _test =
+  let _ = run_test_allocations_familiales () in
+  let raw_events = Runtime.retrieve_log () in
+  Runtime.EventParser.parse_raw_events raw_events
+
 let _bench =
   Random.init (int_of_float (Unix.time ()));
   let num_iter = 10000 in

--- a/french_law/ocaml/dune
+++ b/french_law/ocaml/dune
@@ -25,3 +25,8 @@
   "A collection of functions for computing French taxes and benefits derived from Catala programs")
  (libraries catala.runtime_ocaml law_source)
  (modules api))
+
+(rule
+ (alias runtest)
+ (action
+  (run ./bench.exe)))

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -171,7 +171,7 @@ and var_def = {
 
 and fun_call = {
   fun_name : information;
-  input : var_def;
+  inputs : var_def list;
   body : event list;
   output : var_def;
 }


### PR DESCRIPTION
Follow-up of #404.

Last pull request enabled multiple argument functions within the compiler (even if it is not possible to create those in the surface language). This broke the handmade event parsers in the runtime. This change correct the handcrafted parser by permitting multiple VarDefintions. It have been tested on french housing and family benefits.

Left to do:
- include this part of the compiler to the tests to not get in the same kind of issues later on.
