### PR TITLE
Fix build failure due to breaking change in `ppx_yojson_conv`

### DIFF
--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -13,6 +13,7 @@
    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
    License for the specific language governing permissions and limitations under
    the License. *)
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
 
 type nonrec unit = unit
 type nonrec bool = bool


### PR DESCRIPTION
There is a breaking change in version 0.16.0 of [ppx_yojson_conv](https://github.com/janestreet/ppx_yojson_conv/) that causes catala to fail to build: 

```
File "runtimes/ocaml/runtime.ml", line 28, characters 49-53:
28 | type io_log = { io_input : io_input; io_output : bool } [@@deriving yojson_of]
                                                      ^^^^
Error: Unbound value yojson_of_bool
```

This occurs since yojson primitives are now not exposed by default. See https://github.com/janestreet/ppx_yojson_conv/issues/18. To fix this, I added an explicit open to the primitives module. I guess it could also be fixed by restricting the version of the dependency to `<= 0.15.1` instead.