### PR TITLE
Generic mapping function across different ASTs

### DIFF
--- a/compiler/dcalc/ast.ml
+++ b/compiler/dcalc/ast.ml
@@ -17,8 +17,6 @@
 
 open Shared_ast
 
-type lit = dcalc glit
-
 type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
 and 'm expr = (dcalc, 'm mark) gexpr
 

--- a/compiler/dcalc/ast.mli
+++ b/compiler/dcalc/ast.mli
@@ -19,8 +19,6 @@
 
 open Shared_ast
 
-type lit = dcalc glit
-
 type 'm naked_expr = (dcalc, 'm mark) naked_gexpr
 and 'm expr = (dcalc, 'm mark) gexpr
 

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -201,8 +201,8 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm Scopelang.Ast.expr) :
   match Marked.unmark e with
   | EVar v -> Expr.evar (Var.Map.find v ctx.local_vars) m
   | ELit
-      (( LBool _ | LEmptyError | LInt _ | LRat _ | LMoney _ | LUnit | LDate _
-       | LDuration _ ) as l) ->
+      ((LBool _ | LInt _ | LRat _ | LMoney _ | LUnit | LDate _ | LDuration _) as
+      l) ->
     Expr.elit l m
   | EStruct { name; fields } ->
     let fields = StructField.Map.map (translate_expr ctx) fields in
@@ -254,7 +254,7 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm Scopelang.Ast.expr) :
           let expr =
             match str_field, expr with
             | Some { scope_input_io = Desugared.Ast.Reentrant, _; _ }, None ->
-              Some (Expr.unbox (Expr.elit LEmptyError (mark_tany m pos)))
+              Some (Expr.unbox (Expr.eemptyerror (mark_tany m pos)))
             | _ -> expr
           in
           match str_field, expr with
@@ -410,7 +410,7 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm Scopelang.Ast.expr) :
            (Marked.mark
               (Expr.with_ty m
                  (TStruct sc_sig.scope_sig_output_struct, Expr.pos e))
-              (ELit LEmptyError)))
+              EEmptyError))
         (Expr.with_ty m (TStruct sc_sig.scope_sig_output_struct, Expr.pos e))
     in
     (* let result_var = calling_expr in let result_eta_expanded_var =
@@ -561,6 +561,7 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm Scopelang.Ast.expr) :
   | EOp { op = Add_dat_dur _; tys } ->
     Expr.eop (Add_dat_dur ctx.date_rounding) tys m
   | EOp { op; tys } -> Expr.eop (Operator.translate op) tys m
+  | EEmptyError -> Expr.eemptyerror m
   | EErrorOnEmpty e' -> Expr.eerroronempty (translate_expr ctx e') m
   | EArray es -> Expr.earray (List.map (translate_expr ctx) es) m
 

--- a/compiler/dcalc/optimizations.ml
+++ b/compiler/dcalc/optimizations.ml
@@ -29,7 +29,7 @@ let rec partial_evaluation (ctx : partial_evaluation_ctx) (e : 'm expr) :
   let e = Expr.map ~f:(partial_evaluation ctx) e in
   let mark = Marked.get_mark e in
   (* Then reduce the parent node *)
-  let reduce e =
+  let reduce (e : 'm expr) =
     (* Todo: improve the handling of eapp(log,elit) cases here, it obfuscates
        the matches and the log calls are not preserved, which would be a good
        property *)
@@ -99,9 +99,7 @@ let rec partial_evaluation (ctx : partial_evaluation_ctx) (e : 'm expr) :
     | EDefault { excepts; just; cons } -> (
       (* TODO: mechanically prove each of these optimizations correct :) *)
       let excepts =
-        List.filter
-          (fun except -> Marked.unmark except <> ELit LEmptyError)
-          excepts
+        List.filter (fun except -> Marked.unmark except <> EEmptyError) excepts
         (* we can discard the exceptions that are always empty error *)
       in
       let value_except_count =
@@ -137,7 +135,7 @@ let rec partial_evaluation (ctx : partial_evaluation_ctx) (e : 'm expr) :
                     args = [(ELit (LBool false), _)];
                   } ),
               _ ) ) ->
