### PR TITLE
Add some helper functions in a wrapper `Map` module

### DIFF
--- a/compiler/catala_utils/map.ml
+++ b/compiler/catala_utils/map.ml
@@ -1,0 +1,102 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2020 Inria, contributor:
+   Louis Gesbert <louis.gesbert@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+(** Small wrapper on top of the stdlib [Map] module to add some useful functions *)
+
+(* NOTE: only defines typed module, a .mli would be completely redundant *)
+
+include Stdlib.Map
+
+module type OrderedType = sig
+  include Stdlib.Map.OrderedType
+
+  val format : Format.formatter -> t -> unit
+end
+
+module type S = sig
+  include Stdlib.Map.S
+
+  val keys : 'a t -> key list
+  val values : 'a t -> 'a list
+  val of_list : (key * 'a) list -> 'a t
+
+  val format_keys :
+    ?pp_sep:(Format.formatter -> unit -> unit) ->
+    Format.formatter ->
+    'a t ->
+    unit
+
+  val format_values :
+    ?pp_sep:(Format.formatter -> unit -> unit) ->
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter ->
+    'a t ->
+    unit
+
+  val format_bindings :
+    ?pp_sep:(Format.formatter -> unit -> unit) ->
+    (Format.formatter -> (Format.formatter -> unit) -> 'a -> unit) ->
+    Format.formatter ->
+    'a t ->
+    unit
+  (** Formats the bindings of [t] in order. The user-supplied format function is
+      provided with a formatter for keys (can be used with ["%t"]) and the
+      corresponding value. *)
+
+  val format :
+    ?pp_sep:(Format.formatter -> unit -> unit) ->
+    ?pp_bind:(Format.formatter -> unit -> unit) ->
+    (Format.formatter -> 'a -> unit) ->
+    Format.formatter ->
+    'a t ->
+    unit
+  (** Formats all bindings of the map in order using the given separator
+      (default ["; "]) and binding indicator (default [" = "]). *)
+end
+
+module Make (Ord : OrderedType) : S with type key = Ord.t = struct
+  include Stdlib.Map.Make (Ord)
+
+  let keys t = fold (fun k _ acc -> k :: acc) t [] |> List.rev
+  let values t = fold (fun _ v acc -> v :: acc) t [] |> List.rev
+  let of_list l = List.fold_left (fun m (k, v) -> add k v m) empty l
+
+  let format_keys ?pp_sep ppf t =
+    Format.pp_print_list ?pp_sep Ord.format ppf (keys t)
+
+  let format_values ?pp_sep pp_value ppf t =
+    Format.pp_print_list ?pp_sep pp_value ppf (values t)
+
+  let format_bindings ?pp_sep pp_bnd ppf t =
+    Format.pp_print_list ?pp_sep
+      (fun ppf (k, v) -> pp_bnd ppf (fun ppf -> Ord.format ppf k) v)
+      ppf (bindings t)
+
+  let format
+      ?(pp_sep = fun ppf () -> Format.fprintf ppf ";@ ")
+      ?(pp_bind = fun ppf () -> Format.fprintf ppf " =@ ")
+      pp_value
+      ppf
+      t =
+    Format.pp_print_list ~pp_sep
+      (fun ppf (key, value) ->
+        Format.pp_open_hvbox ppf 2;
+        Ord.format ppf key;
+        pp_bind ppf ();
+        pp_value ppf value;
+        Format.pp_close_box ppf ())
+      ppf (bindings t)
+end

--- a/compiler/catala_utils/string.ml
+++ b/compiler/catala_utils/string.ml
@@ -66,7 +66,13 @@ let width s =
   in
   aux 0 0
 
-let format_t ppf s = Format.pp_print_as ppf (width s) s
+let format ppf s = Format.pp_print_as ppf (width s) s
 
-module Set = Set.Make (Stdlib.String)
-module Map = Map.Make (Stdlib.String)
+module Arg = struct
+  include Stdlib.String
+
+  let format = format
+end
+
+module Set = Set.Make (Arg)
+module Map = Map.Make (Arg)

--- a/compiler/catala_utils/string.mli
+++ b/compiler/catala_utils/string.mli
@@ -45,7 +45,7 @@ val remove_prefix : prefix:string -> string -> string
     - if [str] starts with [prefix], a string [s] such that [prefix ^ s = str]
     - otherwise, [str] unchanged *)
 
-val format_t : Format.formatter -> string -> unit
+val format : Format.formatter -> string -> unit
 
 val width : string -> int
 (** Returns the width of a given string in screen columns (assuming a monospace

--- a/compiler/catala_utils/uid.ml
+++ b/compiler/catala_utils/uid.ml
@@ -31,13 +31,12 @@ module type Id = sig
   val get_info : t -> info
   val compare : t -> t -> int
   val equal : t -> t -> bool
-  val format_t : Format.formatter -> t -> unit
+  val format : Format.formatter -> t -> unit
   val hash : t -> int
 
   module Set : Set.S with type elt = t
   module SetLabels : MoreLabels.Set.S with type elt = t and type t = Set.t
   module Map : Map.S with type key = t
-  module MapLabels : MoreLabels.Map.S with type key = t and type 'a t = 'a Map.t
 end
 
 module Make (X : Info) () : Id with type info = X.info = struct
@@ -46,6 +45,7 @@ module Make (X : Info) () : Id with type info = X.info = struct
 
     let compare (x : t) (y : t) : int = compare x.id y.id
     let equal x y = Int.equal x.id y.id
+    let format ppf t = X.format ppf t.info
   end
 
   include Ordering
@@ -59,7 +59,7 @@ module Make (X : Info) () : Id with type info = X.info = struct
     { id = !counter; info }
 
   let get_info (uid : t) : X.info = uid.info
-  let format_t (fmt : Format.formatter) (x : t) : unit = X.format fmt x.info
+  let format (fmt : Format.formatter) (x : t) : unit = X.format fmt x.info
   let hash (x : t) : int = x.id
 
   module Set = Set.Make (Ordering)
@@ -72,7 +72,7 @@ module MarkedString = struct
   type info = string Mark.pos
 
   let to_string (s, _) = s
-  let format fmt i = String.format_t fmt (to_string i)
+  let format fmt i = String.format fmt (to_string i)
   let equal = Mark.equal String.equal
   let compare = Mark.compare String.compare
 end

--- a/compiler/catala_utils/uid.mli
+++ b/compiler/catala_utils/uid.mli
@@ -46,13 +46,12 @@ module type Id = sig
   val get_info : t -> info
   val compare : t -> t -> int
   val equal : t -> t -> bool
-  val format_t : Format.formatter -> t -> unit
+  val format : Format.formatter -> t -> unit
   val hash : t -> int
 
   module Set : Set.S with type elt = t
   module SetLabels : MoreLabels.Set.S with type elt = t and type t = Set.t
   module Map : Map.S with type key = t
-  module MapLabels : MoreLabels.Map.S with type key = t and type 'a t = 'a Map.t
 end
 
 (** This is the generative functor that ensures that two modules resulting from

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -50,13 +50,13 @@ module ScopeDef = struct
       | Var (_, Some sx) -> Mark.get (StateName.get_info sx)
       | SubScopeVar (_, _, pos) -> pos
 
-    let format_t fmt x =
+    let format fmt x =
       match x with
-      | Var (v, None) -> ScopeVar.format_t fmt v
+      | Var (v, None) -> ScopeVar.format fmt v
       | Var (v, Some sv) ->
-        Format.fprintf fmt "%a.%a" ScopeVar.format_t v StateName.format_t sv
+        Format.fprintf fmt "%a.%a" ScopeVar.format v StateName.format sv
       | SubScopeVar (s, v, _) ->
-        Format.fprintf fmt "%a.%a" SubScopeName.format_t s ScopeVar.format_t v
+        Format.fprintf fmt "%a.%a" SubScopeName.format s ScopeVar.format v
 
     let hash x =
       match x with
@@ -89,6 +89,7 @@ module ExprMap = Map.Make (struct
   type t = expr
 
   let compare = Expr.compare
+  let format = Expr.format
 end)
 
 type io = { io_output : bool Mark.pos; io_input : Runtime.io_input Mark.pos }

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -28,7 +28,7 @@ module ScopeDef : sig
 
   val compare : t -> t -> int
   val get_position : t -> Pos.t
-  val format_t : Format.formatter -> t -> unit
+  val format : Format.formatter -> t -> unit
   val hash : t -> int
 
   module Map : Map.S with type key = t

--- a/compiler/desugared/dependency.mli
+++ b/compiler/desugared/dependency.mli
@@ -39,7 +39,7 @@ module Vertex : sig
     | SubScope of Shared_ast.SubScopeName.t
     | Assertion of Ast.AssertionName.t
 
-  val format_t : Format.formatter -> t -> unit
+  val format : Format.formatter -> t -> unit
   val info : t -> Uid.MarkedString.info
 
   include Graph.Sig.COMPARABLE with type t := t

--- a/compiler/desugared/linting.ml
+++ b/compiler/desugared/linting.ml
@@ -37,7 +37,7 @@ let detect_empty_definitions (p : program) : unit =
               (ScopeDef.get_position scope_def_key)
               "In scope @{<yellow>\"%a\"@}, the variable @{<yellow>\"%a\"@} is \
                declared but never defined; did you forget something?"
-              ScopeName.format_t scope_name Ast.ScopeDef.format_t scope_def_key)
+              ScopeName.format scope_name Ast.ScopeDef.format scope_def_key)
         scope.scope_defs)
     p.program_scopes
 
@@ -63,6 +63,8 @@ module RuleExpressionsMap = Map.Make (struct
            (fun xc yc -> Expr.compare (xc, xc_mark) (yc, yc_mark))
            xc yc)
     else just
+
+  let format ppf r = RuleName.format ppf r.rule_id
 end)
 
 let detect_identical_rules (p : program) : unit =
@@ -146,7 +148,7 @@ let detect_unused_struct_fields (p : program) : unit =
           (snd (StructName.get_info s_name))
           "The structure @{<yellow>\"%a\"@} is never used; maybe it's \
            unnecessary?"
-          StructName.format_t s_name
+          StructName.format s_name
       else
         StructField.Map.iter
           (fun field _ ->
@@ -158,7 +160,7 @@ let detect_unused_struct_fields (p : program) : unit =
                 (snd (StructField.get_info field))
                 "The field @{<yellow>\"%a\"@} of struct @{<yellow>\"%a\"@} is \
                  never used; maybe it's unnecessary?"
-                StructField.format_t field StructName.format_t s_name)
+                StructField.format field StructName.format s_name)
           fields)
     p.program_ctx.ctx_structs
 
