### PR TITLE
CI improvements attempt

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,0 +1,44 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Catala artifacts
+          path: artifacts/*
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'artifacts/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/run-make-all.yml
+++ b/.github/workflows/run-make-all.yml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Prepare container with all dependencies
@@ -36,7 +36,7 @@ jobs:
               opam --cli=2.1 remove z3 >&2
               opam --cli=2.1 exec -- dune build --profile=release french_law compiler/catala.bc.js >&2
               mv _build/default/compiler/catala.bc.js catala_'"${RELEASE_TAG}"'_node.js >&2
-              tar c -h catala_'"${RELEASE_TAG}"'_node.js french_law --exclude french_law/js/node_modules --exclude french_law/python/env --exclude '"'"'.*'"'"'
+              tar c -h catala_'"${RELEASE_TAG}"'_node.js doc/syntax/syntax.pdf french_law --exclude french_law/js/node_modules --exclude french_law/python/env --exclude '"'"'.*'"'"'
             ' | tar vx -C artifacts
       - name: Build static binaries
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN opam exec -- ./french_law/python/setup_env.sh
 
 # OCaml backtraces may be useful on failure
 ENV OCAMLRUNPARAM=b
+# Make sure warnings are treated as errors (variable used in Makefile, profile
+# defined in ./dune)
+ENV DUNE_PROFILE=check
 
 # Check promoted files (but delay failure)
 RUN opam exec -- make check-promoted > promotion.out 2>&1 || touch bad-promote

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ help : Makefile
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-export DUNE_PROFILE ?= release
+export DUNE_PROFILE ?= dev
 
 # Export all variables to sub-make
 export

--- a/dune
+++ b/dune
@@ -4,6 +4,30 @@
 
 (copy_files compiler/surface/grammar.html)
 
+; Override dune default warnings with sane settings
+
+(env
+ ; don't stop building because of warnings
+ (dev
+  (flags
+   (:standard -warn-error -a)))
+ ; for CI runs: must fail on warnings
+ (check
+  (flags
+   (:standard
+    -w
+    +a-4-29-40-41-42-44-45-48-58-59-60-63-64-65-66-67-68-69-70
+    -warn-error
+    +a)))
+ ; let us see the warnings even in release mode, but non-fatal
+ (release
+  (flags
+   (:standard
+    -w
+    +a-4-29-40-41-42-44-45-48-58-59-60-63-64-65-66-67-68-69-70
+    -warn-error
+    -a))))
+
 (rule
  (action
   (with-stdout-to


### PR DESCRIPTION
- fix dune compilation options: ensure both no dev failure on warnings and
CI
 failure on warnings (the defaults do neither of those things !)

- attempt to publish the build artifacts to github-pages, so that they
could be
 made more easily available and we could maybe remove the ones that are
still
 there from the main repo