### PR TITLE
Temporarily disable unstable test

### DIFF
--- a/tests/test_modules/good/mod_use.catala_en
+++ b/tests/test_modules/good/mod_use.catala_en
@@ -20,7 +20,9 @@ scope T2:
   assertion o4 = 5.0
 ```
 
-```catala-test-inline
+The following test is disabled at the moment because it requires prior compilation of the module. This will be fixed with the new Clerk version that handles dependencies transparently.
+
+```disabled catala-test-inline
 $ catala interpret -s T2 --disable_warnings --use mod_def.catala_en
 [RESULT] Computation successful! Results:
 [RESULT] o1 = No ()


### PR DESCRIPTION
The mod_use test requires prior compilation of the module which the build system
doesn't guarantee. This will be fixed with the new Clerk version that handles
dependencies transparently, disabled until then to avoid spurious failures..