@@ -199,7 +201,7 @@ let detect_unused_enum_constructors (p : program) : unit =
           (snd (EnumName.get_info e_name))
           "The enumeration @{<yellow>\"%a\"@} is never used; maybe it's \
            unnecessary?"
-          EnumName.format_t e_name
+          EnumName.format e_name
       else
         EnumConstructor.Map.iter
           (fun constructor _ ->
@@ -209,7 +211,7 @@ let detect_unused_enum_constructors (p : program) : unit =
                 (snd (EnumConstructor.get_info constructor))
                 "The constructor @{<yellow>\"%a\"@} of enumeration \
                  @{<yellow>\"%a\"@} is never used; maybe it's unnecessary?"
-                EnumConstructor.format_t constructor EnumName.format_t e_name)
+                EnumConstructor.format constructor EnumName.format e_name)
           constructors)
     p.program_ctx.ctx_enums
 

--- a/compiler/desugared/name_resolution.ml
+++ b/compiler/desugared/name_resolution.ml
@@ -124,7 +124,7 @@ let get_var_uid
   | Some (ScopeVar uid) -> uid
   | _ ->
     raise_unknown_identifier
-      (Format.asprintf "for a variable of scope %a" ScopeName.format_t scope_uid)
+      (Format.asprintf "for a variable of scope %a" ScopeName.format scope_uid)
       (x, pos)
 
 (** Get the subscope uid inside the scope given in argument *)
