### PR TITLE
Allow use of if_then_else beyond booleans in proof backend

### DIFF
--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -772,18 +772,13 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
   | EOp _ -> failwith "[Z3 encoding] EOp unsupported"
   | EDefault _ -> failwith "[Z3 encoding] EDefault unsupported"
   | EIfThenElse { cond = e_if; etrue = e_then; efalse = e_else } ->
-    (* Encode this as (e_if ==> e_then) /\ (not e_if ==> e_else) *)
+    (* We rely on Z3's native encoding for ite to encode this node. There might
+       be some interesting optimization in the future about when to split this
+       node/bubble up the if_then_else, but this is left as future work *)
     let ctx, z3_if = translate_expr ctx e_if in
     let ctx, z3_then = translate_expr ctx e_then in
     let ctx, z3_else = translate_expr ctx e_else in
-    ( ctx,
-      Boolean.mk_and ctx.ctx_z3
-        [
-          Boolean.mk_implies ctx.ctx_z3 z3_if z3_then;
-          Boolean.mk_implies ctx.ctx_z3
-            (Boolean.mk_not ctx.ctx_z3 z3_if)
-            z3_else;
-        ] )
+    ctx, Boolean.mk_ite ctx.ctx_z3 z3_if z3_then z3_else
   | EEmptyError -> failwith "[Z3 encoding] LEmptyError literals not supported"
   | EErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
   | _ -> .


### PR DESCRIPTION
This PR provides a better encoding for if_then_else nodes in verification conditions inside the proof platform.
When encoding a verification condition to Z3, the current z3 backend was translating an IfThenElse(e1, e2, e3) node to
`e1 ==> e2 /\ not e1 ==> e3`.

I can't precisely remember the rationale behind this, but I'm assuming that when we first implemented this backend with @denismerigoux , we considered that VCs would be purely logical terms.
However, as we try to use the proof platform on real programs, this does not hold anymore, and the translation of the node `IfThenElse(constraint, 8, 10)` was failing, as 8 and 10 could not be typed as booleans.

This PR fixes this issue by relying on the native Z3 `ite` expression for encoding IfThenElse

Fixes #458 