### PR TITLE
Program slicing for ambiguous dates computation

### DIFF
--- a/compiler/verification/conditions.mli
+++ b/compiler/verification/conditions.mli
@@ -23,10 +23,13 @@ open Shared_ast
 type verification_condition_kind =
   | NoEmptyError
       (** This verification condition checks whether a definition never returns
-          an empty error *)
+          an empty error. Has type [bool]. *)
   | NoOverlappingExceptions
       (** This verification condition checks whether a definition never returns
-          a conflict error *)
+          a conflict error. Has type [bool]. *)
+  | DateComputation
+      (** This verification condition is just a slice of the program (a
+          subexpression) that features computations on dates. *)
 
 type verification_condition = {
   vc_guard : typed Dcalc.Ast.expr;

--- a/compiler/verification/io.mli
+++ b/compiler/verification/io.mli
@@ -71,11 +71,10 @@ module type BackendIO = sig
     model option ->
     string
 
-  val encode_and_check_vc :
+  val check_vc :
     decl_ctx -> Conditions.verification_condition * vc_encoding_result -> bool
-  (** [encode_and_check_vc] spawns a new Z3 solver and tries to solve the
-      expression [vc]. Returns [true] if the vs was proven true and [false]
-      otherwise. **)
+  (** [check_vc] spawns a new Z3 solver and tries to solve the expression [vc].
+      Returns [true] if the vs was proven true and [false] otherwise. **)
 end
 
 module MakeBackendIO : functor (B : Backend) ->

--- a/compiler/verification/z3backend.dummy.ml
+++ b/compiler/verification/z3backend.dummy.ml
@@ -37,5 +37,5 @@ module Io = struct
   type vc_encoding_result = Success of model * model | Fail of string
 
   let print_negative_result _ _ _ = dummy ()
-  let encode_and_check_vc _ _ = dummy ()
+  let check_vc _ _ = dummy ()
 end


### PR DESCRIPTION
This PR adds a new kind of verification conditions that can be handled by the verification backends : a subexpression that could raise `Dates_calc.AmbiguousComputation`.