@@ -737,7 +737,7 @@ let get_def_key
                 Some "Variable declaration:", Mark.get (ScopeVar.get_info x_uid);
               ]
               "This identifier is not a state declared for variable %a."
-              ScopeVar.format_t x_uid)
+              ScopeVar.format x_uid)
         | None ->
           if not (Ident.Map.is_empty var_sig.var_sig_states_idmap) then
             Message.raise_multispanned_error
@@ -747,7 +747,7 @@ let get_def_key
               ]
               "This definition does not indicate which state has to be \
                considered for variable %a."
-              ScopeVar.format_t x_uid
+              ScopeVar.format x_uid
           else None )
   | [y; x] ->
     let (subscope_uid, subscope_real_uid) : SubScopeName.t * ScopeName.t =

--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -34,7 +34,7 @@ let format_exception_tree (fmt : Format.formatter) (t : exception_tree) =
       | Leaf l -> l.Dependency.ExceptionVertex.label, []
       | Node (sons, l) -> l.Dependency.ExceptionVertex.label, sons
     in
-    Format.fprintf fmt "@{<yellow>\"%a\"@}" LabelName.format_t label;
+    Format.fprintf fmt "@{<yellow>\"%a\"@}" LabelName.format label;
     let w = String.width (fst (LabelName.get_info label)) + 2 in
     if sons != [] then
       let pref', prefsz' = pref ^ String.make (w + 1) ' ', prefsz + w + 2 in
@@ -89,14 +89,14 @@ let print_exceptions_graph
   Message.emit_result
     "Printing the tree of exceptions for the definitions of variable \
      @{<yellow>\"%a\"@} of scope @{<yellow>\"%a\"@}."
-    Ast.ScopeDef.format_t var ScopeName.format_t scope;
+    Ast.ScopeDef.format var ScopeName.format scope;
   Dependency.ExceptionsDependencies.iter_vertex
     (fun ex ->
       Message.emit_result
-        "@[<v>Definitions with label @{<yellow>\"%a\"@}:@,%a@]"
-        LabelName.format_t ex.Dependency.ExceptionVertex.label
-        (Format.pp_print_list (fun fmt (_, pos) -> Pos.format_loc_text fmt pos))
-        (RuleName.Map.bindings ex.Dependency.ExceptionVertex.rules))
+        "@[<v>Definitions with label @{<yellow>\"%a\"@}:@,%a@]" LabelName.format
+        ex.Dependency.ExceptionVertex.label
+        (RuleName.Map.format_values Pos.format_loc_text)
+        ex.Dependency.ExceptionVertex.rules)
     g;
   let tree = build_exception_tree g in
   Message.emit_result "@[<v>The exception tree structure is as follows:@,@,%a@]"

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -248,7 +248,7 @@ module Commands = struct
     | None ->
       Message.raise_error
         "Variable @{<yellow>\"%s\"@} not found inside scope @{<yellow>\"%a\"@}"