-          ELit LEmptyError
+          EEmptyError
         | [], just when not !Cli.avoid_exceptions_flag ->
           (* without exceptions, a default is just an [if then else] raising an
              error in the else case. This exception is only valid in the context
@@ -145,8 +143,7 @@ let rec partial_evaluation (ctx : partial_evaluation_ctx) (e : 'm expr) :
              flag to know if we will be compiling using exceptions or the option
              monad. FIXME: move this optimisation somewhere else to avoid this
              check *)
-          EIfThenElse
-            { cond = just; etrue = cons; efalse = ELit LEmptyError, mark }
+          EIfThenElse { cond = just; etrue = cons; efalse = EEmptyError, mark }
         | excepts, just -> EDefault { excepts; just; cons })
     | EIfThenElse
         {

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -145,7 +145,7 @@ let empty_rule
     (parameters : (Uid.MarkedString.info * typ) list Marked.pos option) : rule =
   {
     rule_just = Expr.box (ELit (LBool false), Untyped { pos });
-    rule_cons = Expr.box (ELit LEmptyError, Untyped { pos });
+    rule_cons = Expr.box (EEmptyError, Untyped { pos });
     rule_parameter =
       Option.map
         (Marked.map_under_mark

--- a/compiler/lcalc/ast.ml
+++ b/compiler/lcalc/ast.ml
@@ -17,8 +17,6 @@
 open Catala_utils
 include Shared_ast
 
-type lit = lcalc glit
-
 type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
 and 'm expr = (lcalc, 'm mark) gexpr
 

--- a/compiler/lcalc/ast.mli
+++ b/compiler/lcalc/ast.mli
@@ -21,8 +21,6 @@ open Shared_ast
 
 (** {1 Abstract syntax tree} *)
 
-type lit = lcalc glit
-
 type 'm naked_expr = (lcalc, 'm mark) naked_gexpr
 and 'm expr = (lcalc, 'm mark) gexpr
 

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -77,7 +77,7 @@ and translate_expr (ctx : 'm ctx) (e : 'm D.expr) : 'm A.expr boxed =
       ((LBool _ | LInt _ | LRat _ | LMoney _ | LUnit | LDate _ | LDuration _) as
       l) ->
     Expr.elit l m
-  | ELit LEmptyError -> Expr.eraise EmptyError m
+  | EEmptyError -> Expr.eraise EmptyError m
   | EOp { op; tys } -> Expr.eop (Operator.translate op) tys m
   | EIfThenElse { cond; etrue; efalse } ->
     Expr.eifthenelse (translate_expr ctx cond) (translate_expr ctx etrue)

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -59,44 +59,11 @@ let rec translate_default
 and translate_expr (ctx : 'm ctx) (e : 'm D.expr) : 'm A.expr boxed =
   let m = Marked.get_mark e in
   match Marked.unmark e with
-  | EVar v -> Expr.make_var (translate_var v) m
-  | EStruct { name; fields } ->
-    Expr.estruct name (StructField.Map.map (translate_expr ctx) fields) m
-  | EStructAccess { name; e; field } ->
-    Expr.estructaccess (translate_expr ctx e) field name m
-  | ETuple es -> Expr.etuple (List.map (translate_expr ctx) es) m
-  | ETupleAccess { e; index; size } ->
-    Expr.etupleaccess (translate_expr ctx e) index size m
-  | EInj { name; e; cons } -> Expr.einj (translate_expr ctx e) cons name m
-  | EMatch { name; e; cases } ->
-    Expr.ematch (translate_expr ctx e) name
-      (EnumConstructor.Map.map (translate_expr ctx) cases)
-      m
-  | EArray es -> Expr.earray (List.map (translate_expr ctx) es) m
-  | ELit
-      ((LBool _ | LInt _ | LRat _ | LMoney _ | LUnit | LDate _ | LDuration _) as
-      l) ->
-    Expr.elit l m
   | EEmptyError -> Expr.eraise EmptyError m
-  | EOp { op; tys } -> Expr.eop (Operator.translate op) tys m
-  | EIfThenElse { cond; etrue; efalse } ->
-    Expr.eifthenelse (translate_expr ctx cond) (translate_expr ctx etrue)
-      (translate_expr ctx efalse)
-      m
-  | EAssert e1 -> Expr.eassert (translate_expr ctx e1) m
   | EErrorOnEmpty arg ->
     Expr.ecatch (translate_expr ctx arg) EmptyError
       (Expr.eraise NoValueProvided m)
       m
