### PR TITLE
bugfix: address breaking change in markdown-mode v2.6

### DIFF
--- a/syntax_highlighting/emacs/catala-mode.el
+++ b/syntax_highlighting/emacs/catala-mode.el
@@ -65,6 +65,8 @@
         (catala-mode-fr)
       (catala-mode-en)))
   (run-mode-hooks 'catala-code-mode-hook))
+;; needed due to <https://github.com/jrblevin/markdown-mode/pull/764>
+(add-to-list 'auto-mode-alist '("\\.catala" . catala-code-mode))
 
 (provide 'catala-code-mode)
 


### PR DESCRIPTION
https://github.com/jrblevin/markdown-mode/pull/764 (part of `markdown-mode` v2.6) makes it so that highlighting doesn't work unless a language mode is in `auto-mode-alist`.

this commit fixes syntax highlighting for `catala` blocks in Emacs.