-        variable ScopeName.format_t scope_uid
+        variable ScopeName.format scope_uid
     | Some
         (Desugared.Name_resolution.SubScope (subscope_var_name, subscope_name))
       -> (
@@ -258,7 +258,7 @@ module Commands = struct
           "Subscope @{<yellow>\"%a\"@} of scope @{<yellow>\"%a\"@} cannot be \
            selected by itself, please add \".<var>\" where <var> is a subscope \
            variable."
-          SubScopeName.format_t subscope_var_name ScopeName.format_t scope_uid
+          SubScopeName.format subscope_var_name ScopeName.format scope_uid
       | Some second_part -> (
         match
           Ident.Map.find_opt second_part
@@ -271,8 +271,8 @@ module Commands = struct
             "Var @{<yellow>\"%s\"@} of subscope @{<yellow>\"%a\"@} in scope \
              @{<yellow>\"%a\"@} does not exist, please check your command line \
              arguments."
-            second_part SubScopeName.format_t subscope_var_name
-            ScopeName.format_t scope_uid))
+            second_part SubScopeName.format subscope_var_name ScopeName.format
+            scope_uid))
     | Some (Desugared.Name_resolution.ScopeVar v) ->
       Desugared.Ast.ScopeDef.Var
         ( v,
@@ -287,7 +287,7 @@ module Commands = struct
                 Message.raise_error
                   "State @{<yellow>\"%s\"@} is not found for variable \
                    @{<yellow>\"%s\"@} of scope @{<yellow>\"%a\"@}"
-                  second_part first_part ScopeName.format_t scope_uid)
+                  second_part first_part ScopeName.format scope_uid)
             second_part )
 
   let get_output ?ext options output_file =

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -169,11 +169,7 @@ let rec trans (ctx : typed ctx) (e : typed D.expr) : (lcalc, typed) boxed_gexpr
     Ast.OptionMonad.return ~mark
       (Expr.eapp
          (Expr.evar (trans_var ctx scope) mark)
-         [
-           Expr.estruct name
-             (StructField.MapLabels.map fields ~f:(trans ctx))
-             mark;
-         ]
+         [Expr.estruct name (StructField.Map.map (trans ctx) fields) mark]
          mark)
   | EApp { f = (EVar ff, _) as f; args }
     when not (Var.Map.find ff ctx.ctx_vars).is_scope ->
@@ -371,7 +367,8 @@ let rec trans (ctx : typed ctx) (e : typed D.expr) : (lcalc, typed) boxed_gexpr
     res
   | EMatch { name; e; cases } ->
     let cases =
-      EnumConstructor.MapLabels.map cases ~f:(fun case ->
+      EnumConstructor.Map.map
+        (fun case ->
           match Mark.remove case with
           | EAbs { binder; tys } ->
             let vars, body = Bindlib.unmbind binder in
@@ -394,6 +391,7 @@ let rec trans (ctx : typed ctx) (e : typed D.expr) : (lcalc, typed) boxed_gexpr
             in
             Expr.eabs binder tys m
           | _ -> assert false)
+        cases
     in
     Ast.OptionMonad.bind_cont
       ~var_name:(context_or_same_var ctx e)

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -146,7 +146,7 @@ let avoid_keywords (s : string) : string =
    and [new_user] *)
 
 let format_struct_name (fmt : Format.formatter) (v : StructName.t) : unit =
-  Format.asprintf "%a" StructName.format_t v
+  Format.asprintf "%a" StructName.format v
   |> String.to_ascii
   |> String.to_snake_case
   |> avoid_keywords
@@ -156,8 +156,8 @@ let format_to_module_name
     (fmt : Format.formatter)
     (name : [< `Ename of EnumName.t | `Sname of StructName.t ]) =
   (match name with
-  | `Ename v -> Format.asprintf "%a" EnumName.format_t v
-  | `Sname v -> Format.asprintf "%a" StructName.format_t v)
+  | `Ename v -> Format.asprintf "%a" EnumName.format v
+  | `Sname v -> Format.asprintf "%a" StructName.format v)
   |> String.to_ascii
   |> String.to_snake_case
   |> avoid_keywords
@@ -174,19 +174,19 @@ let format_struct_field_name
     Format.fprintf fmt "%a.%s" format_to_module_name (`Sname sname)
   | None -> Format.fprintf fmt "%s")
     (avoid_keywords
-       (String.to_ascii (Format.asprintf "%a" StructField.format_t v)))
+       (String.to_ascii (Format.asprintf "%a" StructField.format v)))
 
 let format_enum_name (fmt : Format.formatter) (v : EnumName.t) : unit =
   Format.fprintf fmt "%s"
     (avoid_keywords
        (String.to_snake_case
-          (String.to_ascii (Format.asprintf "%a" EnumName.format_t v))))
+          (String.to_ascii (Format.asprintf "%a" EnumName.format v))))
 
 let format_enum_cons_name (fmt : Format.formatter) (v : EnumConstructor.t) :
     unit =
   Format.fprintf fmt "%s"
     (avoid_keywords
-       (String.to_ascii (Format.asprintf "%a" EnumConstructor.format_t v)))
+       (String.to_ascii (Format.asprintf "%a" EnumConstructor.format v)))
 
 let rec typ_embedding_name (fmt : Format.formatter) (ty : typ) : unit =
   match Mark.remove ty with
@@ -468,11 +468,11 @@ let format_struct_embedding
        @[<hov 2>[%a]@])@]@\n\
        @\n"
       format_struct_name struct_name format_to_module_name (`Sname struct_name)