-  | EApp { f; args } ->
-    Expr.eapp (translate_expr ctx f)
-      (List.map (translate_expr ctx) args)
-      (Marked.get_mark e)
-  | EAbs { binder; tys } ->
-    let vars, body = Bindlib.unmbind binder in
-    let new_body = translate_expr ctx body in
-    let new_binder = Expr.bind (Array.map translate_var vars) new_body in
-    Expr.eabs new_binder tys (Marked.get_mark e)
   | EDefault { excepts = [exn]; just; cons } when !Cli.optimize_flag ->
     (* FIXME: bad place to rely on a global flag *)
     Expr.ecatch (translate_expr ctx exn) EmptyError
@@ -106,6 +73,12 @@ and translate_expr (ctx : 'm ctx) (e : 'm D.expr) : 'm A.expr boxed =
       (Marked.get_mark e)
   | EDefault { excepts; just; cons } ->
     translate_default ctx excepts just cons (Marked.get_mark e)
+  | ( ELit _ | EApp _ | EOp _ | EArray _ | EVar _ | EAbs _ | EIfThenElse _
+    | ETuple _ | ETupleAccess _ | EInj _ | EAssert _ | EStruct _
+    | EStructAccess _ | EMatch _ ) as e ->
+    Expr.map_raw ~fop:Operator.translate
+      ~floc:(function _ -> .)
+      ~f:(translate_expr ctx) (Marked.mark m e)
 
 let rec translate_scope_lets
     (decl_ctx : decl_ctx)

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -182,7 +182,7 @@ let rec translate_and_hoist (ctx : 'm ctx) (e : 'm D.expr) :
   | EDefault _ ->
     let v' = Var.make "default_term" in
     Expr.make_var v' mark, Var.Map.singleton v' e
-  | ELit LEmptyError ->
+  | EEmptyError ->
     let v' = Var.make "empty_litteral" in
     Expr.make_var v' mark, Var.Map.singleton v' e
   (* This one is a very special case. It transform an unpure expression
@@ -333,7 +333,7 @@ and translate_expr ?(append_esome = true) (ctx : 'm ctx) (e : 'm D.expr) :
             (Expr.make_var (Var.translate A.handle_default_opt) mark_hoist)
             [Expr.earray excepts' mark_hoist; just'; cons']
             pos
-        | ELit LEmptyError -> A.make_none mark_hoist
+        | EEmptyError -> A.make_none mark_hoist
         | EAssert arg ->
           let arg' = translate_expr ctx arg in
 

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -36,7 +36,7 @@ and naked_expr =
   | EStructFieldAccess : expr * StructField.t * StructName.t -> naked_expr
   | EInj : expr * EnumConstructor.t * EnumName.t -> naked_expr
   | EArray : expr list -> naked_expr
-  | ELit : L.lit -> naked_expr
+  | ELit : lit -> naked_expr
   | EApp : expr * expr list -> naked_expr
   | EOp : operator -> naked_expr
 

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -22,7 +22,7 @@ module Runtime = Runtime_ocaml.Runtime
 module D = Dcalc.Ast
 module L = Lcalc.Ast
 
-let format_lit (fmt : Format.formatter) (l : L.lit Marked.pos) : unit =
+let format_lit (fmt : Format.formatter) (l : lit Marked.pos) : unit =
   match Marked.unmark l with
   | LBool true -> Format.pp_print_string fmt "True"
   | LBool false -> Format.pp_print_string fmt "False"

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -120,8 +120,8 @@ let rec translate_expr (ctx : ctx) (e : Desugared.Ast.expr) :
          args ScopeVar.Map.empty)
       m
   | ELit
-      (( LBool _ | LEmptyError | LInt _ | LRat _ | LMoney _ | LUnit | LDate _
-       | LDuration _ ) as l) ->
+      ((LBool _ | LInt _ | LRat _ | LMoney _ | LUnit | LDate _ | LDuration _) as
+      l) ->
     Expr.elit l m
   | EAbs { binder; tys } ->
     let vars, body = Bindlib.unmbind binder in
@@ -159,6 +159,7 @@ let rec translate_expr (ctx : ctx) (e : Desugared.Ast.expr) :
       (translate_expr ctx efalse)
       m
   | EArray args -> Expr.earray (List.map (translate_expr ctx) args) m
+  | EEmptyError -> Expr.eemptyerror m
   | EErrorOnEmpty e1 -> Expr.eerroronempty (translate_expr ctx e1) m
 
 (** {1 Rule tree construction} *)
@@ -292,8 +293,7 @@ let rec rule_tree_to_expr
          (translate_and_unbox_list base_just_list)
          (translate_and_unbox_list base_cons_list))
       (Expr.elit (LBool false) emark)
