### PR TITLE
Tweak tutorial language in response to #473.

### DIFF
--- a/examples/tutorial_en/tutorial_en.catala_en
+++ b/examples/tutorial_en/tutorial_en.catala_en
@@ -227,13 +227,17 @@ scope IncomeTaxComputation:
   consequence equals 15 %
   # Writing 15% is just an abbreviation for "0.15".
 ```
+While conditional definitions are a powerful tool for expressing legal conditions,
+a correctly drafted legislative source should always ensure that at most one
+condition is true at all times.  This way, when the Catala program is
+executed, the right definition will be dynamically chosen by looking at which
+condition is true.
 
-When the Catala program will execute, the right definition will be dynamically
-chosen by looking at which condition is true. A correctly drafted legislative
-source should always ensure that at most one condition is true at all times.
-However, if it is not the case, Catala will let you define a precedence on the
-conditions, which has to be justified by the law. But we will see how to
-do that later.
+Here, however, our definition of `fixed_percentage` conflicts
+with the more general definition that we gave above---so Catala will give us
+an error if we try and use this definition as is.  In situations like this, Catala
+allows us to define a precedence on the conditions, which has to be justified by
+the law. But we will see how to do that later.
 
 ## Rules
 

--- a/examples/tutoriel_fr/tutoriel_fr.catala_fr
+++ b/examples/tutoriel_fr/tutoriel_fr.catala_fr
@@ -251,7 +251,7 @@ garantir qu’une seule condition, au maximum, soit vraie à tout moment.  De ce
 façon, quand le programme Catala va s’exécuter, la juste définition sera choisie
 dynamiquement en déterminant quelle condition est vraie, selon le contexte.
 
-Ici, cependant, notre définition des conflits `fixed_percentage` avec la définition
+Ici, cependant, notre définition des conflits `pourcentage_fixe` avec la définition
 plus générale que nous avons donnée ci-dessus.  Ainsi Catala nous donnera une erreur
 si nous essayons d'utiliser cette définition telle quelle.
 

--- a/examples/tutoriel_fr/tutoriel_fr.catala_fr
+++ b/examples/tutoriel_fr/tutoriel_fr.catala_fr
@@ -245,19 +245,23 @@ champ d'application CalculImpôtRevenu:
   conséquence égal à 15%
   # Ecrire 15% est juste une abbréviation pour « 0.15 »
 ```
-Alors que les définitions conditionelles sont un outil puissant por exprimer
-conditions légales, une source législative rédigée correctement doit toujours
-garantir qu’une seule condition, au maximum, soit vraie à tout moment.  De cette
-façon, quand le programme Catala va s’exécuter, la juste définition sera choisie
-dynamiquement en déterminant quelle condition est vraie, selon le contexte.
 
-Ici, cependant, notre définition des conflits `pourcentage_fixe` avec la définition
-plus générale que nous avons donnée ci-dessus.  Ainsi Catala nous donnera une erreur
-si nous essayons d'utiliser cette définition telle quelle.
+Même si les définitions conditionelles sont un outil puissant et expressif,
+une document juridique correctement rédigé doit toujours garantir qu’une seule
+condition au maximum soit vraie à tout moment. De cette façon, quand le
+programme Catala va s’exécuter, la juste définition sera choisie dynamiquement
+en déterminant quelle condition est vraie, selon le contexte.
 
-Dans des situations comme celle-ci, Catala vous permettra de définir un ordre des priorités sur les
-conditions, qui devra être justifié par un raisonnement juridique. Mais nous
-verrons comment faire cela plus tard.
+Ici, nous pouvons détecter un conflit sur `pourcentage_fixe` entre la
+définition générale et celle ci-dessus avec plus de ceux enfants. Catala
+donnera une erreur à l'exécution si nous essayons d'utiliser ces définitions
+de `pourcentage_fixe` avec plus de deux enfants ; les deux définitions
+contradictoires sont valables en même temps.
+
+
+Dans des situations comme celle-ci, Catala vous permettra de définir un ordre
+des priorité sur les conditions, qui devra être justifié par un raisonnement
+juridique. Mais nous verrons comment faire cela plus tard.
 
 ## Règles
 

--- a/examples/tutoriel_fr/tutoriel_fr.catala_fr
+++ b/examples/tutoriel_fr/tutoriel_fr.catala_fr
@@ -245,12 +245,17 @@ champ d'application CalculImpôtRevenu:
   conséquence égal à 15%
   # Ecrire 15% est juste une abbréviation pour « 0.15 »
 ```
-
-Quand le programme Catala va s’exécuter, la juste définition sera choisie
+Alors que les définitions conditionelles sont un outil puissant por exprimer
+conditions légales, une source législative rédigée correctement doit toujours
+garantir qu’une seule condition, au maximum, soit vraie à tout moment.  De cette
+façon, quand le programme Catala va s’exécuter, la juste définition sera choisie
 dynamiquement en déterminant quelle condition est vraie, selon le contexte.
-Une source législative rédigée correctement doit toujours garantir qu’une seule
-condition, au maximum, soit vraie à tout moment. Toutefois, si ce n’est pas
-le cas, Catala vous permettra de définir un ordre des priorités sur les
+
+Ici, cependant, notre définition des conflits `fixed_percentage` avec la définition
+plus générale que nous avons donnée ci-dessus.  Ainsi Catala nous donnera une erreur
+si nous essayons d'utiliser cette définition telle quelle.
+
+Dans des situations comme celle-ci, Catala vous permettra de définir un ordre des priorités sur les
 conditions, qui devra être justifié par un raisonnement juridique. Mais nous
 verrons comment faire cela plus tard.
 


### PR DESCRIPTION
Change some wording so it's easier for users to understand that the conflicting conditional definitions in the tutorial will fail (see #473).

I tried to keep the French and English tutorials in sync with this PR, but _my French skills are poor, so please check the edits I made to the French tutorial for grammar!_