-      StructName.format_t struct_name
+      StructName.format struct_name
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt ";@\n")
          (fun _fmt (struct_field, struct_field_type) ->
-           Format.fprintf fmt "(\"%a\",@ %a@ x.%a)" StructField.format_t
+           Format.fprintf fmt "(\"%a\",@ %a@ x.%a)" StructField.format
              struct_field typ_embedding_name struct_field_type
              format_struct_field_name
              (Some struct_name, struct_field)))
@@ -490,12 +490,12 @@ let format_enum_embedding
        =@]@ Enum([\"%a\"],@ @[<hov 2>match x with@ %a@])@]@\n\
        @\n"
       format_enum_name enum_name format_to_module_name (`Ename enum_name)
-      EnumName.format_t enum_name
+      EnumName.format enum_name
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
          (fun _fmt (enum_cons, enum_cons_type) ->
            Format.fprintf fmt "@[<hov 2>| %a x ->@ (\"%a\", %a x)@]"
-             format_enum_cons_name enum_cons EnumConstructor.format_t enum_cons
+             format_enum_cons_name enum_cons EnumConstructor.format enum_cons
              typ_embedding_name enum_cons_type))
       (EnumConstructor.Map.bindings enum_cases)
 

--- a/compiler/plugin.ml
+++ b/compiler/plugin.ml
@@ -33,7 +33,10 @@ let load_file f =
   try
     Dynlink.loadfile f;
     Message.emit_debug "Plugin %S loaded" f
-  with e ->
+  with
+  | Dynlink.Error (Dynlink.Module_already_loaded s) ->
+    Message.emit_debug "Plugin %S (%s) was already loaded, skipping" f s
+  | e ->
     Message.emit_warning "Could not load plugin %S: %s" f (Printexc.to_string e)
 
 let rec load_dir d =

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -35,7 +35,7 @@ module To_jsoo = struct
       (fmt : Format.formatter)
       (v : StructField.t) : unit =
     let s =
-      Format.asprintf "%a" StructField.format_t v
+      Format.asprintf "%a" StructField.format v
       |> String.to_ascii
       |> String.to_snake_case
       |> avoid_keywords

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -53,8 +53,8 @@ module Env = struct
 
   let print ppf (Env t) =
     Format.pp_print_list ~pp_sep:Format.pp_print_space
-      (fun ppf (v, { contents = _e, _env }) -> Print.var_debug ppf v)
-      ppf (Var.Map.bindings t)
+      (fun ppf v -> Print.var_debug ppf v)
+      ppf (Var.Map.keys t)
 end
 
 let rec lazy_eval :

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -41,9 +41,9 @@ let rec translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) : A.block * A.expr =
           Message.raise_spanned_error (Expr.pos expr)
             "Var not found in lambda→scalc: %a@\nknown: @[<hov>%a@]@\n"
             Print.var_debug v
-            (Format.pp_print_list ~pp_sep:Format.pp_print_space
-               (fun ppf (v, _) -> Print.var_debug ppf v))
-            (Var.Map.bindings ctxt.var_dict))
+            (Format.pp_print_list ~pp_sep:Format.pp_print_space (fun ppf v ->
+                 Print.var_debug ppf v))
+            (Var.Map.keys ctxt.var_dict))
     in
     [], (local_var, Expr.pos expr)
   | EStruct { fields; name } ->

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -21,11 +21,10 @@ open Ast
 let needs_parens (_e : expr) : bool = false
 
 let format_var_name (fmt : Format.formatter) (v : VarName.t) : unit =
-  Format.fprintf fmt "%a_%s" VarName.format_t v (string_of_int (VarName.hash v))
+  Format.fprintf fmt "%a_%s" VarName.format v (string_of_int (VarName.hash v))
 
 let format_func_name (fmt : Format.formatter) (v : FuncName.t) : unit =
-  Format.fprintf fmt "%a_%s" FuncName.format_t v
-    (string_of_int (FuncName.hash v))
+  Format.fprintf fmt "%a_%s" FuncName.format v (string_of_int (FuncName.hash v))
 
 let rec format_expr
     (decl_ctx : decl_ctx)
@@ -43,13 +42,13 @@ let rec format_expr
   | EVar v -> Format.fprintf fmt "%a" format_var_name v
   | EFunc v -> Format.fprintf fmt "%a" format_func_name v
   | EStruct (es, s) ->
-    Format.fprintf fmt "@[<hov 2>%a@ %a%a%a@]" StructName.format_t s
+    Format.fprintf fmt "@[<hov 2>%a@ %a%a%a@]" StructName.format s
       Print.punctuation "{"
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
          (fun fmt (e, (struct_field, _)) ->
            Format.fprintf fmt "%a%a%a%a %a" Print.punctuation "\""
-             StructField.format_t struct_field Print.punctuation "\""
+             StructField.format struct_field Print.punctuation "\""
              Print.punctuation ":" format_expr e))
       (List.combine es
          (StructField.Map.bindings (StructName.Map.find s decl_ctx.ctx_structs)))
@@ -62,7 +61,7 @@ let rec format_expr
       es Print.punctuation "]"
   | EStructFieldAccess (e1, field, _) ->
     Format.fprintf fmt "%a%a%a%a%a" format_expr e1 Print.punctuation "."
-      Print.punctuation "\"" StructField.format_t field Print.punctuation "\""
+      Print.punctuation "\"" StructField.format field Print.punctuation "\""
   | EInj (e, cons, _) ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" Print.enum_constructor cons
       format_expr e

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -129,25 +129,25 @@ let format_struct_name (fmt : Format.formatter) (v : StructName.t) : unit =
   Format.fprintf fmt "%s"
     (avoid_keywords
        (String.to_camel_case
-          (String.to_ascii (Format.asprintf "%a" StructName.format_t v))))
+          (String.to_ascii (Format.asprintf "%a" StructName.format v))))
 
 let format_struct_field_name (fmt : Format.formatter) (v : StructField.t) : unit
     =
   Format.fprintf fmt "%s"
     (avoid_keywords
-       (String.to_ascii (Format.asprintf "%a" StructField.format_t v)))
+       (String.to_ascii (Format.asprintf "%a" StructField.format v)))
 
 let format_enum_name (fmt : Format.formatter) (v : EnumName.t) : unit =
   Format.fprintf fmt "%s"
     (avoid_keywords
        (String.to_camel_case
-          (String.to_ascii (Format.asprintf "%a" EnumName.format_t v))))
+          (String.to_ascii (Format.asprintf "%a" EnumName.format v))))
 
 let format_enum_cons_name (fmt : Format.formatter) (v : EnumConstructor.t) :
     unit =
   Format.fprintf fmt "%s"
     (avoid_keywords
-       (String.to_ascii (Format.asprintf "%a" EnumConstructor.format_t v)))
+       (String.to_ascii (Format.asprintf "%a" EnumConstructor.format v)))
 
 let typ_needs_parens (e : typ) : bool =
   match Mark.remove e with TArrow _ | TArray _ -> true | _ -> false
@@ -196,8 +196,13 @@ let format_name_cleaned (fmt : Format.formatter) (s : string) : unit =
   |> avoid_keywords
   |> Format.fprintf fmt "%s"
 
-module StringMap = Map.Make (String)
-module IntMap = Map.Make (Int)
+module StringMap = String.Map
+
+module IntMap = Map.Make (struct
+  include Int
+
+  let format ppf i = Format.pp_print_int ppf i
+end)
 
 (** For each `VarName.t` defined by its string and then by its hash, we keep
     track of which local integer id we've given it. This is used to keep

--- a/compiler/scopelang/dependency.mli
+++ b/compiler/scopelang/dependency.mli
@@ -38,7 +38,7 @@ val get_defs_ordering : SDependencies.t -> vertex list
 module TVertex : sig
   type t = Struct of StructName.t | Enum of EnumName.t
 
-  val format_t : Format.formatter -> t -> unit
+  val format : Format.formatter -> t -> unit
   val get_info : t -> StructName.info
 
   include Graph.Sig.COMPARABLE with type t := t

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -24,11 +24,11 @@ let struc
     (name : StructName.t)
     (fields : typ StructField.Map.t) : unit =
   Format.fprintf fmt "%a %a %a %a@\n@[<hov 2>  %a@]@\n%a" Print.keyword "struct"
-    StructName.format_t name Print.punctuation "=" Print.punctuation "{"
+    StructName.format name Print.punctuation "=" Print.punctuation "{"
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt (field_name, typ) ->
-         Format.fprintf fmt "%a%a %a" StructField.format_t field_name
+         Format.fprintf fmt "%a%a %a" StructField.format field_name
            Print.punctuation ":" (Print.typ ctx) typ))
     (StructField.Map.bindings fields)
     Print.punctuation "}"
@@ -39,22 +39,22 @@ let enum
     (name : EnumName.t)
     (cases : typ EnumConstructor.Map.t) : unit =
   Format.fprintf fmt "%a %a %a @\n@[<hov 2>  %a@]" Print.keyword "enum"
-    EnumName.format_t name Print.punctuation "="
+    EnumName.format name Print.punctuation "="
     (Format.pp_print_list
        ~pp_sep:(fun fmt () -> Format.fprintf fmt "@\n")
        (fun fmt (field_name, typ) ->
          Format.fprintf fmt "%a %a%a %a" Print.punctuation "|"
-           EnumConstructor.format_t field_name Print.punctuation ":"
+           EnumConstructor.format field_name Print.punctuation ":"
            (Print.typ ctx) typ))
     (EnumConstructor.Map.bindings cases)
 
 let scope ?debug ctx fmt (name, decl) =
   Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@]@\n@[<v 2>  %a@]"
-    Print.keyword "let" Print.keyword "scope" ScopeName.format_t name
+    Print.keyword "let" Print.keyword "scope" ScopeName.format name
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
        (fun fmt (scope_var, (typ, vis)) ->
          Format.fprintf fmt "%a%a%a %a%a%a%a%a" Print.punctuation "("
-           ScopeVar.format_t scope_var Print.punctuation ":" (Print.typ ctx) typ
+           ScopeVar.format scope_var Print.punctuation ":" (Print.typ ctx) typ
            Print.punctuation "|" Print.keyword
            (match Mark.remove vis.Desugared.Ast.io_input with
            | NoInput -> "internal"
@@ -94,8 +94,8 @@ let scope ?debug ctx fmt (name, decl) =
              (Print.expr ?debug ()) e
          | Call (scope_name, subscope_name, _) ->
            Format.fprintf fmt "%a %a%a%a%a" Print.keyword "call"
-             ScopeName.format_t scope_name Print.punctuation "["
-             SubScopeName.format_t subscope_name Print.punctuation "]"))
+             ScopeName.format scope_name Print.punctuation "["
+             SubScopeName.format subscope_name Print.punctuation "]"))
     decl.scope_decl_rules
 
 let print_topdef ctx ppf name (e, ty) =
@@ -104,7 +104,7 @@ let print_topdef ctx ppf name (e, ty) =
     Format.pp_open_hovbox ppf 2;
     Print.keyword ppf "let";
     Format.pp_print_space ppf ();
-    TopdefName.format_t ppf name;
+    TopdefName.format ppf name;
     Print.punctuation ppf ":";
     Format.pp_print_space ppf ();
     Print.typ ctx ppf ty;

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -616,12 +616,12 @@ let rec evaluate_expr :
         Message.raise_spanned_error (Expr.pos e)
           "Invalid field access %a in struct %a (should not happen if the term \
            was well-typed)"
-          StructField.format_t field StructName.format_t s)
+          StructField.format field StructName.format s)
     | _ ->
       Message.raise_spanned_error (Expr.pos e)
         "The expression %a should be a struct %a but is not (should not happen \
          if the term was well-typed)"
-        (Print.expr ()) e StructName.format_t s)
+        (Print.expr ()) e StructName.format s)
   | ETuple es -> Mark.add m (ETuple (List.map (evaluate_expr ctx) es))
   | ETupleAccess { e = e1; index; size } -> (
     match evaluate_expr ctx e1 with

--- a/compiler/shared_ast/qident.ml
+++ b/compiler/shared_ast/qident.ml
@@ -31,16 +31,6 @@ let compare (p1, i1) (p2, i2) =
   match compare_path p1 p2 with 0 -> String.compare i1 i2 | n -> n
 
 let equal (p1, i1) (p2, i2) = equal_path p1 p2 && String.equal i1 i2
-
-module Ord = struct
-  type nonrec t = t
-
-  let compare = compare
-end
-
-module Set = Set.Make (Ord)
-module Map = Map.Make (Ord)
-
 let format_modname ppf m = Format.fprintf ppf "@{<blue>%s@}" m
 
 let format_path ppf p =
@@ -51,3 +41,13 @@ let format_path ppf p =
 let format ppf (p, i) =
   format_path ppf p;
   Format.pp_print_string ppf i
+
+module Ord = struct
+  type nonrec t = t
+
+  let compare = compare
+  let format = format
+end
+
+module Set = Set.Make (Ord)
+module Map = Map.Make (Ord)

--- a/compiler/shared_ast/var.ml
+++ b/compiler/shared_ast/var.ml
@@ -14,6 +14,7 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
+open Catala_utils
 open Definitions
 
 (** {1 Variables and their collections} *)
@@ -58,6 +59,7 @@ module Generic = struct
   let get (Var v) = Bindlib.copy_var v (fun x -> EVar x) (Bindlib.name_of v)
   let compare (Var x) (Var y) = Bindlib.compare_vars x y
   let eq (Var x) (Var y) = Bindlib.eq_vars x y [@@ocaml.warning "-32"]
+  let format ppf v = String.format ppf (Bindlib.name_of (get v))
 end
 
 (* Wrapper around Set.Make to re-add type parameters (avoid inconsistent
@@ -100,6 +102,8 @@ module Map = struct
   let mem x m = mem (t x) m
   let union f m1 m2 = union (fun v x1 x2 -> f (get v) x1 x2) m1 m2
   let fold f m acc = fold (fun v x acc -> f (get v) x acc) m acc
+  let keys m = keys m |> List.map get
+  let values m = values m
 
   (* Add more as needed *)
 end

--- a/compiler/shared_ast/var.mli
+++ b/compiler/shared_ast/var.mli
@@ -71,4 +71,6 @@ module Map : sig
     ('e var -> 'x -> 'x -> 'x option) -> ('e, 'x) t -> ('e, 'x) t -> ('e, 'x) t
 
   val fold : ('e var -> 'x -> 'acc -> 'acc) -> ('e, 'x) t -> 'acc -> 'acc
+  val keys : ('e, 'x) t -> 'e var list
+  val values : ('e, 'x) t -> 'x list
 end

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -215,7 +215,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
                 match Mark.remove arg with
                 | EStruct { fields; _ } ->
                   List.map
-                    (fun (_, field) ->
+                    (fun field ->
                       match Mark.remove field with
                       | EAbs { binder; tys = [(TLit TUnit, _)] } -> (
                         (* Invariant: when calling a function with a thunked
@@ -232,7 +232,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
                           (* same as basic [EAbs case]*)
                           generate_vc_must_not_return_empty ctx field)
                       | _ -> generate_vc_must_not_return_empty ctx field)
-                    (StructField.Map.bindings fields)
+                    (StructField.Map.values fields)
                 | _ -> [generate_vc_must_not_return_empty ctx arg])
               args))
       (Mark.get e)
@@ -458,7 +458,7 @@ let generate_verification_conditions (p : 'm program) (s : ScopeName.t option) :
     (fun vc1 vc2 ->
       let to_str vc =
         Format.asprintf "%s.%s"
-          (Format.asprintf "%a" ScopeName.format_t vc.vc_scope)
+          (Format.asprintf "%a" ScopeName.format vc.vc_scope)
           (Bindlib.name_of (Mark.remove vc.vc_variable))
       in
       String.compare (to_str vc1) (to_str vc2))

--- a/compiler/verification/io.ml
+++ b/compiler/verification/io.ml
@@ -102,7 +102,7 @@ module MakeBackendIO (B : Backend) = struct
         Format.asprintf
           "@[<v>@{<yellow>[%a.%s]@} This variable might return an empty error:@,\
            %a@]"
-          ScopeName.format_t vc.vc_scope
+          ScopeName.format vc.vc_scope
           (Bindlib.name_of (Mark.remove vc.vc_variable))
           Pos.format_loc_text (Mark.get vc.vc_variable)
       | Conditions.NoOverlappingExceptions ->
@@ -110,7 +110,7 @@ module MakeBackendIO (B : Backend) = struct
           "@[<v>@{<yellow>[%a.%s]@} At least two exceptions overlap for this \
            variable:@,\
            %a@]"
-          ScopeName.format_t vc.vc_scope
+          ScopeName.format vc.vc_scope
           (Bindlib.name_of (Mark.remove vc.vc_variable))
           Pos.format_loc_text (Mark.get vc.vc_variable)
     in
@@ -170,7 +170,7 @@ module MakeBackendIO (B : Backend) = struct
     | Fail msg ->
       Message.emit_warning
         "@[<v>@{<yellow>[%a.%s]@} The translation to Z3 failed:@,%s@]"
-        ScopeName.format_t vc.vc_scope
+        ScopeName.format vc.vc_scope
         (Bindlib.name_of (Mark.remove vc.vc_variable))
         msg;
       false

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -344,9 +344,8 @@ and find_or_create_struct (ctx : context) (s : StructName.t) :
     let z3_fieldnames =
       List.map
         (fun f ->
-          Mark.remove (StructField.get_info (fst f))
-          |> Symbol.mk_string ctx.ctx_z3)
-        (StructField.Map.bindings fields)
+          Mark.remove (StructField.get_info f) |> Symbol.mk_string ctx.ctx_z3)
+        (StructField.Map.keys fields)
     in
     let ctx, z3_fieldtypes_rev =
       StructField.Map.fold
@@ -669,9 +668,8 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     let accessors = List.hd (Datatype.get_accessors z3_struct) in
     let idx_mappings =
       List.combine
-        (List.map fst
-           (StructField.Map.bindings
-              (StructName.Map.find name ctx.ctx_decl.ctx_structs)))
+        (StructField.Map.keys
+           (StructName.Map.find name ctx.ctx_decl.ctx_structs))
         accessors
     in
     let _, accessor =
@@ -690,9 +688,8 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     (* This should always succeed if the expression is well-typed in dcalc *)
     let idx_mappings =
       List.combine
-        (List.map fst
-           (EnumConstructor.Map.bindings
-              (EnumName.Map.find name ctx.ctx_decl.ctx_enums)))
+        (EnumConstructor.Map.keys
+           (EnumName.Map.find name ctx.ctx_decl.ctx_enums))
         ctrs
     in
     let _, ctr =
@@ -721,7 +718,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
         (translate_match_arm z3_arg)
         ctx
         (List.combine
-           (List.map snd (EnumConstructor.Map.bindings cases))
+           (EnumConstructor.Map.values cases)
            (Datatype.get_accessors z3_enum))
     in
     let z3_arms =


### PR DESCRIPTION
and use them throughout. No more `List.map fst (Map.bindings m)` !

Also adds some facilities for direct formatting without going through a
list.