-      (Expr.elit LEmptyError emark)
-      emark
+      (Expr.eemptyerror emark) emark
   in
   let exceptions =
     List.map
@@ -390,7 +390,7 @@ let translate_def
        caller. *)
   then
     let m = Untyped { pos = Desugared.Ast.ScopeDef.get_position def_info } in
-    let empty_error = Expr.elit LEmptyError m in
+    let empty_error = Expr.eemptyerror m in
     match params with
     | Some (ps, _) ->
       let labels, tys = List.split ps in

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -267,15 +267,14 @@ type except = ConflictError | EmptyError | NoValueProvided | Crash
 
 (** Literals are the same throughout compilation except for the [LEmptyError]
     case which is eliminated midway through. *)
-type _ glit =
-  | LBool : bool -> 'a glit
-  | LInt : Runtime.integer -> 'a glit
-  | LRat : Runtime.decimal -> 'a glit
-  | LMoney : Runtime.money -> 'a glit
-  | LUnit : 'a glit
-  | LDate : date -> 'a glit
-  | LDuration : duration -> 'a glit
-  | LEmptyError : [> `DefaultTerms ] glit
+type lit =
+  | LBool of bool
+  | LInt of Runtime.integer
+  | LRat of Runtime.decimal
+  | LMoney of Runtime.money
+  | LUnit
+  | LDate of date
+  | LDuration of duration
 
 (** Locations are handled differently in [desugared] and [scopelang] *)
 type 'a glocation =
@@ -306,7 +305,7 @@ type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
 
 and ('a, 't) naked_gexpr =
   (* Constructors common to all ASTs *)
-  | ELit : 'a glit -> (([< all ] as 'a), 't) naked_gexpr
+  | ELit : lit -> (([< all ] as 'a), 't) naked_gexpr
   | EApp : {
       f : ('a, 't) gexpr;
       args : ('a, 't) gexpr list;
@@ -388,6 +387,7 @@ and ('a, 't) naked_gexpr =
       cons : ('a, 't) gexpr;
     }
       -> (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr
+  | EEmptyError : (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr
   | EErrorOnEmpty :
       ('a, 't) gexpr
       -> (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -288,6 +288,8 @@ type 'a glocation =
   | ToplevelVar : TopdefName.t Marked.pos -> [> `ExplicitScopes ] glocation
 
 type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
