### PR TITLE
CI: fix another rebuild

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -26,13 +26,12 @@ CUSTOM_LINKING_CATALA_NOZ3="(-cclib -static -cclib -no-pie)"
 CUSTOM_LINKING_CLERK="(-cclib -static -cclib -no-pie)"
 
 git archive HEAD --prefix catala/ | \
-docker run --rm -i registry.gitlab.inria.fr/lgesbert/catala-ci-images:ocaml.4.14-z3static.4.10.1 \
+docker run --rm -i registry.gitlab.inria.fr/lgesbert/catala-ci-images:ocaml.4.14-z3static.4.11.2 \
   sh -uexc \
     '{ tar x &&
        cd catala &&
        echo "'"${CUSTOM_LINKING_CATALA_Z3}"'" >compiler/custom_linking.sexp &&
        echo "'"${CUSTOM_LINKING_CLERK}"'" >build_system/custom_linking.sexp &&
-       opam --cli=2.1 update &&
        opam --cli=2.1 install ./ninja_utils.opam ./clerk.opam ./catala.opam --destdir ../release.out/ &&
        mv ../release.out/bin/catala ../release.out/bin/catala-z3 &&
        opam --cli=2.1 remove z3 catala &&


### PR DESCRIPTION
Don't put 'opam update' in the builds. Update the Docker images if needed.