### PR TITLE
Fixes OCaml error not caught in JS

### DIFF
--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -355,7 +355,9 @@ module To_jsoo = struct
         | Topdef _ -> ()
         | ScopeDef (_name, body) ->
           let fmt_fun_call fmt _ =
-            Format.fprintf fmt "@[<hv>%a@ |> %a_of_jsoo@ |> %a@ |> %a_to_jsoo@]"
+            Format.fprintf fmt
+              "@[<hv>@[<hv 2>execute_or_throw_error@ (@[<hv 2>fun () ->@ %a@ \
+               |> %a_of_jsoo@ |> %a@ |> %a_to_jsoo@])@]@]"
               fmt_input_struct_name body fmt_input_struct_name body format_var
               var fmt_output_struct_name body
           in

--- a/french_law/ocaml/api_web.ml
+++ b/french_law/ocaml/api_web.ml
@@ -31,21 +31,19 @@ let () =
        method computeAllocationsFamiliales
            : (AF_web.interface_allocations_familiales_in -> float) Js.callback =
          Js.wrap_callback (fun interface_allocations_familiales_in ->
-             execute_or_throw_error (fun () ->
-                 let result =
-                   interface_allocations_familiales_in
-                   |> AF_web.interface_allocations_familiales
-                 in
-                 result##.iMontantVerse))
+             let result =
+               interface_allocations_familiales_in
+               |> AF_web.interface_allocations_familiales
+             in
+             result##.iMontantVerse)
 
        method computeAidesAuLogement
            : (AL_web.calculette_aides_au_logement_garde_alternee_in -> float)
              Js.callback =
          Js.wrap_callback (fun calculette_aides_au_logement_garde_alternee_in ->
-             execute_or_throw_error (fun () ->
-                 let result =
-                   calculette_aides_au_logement_garde_alternee_in
-                   |> AL_web.calculette_aides_au_logement_garde_alternee
-                 in
-                 result##.aideFinale))
+             let result =
+               calculette_aides_au_logement_garde_alternee_in
+               |> AL_web.calculette_aides_au_logement_garde_alternee
+             in
+             result##.aideFinale)
     end)

--- a/tests/test_modules/good/.gitignore
+++ b/tests/test_modules/good/.gitignore
@@ -1,0 +1,5 @@
+*.cmi
+*.cmx
+*.cmxs
+*.ml
+*.o


### PR DESCRIPTION
Moves the call to `execute_and_throw_error` from the manually-written API to the API-generator plugin.