+
+and ('a, 't) naked_gexpr = ('a, 'a, 't) base_gexpr
 (** General expressions: groups all expression cases of the different ASTs, and
     uses a GADT to eliminate irrelevant cases for each one. The ['t] annotations
     are also totally unconstrained at this point. The dcalc exprs, for ex ample,
@@ -301,104 +303,101 @@ type ('a, 't) gexpr = (('a, 't) naked_gexpr, 't) Marked.t
     - For recursive functions, you may need to additionally explicit the
       generalisation of the variable: [let rec f: type a . a naked_gexpr -> ...]
     - Always think of using the pre-defined map/fold functions in [Expr] rather
-      than completely defining your recursion manually. *)
+      than completely defining your recursion manually.
 
-and ('a, 't) naked_gexpr =
+    The first argument of the base_gexpr type caracterises the "deep" type of
+    the AST, while the second is the shallow type. They are always equal for
+    well-formed AST types, but differentiating them ephemerally allows us to do
+    well-typed recursive transformations on the AST that change its type *)
+
+and ('a, 'b, 't) base_gexpr =
   (* Constructors common to all ASTs *)
-  | ELit : lit -> (([< all ] as 'a), 't) naked_gexpr
+  | ELit : lit -> ('a, [< all ], 't) base_gexpr
   | EApp : {
       f : ('a, 't) gexpr;
       args : ('a, 't) gexpr list;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
-  | EOp : {
-      op : 'a operator;
-      tys : typ list;
-    }
-      -> (([< all ] as 'a), 't) naked_gexpr
-  | EArray : ('a, 't) gexpr list -> (([< all ] as 'a), 't) naked_gexpr
-  | EVar :
-      ('a, 't) naked_gexpr Bindlib.var
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
+  | EOp : { op : 'a operator; tys : typ list } -> ('a, [< all ], 't) base_gexpr
+  | EArray : ('a, 't) gexpr list -> ('a, [< all ], 't) base_gexpr
+  | EVar : ('a, 't) naked_gexpr Bindlib.var -> ('a, _, 't) base_gexpr
   | EAbs : {
-      binder : (('a, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder;
+      binder : (('a, 'a, 't) base_gexpr, ('a, 't) gexpr) Bindlib.mbinder;
       tys : typ list;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
   | EIfThenElse : {
       cond : ('a, 't) gexpr;
       etrue : ('a, 't) gexpr;
       efalse : ('a, 't) gexpr;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
   | EStruct : {
       name : StructName.t;
       fields : ('a, 't) gexpr StructField.Map.t;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
   | EInj : {
       name : EnumName.t;
       e : ('a, 't) gexpr;
       cons : EnumConstructor.t;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
   | EMatch : {
       name : EnumName.t;
       e : ('a, 't) gexpr;
       cases : ('a, 't) gexpr EnumConstructor.Map.t;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
-  | ETuple : ('a, 't) gexpr list -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
+  | ETuple : ('a, 't) gexpr list -> ('a, [< all ], 't) base_gexpr
   | ETupleAccess : {
       e : ('a, 't) gexpr;
       index : int;
       size : int;
     }
-      -> (([< all ] as 'a), 't) naked_gexpr
+      -> ('a, [< all ], 't) base_gexpr
   (* Early stages *)
-  | ELocation :
-      'a glocation
-      -> (([< all > `ExplicitScopes ] as 'a), 't) naked_gexpr
+  | ELocation : 'a glocation -> ('a, [< all > `ExplicitScopes ], 't) base_gexpr
   | EScopeCall : {
       scope : ScopeName.t;
       args : ('a, 't) gexpr ScopeVar.Map.t;
     }
-      -> (([< all > `ExplicitScopes ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `ExplicitScopes ], 't) base_gexpr
   | EDStructAccess : {
       name_opt : StructName.t option;
       e : ('a, 't) gexpr;
       field : IdentName.t;
     }
-      -> (([< all > `SyntacticNames ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `SyntacticNames ], 't) base_gexpr
       (** [desugared] has ambiguous struct fields *)
   | EStructAccess : {
       name : StructName.t;
       e : ('a, 't) gexpr;
       field : StructField.t;
     }
-      -> (([< all > `ResolvedNames ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `ResolvedNames ], 't) base_gexpr
       (** Resolved struct/enums, after [desugared] *)
   (* Lambda-like *)
-  | EAssert : ('a, 't) gexpr -> (([< all > `Assertions ] as 'a), 't) naked_gexpr
+  | EAssert : ('a, 't) gexpr -> ('a, [< all > `Assertions ], 't) base_gexpr
   (* Default terms *)
   | EDefault : {
       excepts : ('a, 't) gexpr list;
       just : ('a, 't) gexpr;
       cons : ('a, 't) gexpr;
     }
-      -> (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr
-  | EEmptyError : (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `DefaultTerms ], 't) base_gexpr
+  | EEmptyError : ('a, [< all > `DefaultTerms ], 't) base_gexpr
   | EErrorOnEmpty :
       ('a, 't) gexpr
-      -> (([< all > `DefaultTerms ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `DefaultTerms ], 't) base_gexpr
   (* Lambda calculus with exceptions *)
-  | ERaise : except -> (([< all > `Exceptions ] as 'a), 't) naked_gexpr
+  | ERaise : except -> ('a, [< all > `Exceptions ], 't) base_gexpr
   | ECatch : {
       body : ('a, 't) gexpr;
       exn : except;
       handler : ('a, 't) gexpr;
     }
-      -> (([< all > `Exceptions ] as 'a), 't) naked_gexpr
+      -> ('a, [< all > `Exceptions ], 't) base_gexpr
 
 type ('a, 't) boxed_gexpr = (('a, 't) naked_gexpr Bindlib.box, 't) Marked.t
 (** The annotation is lifted outside of the box for expressions *)
@@ -429,7 +428,7 @@ type typed = { pos : Pos.t; ty : typ }
 type _ mark = Untyped : untyped -> untyped mark | Typed : typed -> typed mark
 
 (** Useful for errors and printing, for example *)
-type any_expr = AnyExpr : (_, _ mark) gexpr -> any_expr
+type any_expr = AnyExpr : ('a, _ mark) gexpr -> any_expr
 
 (** {2 Higher-level program structure} *)
 
@@ -460,7 +459,7 @@ type 'e scope_let = {
   (* todo ? Factorise the code_item _list type below and use it here *)
   scope_let_pos : Pos.t;
 }
-  constraint 'e = (_ any, _ mark) gexpr
+  constraint 'e = ('a any, _ mark) gexpr
 (** This type is parametrized by the expression type so it can be reused in
     later intermediate representations. *)
 
@@ -470,14 +469,14 @@ type 'e scope_let = {
 and 'e scope_body_expr =
   | Result of 'e
   | ScopeLet of 'e scope_let
-  constraint 'e = (_ any, _ mark) gexpr
+  constraint 'e = ('a any, _ mark) gexpr
 
 type 'e scope_body = {
   scope_body_input_struct : StructName.t;
   scope_body_output_struct : StructName.t;
   scope_body_expr : ('e, 'e scope_body_expr) binder;
 }
-  constraint 'e = (_ any, _ mark) gexpr
+  constraint 'e = ('a any, _ mark) gexpr
 (** Instead of being a single expression, we give a little more ad-hoc structure
     to the scope body by decomposing it in an ordered list of let-bindings, and
     a result expression that uses the let-binded variables. The first binder is

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -199,6 +199,30 @@ val map :
         f e
     ]} *)
 
+val map_raw :
+  f:(('a, 'm1) gexpr -> ('b, 'm2) boxed_gexpr) ->
+  fop:('a Op.t -> 'b Op.t) ->
+  floc:('a glocation -> 'b glocation) ->
+  (('a, 'b, 'm1) base_gexpr, 'm2) Marked.t ->
+  ('b, 'm2) boxed_gexpr
+(** Lower-level version of shallow [map] that can be used for transforming the
+    type of the AST. See [Lcalc.Compile_without_exceptions] for an example. The
+    structure is like this:
+
+    {[
+      let rec translate = function
+        | SpecificCase e -> TargetCase (translate e)
+        | (All | Other | Common | Cases) as e -> map_raw ~f:translate e
+    ]}
+
+    This function makes it very concise to transform only certain nodes of the
+    AST.
+
+    The [e] parameter passed to [map_raw] here needs to have only the common
+    cases in its shallow type, but can still contain any node from the starting
+    AST deeper inside: this is where the second type parameter to [base_gexpr]
+    becomes useful. *)
+
 val map_top_down :
   f:(('a, 't1) gexpr -> (('a, 't1) naked_gexpr, 't2) Marked.t) ->
   ('a, 't1) gexpr ->
@@ -259,13 +283,13 @@ val make_abs :
   ('a, 'm mark) boxed_gexpr ->
   typ list ->
   Pos.t ->
-  ('a, 'm mark) boxed_gexpr
+  ('a any, 'm mark) boxed_gexpr
 
 val make_app :
-  ('a any, 'm mark) boxed_gexpr ->
+  ('a, 'm mark) boxed_gexpr ->
   ('a, 'm mark) boxed_gexpr list ->
   Pos.t ->
-  ('a, 'm mark) boxed_gexpr
+  ('a any, 'm mark) boxed_gexpr
 
 val empty_thunked_term :
   'm mark -> ([< all > `DefaultTerms ], 'm mark) boxed_gexpr
@@ -276,7 +300,7 @@ val make_let_in :
   ('a, 'm mark) boxed_gexpr ->
   ('a, 'm mark) boxed_gexpr ->
   Pos.t ->
-  ('a, 'm mark) boxed_gexpr
+  ('a any, 'm mark) boxed_gexpr
 
 val make_multiple_let_in :
   ('a, 'm mark) gexpr Var.vars ->
@@ -284,7 +308,7 @@ val make_multiple_let_in :
   ('a, 'm mark) boxed_gexpr list ->
   ('a, 'm mark) boxed_gexpr ->
   Pos.t ->
-  ('a, 'm mark) boxed_gexpr
+  ('a any, 'm mark) boxed_gexpr
 
 val make_default :
   ('a, 't) boxed_gexpr list ->

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -49,7 +49,7 @@ val etupleaccess :
   ('a, 't) boxed_gexpr -> int -> int -> 't -> ('a any, 't) boxed_gexpr
 
 val earray : ('a, 't) boxed_gexpr list -> 't -> ('a any, 't) boxed_gexpr
-val elit : 'a glit -> 't -> ('a any, 't) boxed_gexpr
+val elit : lit -> 't -> ('a any, 't) boxed_gexpr
 
 val eabs :
   (('a, 't) naked_gexpr, ('a, 't) gexpr) Bindlib.mbinder Bindlib.box ->
@@ -81,6 +81,8 @@ val eifthenelse :
   ('a, 't) boxed_gexpr ->
   't ->
   ('a any, 't) boxed_gexpr
+
+val eemptyerror : 't -> (([< all > `DefaultTerms ] as 'a), 't) boxed_gexpr
 
 val eerroronempty :
   ('a, 't) boxed_gexpr ->
@@ -324,8 +326,8 @@ val format :
 
 (** {2 Analysis and tests} *)
 
-val equal_lit : 'a glit -> 'a glit -> bool
-val compare_lit : 'a glit -> 'a glit -> int
+val equal_lit : lit -> lit -> bool
+val compare_lit : lit -> lit -> int
 val equal_location : 'a glocation Marked.pos -> 'a glocation Marked.pos -> bool
 val compare_location : 'a glocation Marked.pos -> 'a glocation Marked.pos -> int
 

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -126,11 +126,10 @@ let rec typ (ctx : decl_ctx option) (fmt : Format.formatter) (ty : typ) : unit =
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" base_type "collection" typ t1
   | TAny -> base_type fmt "any"
 
-let lit (type a) (fmt : Format.formatter) (l : a glit) : unit =
+let lit (fmt : Format.formatter) (l : lit) : unit =
   match l with
   | LBool b -> lit_style fmt (string_of_bool b)
   | LInt i -> lit_style fmt (Runtime.integer_to_string i)
-  | LEmptyError -> lit_style fmt "∅ "
   | LUnit -> lit_style fmt "()"
   | LRat i ->
     lit_style fmt
@@ -364,6 +363,7 @@ let rec expr_aux :
            expr)
         excepts punctuation "|" expr just punctuation "⊢" expr cons punctuation
         "⟩"
+  | EEmptyError -> lit_style fmt "∅ "
   | EErrorOnEmpty e' ->
     Format.fprintf fmt "%a@ %a" op_style "error_empty" with_parens e'
   | EAssert e' ->

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -34,7 +34,7 @@ val enum_constructor : Format.formatter -> EnumConstructor.t -> unit
 val tlit : Format.formatter -> typ_lit -> unit
 val location : Format.formatter -> 'a glocation -> unit
 val typ : decl_ctx -> Format.formatter -> typ -> unit
-val lit : Format.formatter -> 'a glit -> unit
+val lit : Format.formatter -> lit -> unit
 val operator : Format.formatter -> 'a operator -> unit
 val log_entry : Format.formatter -> log_entry -> unit
 val except : Format.formatter -> except -> unit

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -221,7 +221,7 @@ let handle_type_error ctx e t1 t2 =
     (Cli.format_with_style [ANSITerminal.blue; ANSITerminal.Bold])
     "-->" t2_s ()
 
-let lit_type (type a) (lit : a A.glit) : naked_typ =
+let lit_type (lit : A.lit) : naked_typ =
   match lit with
   | LBool _ -> TLit TBool
   | LInt _ -> TLit TInt
@@ -230,7 +230,6 @@ let lit_type (type a) (lit : a A.glit) : naked_typ =
   | LDate _ -> TLit TDate
   | LDuration _ -> TLit TDuration
   | LUnit -> TLit TUnit
-  | LEmptyError -> TAny (Any.fresh ())
 
 (** [op_type] and [resolve_overload] are a bit similar, and work on disjoint
     sets of operators. However, their assumptions are different so we keep the
@@ -742,6 +741,7 @@ and typecheck_expr_top_down :
         e1
     in
     Expr.eassert e1' mark
+  | A.EEmptyError -> Expr.eemptyerror (ty_mark (TAny (Any.fresh ())))
   | A.EErrorOnEmpty e1 ->
     let e1' = typecheck_expr_top_down ~leave_unresolved ctx env tau e1 in
     Expr.eerroronempty e1' context_mark

--- a/compiler/shared_ast/var.ml
+++ b/compiler/shared_ast/var.ml
@@ -21,10 +21,8 @@ open Definitions
 (** This module provides types and helpers for Bindlib variables on the [gexpr]
     type *)
 
-type 'e t = ('a any, 't) naked_gexpr Bindlib.var constraint 'e = ('a, 't) gexpr
-
-type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar
-  constraint 'e = ('a any, 't) gexpr
+type 'e t = ('a, 't) naked_gexpr Bindlib.var constraint 'e = ('a, 't) gexpr
+type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar constraint 'e = ('a, 't) gexpr
 
 let make (name : string) : 'e t = Bindlib.new_var (fun x -> EVar x) name
 let compare = Bindlib.compare_vars

--- a/compiler/shared_ast/var.mli
+++ b/compiler/shared_ast/var.mli
@@ -21,10 +21,8 @@ open Definitions
 (** This module provides types and helpers for Bindlib variables on the [gexpr]
     type *)
 
-type 'e t = ('a any, 't) naked_gexpr Bindlib.var constraint 'e = ('a, 't) gexpr
-
-type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar
-  constraint 'e = ('a any, 't) gexpr
+type 'e t = ('a, 't) naked_gexpr Bindlib.var constraint 'e = ('a, 't) gexpr
+type 'e vars = ('a, 't) naked_gexpr Bindlib.mvar constraint 'e = ('a, 't) gexpr
 
 val make : string -> 'e t
 val compare : 'e t -> 'e t -> int

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -198,7 +198,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
             (Marked.get_mark e);
         ])
       (Marked.get_mark e)
-  | ELit LEmptyError -> Marked.same_mark_as (ELit (LBool false)) e
+  | EEmptyError -> Marked.same_mark_as (ELit (LBool false)) e
   | EVar _
   (* Per default calculus semantics, you cannot call a function with an argument
      that evaluates to the empty error. Thus, all variable evaluate to

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -374,7 +374,6 @@ let translate_lit (ctx : context) (l : lit) : Expr.expr =
   match l with
   | LBool b ->
     if b then Boolean.mk_true ctx.ctx_z3 else Boolean.mk_false ctx.ctx_z3
-  | LEmptyError -> failwith "[Z3 encoding] LEmptyError literals not supported"
   | LInt n ->
     Arithmetic.Integer.mk_numeral_i ctx.ctx_z3 (Runtime.integer_to_int n)
   | LRat r ->
@@ -785,6 +784,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
             (Boolean.mk_not ctx.ctx_z3 z3_if)
             z3_else;
         ] )
+  | EEmptyError -> failwith "[Z3 encoding] LEmptyError literals not supported"
   | EErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
 
 (** [create_z3unit] creates a Z3 sort and expression corresponding to the unit


### PR DESCRIPTION
Used in lcalc/compile_with_exceptions only at the moment

This adds an inner type parameter to the AST nodes, but it's hidden from the
outside (`('a, 't) naked_gexpr` is now actually defined from `('a, 'a, 't)
base_gexpr`) and no concern, unless in the case where you actually want do do
type-transforming recursion — which becomes possible.

And this allows to write extremely light-weight transformations in the compiler
passes, where the terms that actually get rewritten are no longer mixed in a sea
of trivial rewritings :)