### PR TITLE
Improve assertion failure message

### DIFF
--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -1254,4 +1254,8 @@ let translate_program (prgm : 'm Scopelang.Ast.program) : 'm Ast.program =
         ctx )
   in
   let items, ctx = translate_defs top_ctx defs_ordering in
-  { code_items = Bindlib.unbox items; decl_ctx = ctx.decl_ctx }
+  {
+    code_items = Bindlib.unbox items;
+    decl_ctx = ctx.decl_ctx;
+    lang = prgm.program_lang;
+  }

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -233,6 +233,7 @@ type program = {
   program_topdefs : (expr option * typ) TopdefName.Map.t;
   program_ctx : decl_ctx;
   program_modules : program ModuleName.Map.t;
+  program_lang : Cli.backend_lang;
 }
 
 let rec locations_used e : LocationSet.t =

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -117,6 +117,7 @@ type program = {
   program_topdefs : (expr option * typ) TopdefName.Map.t;
   program_ctx : decl_ctx;
   program_modules : program ModuleName.Map.t;
+  program_lang : Cli.backend_lang;
 }
 
 (** {1 Helpers} *)

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -1468,6 +1468,7 @@ let translate_program (ctxt : Name_resolution.context) (surface : S.program) :
         ModuleName.Map.map make_ctx ctxt.Name_resolution.modules
       in
       {
+        Ast.program_lang = surface.program_lang;
         Ast.program_ctx =
           {
             (* After name resolution, type definitions (structs and enums) are

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -356,7 +356,7 @@ let transform_closures_program (p : 'm program) : 'm program Bindlib.box =
   in
   Bindlib.box_apply
     (fun new_code_items ->
-      { code_items = new_code_items; decl_ctx = new_decl_ctx })
+      { code_items = new_code_items; decl_ctx = new_decl_ctx; lang = p.lang })
     new_code_items
 
 (** {1 Hoisting closures}*)

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -769,4 +769,4 @@ let translate_program (prgm : typed D.program) : untyped A.program =
   (* program is closed here. *)
   let code_items = Bindlib.unbox code_items in
 
-  Program.untype { decl_ctx; code_items }
+  Program.untype { decl_ctx; code_items; lang = prgm.lang }

--- a/compiler/plugins/explain.ml
+++ b/compiler/plugins/explain.ml
@@ -310,7 +310,12 @@ let rec lazy_eval : decl_ctx -> Env.t -> laziness_level -> expr -> expr * Env.t
             renv := env;
             e
           in
-          let e = Interpreter.evaluate_operator eval op m args in
+          let e =
+            Interpreter.evaluate_operator eval op m Cli.En
+              (* Default language to English but this should not raise any error
+                 messages so we don't care. *)
+              args
+          in
           e, !renv
       (* fixme: this forwards eempty *)
       | e, _ -> error e "Invalid apply on %a" Expr.format e)

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -130,7 +130,11 @@ let rec lazy_eval :
             renv := env;
             e
           in
-          Interpreter.evaluate_operator eval op m args, !renv
+          ( Interpreter.evaluate_operator eval op m Cli.En
+              (* Default language to English but this should not raise any error
+                 messages so we don't care. *)
+              args,
+            !renv )
       (* fixme: this forwards eempty *)
       | e, _ -> error e "Invalid apply on %a" Expr.format e)
   | (EAbs _ | ELit _ | EOp _ | EEmptyError), _ -> e0, env (* these are values *)

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -55,6 +55,7 @@ type 'm program = {
   program_topdefs : ('m expr * typ) TopdefName.Map.t;
   program_modules : nil program ModuleName.Map.t;
   program_ctx : decl_ctx;
+  program_lang : Cli.backend_lang;
 }
 
 let type_rule decl_ctx env = function

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -51,6 +51,7 @@ type 'm program = {
      expressions. They won't contain any rules or topdefs, but will still have
      the scope signatures needed to respect the call convention *)
   program_ctx : decl_ctx;
+  program_lang : Cli.backend_lang;
 }
 
 val type_program : 'm program -> typed program

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -831,6 +831,7 @@ let translate_program
             process_modules
               (ModuleName.Map.find modname program_ctx.ctx_modules)
               m_desugared;
+          Ast.program_lang = desugared.program_lang;
         })
       desugared.D.program_modules
   in
@@ -855,4 +856,5 @@ let translate_program
     Ast.program_scopes;
     Ast.program_ctx;
     Ast.program_modules;
+    Ast.program_lang = desugared.program_lang;
   }

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -666,4 +666,8 @@ type decl_ctx = {
   ctx_modules : decl_ctx ModuleName.Map.t;
 }
 
-type 'e program = { decl_ctx : decl_ctx; code_items : 'e code_item_list }
+type 'e program = {
+  decl_ctx : decl_ctx;
+  code_items : 'e code_item_list;
+  lang : Cli.backend_lang;
+}

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -102,7 +102,7 @@ exception CatalaException of except
 (* Todo: this should be handled early when resolving overloads. Here we have
    proper structural equality, but the OCaml backend for example uses the
    builtin equality function instead of this. *)
-let handle_eq evaluate_operator pos e1 e2 =
+let handle_eq evaluate_operator pos lang e1 e2 =
   let open Runtime.Oper in
   match e1, e2 with
   | ELit LUnit, ELit LUnit -> true
@@ -116,7 +116,7 @@ let handle_eq evaluate_operator pos e1 e2 =
     try
       List.for_all2
         (fun e1 e2 ->
-          match Mark.remove (evaluate_operator Eq pos [e1; e2]) with
+          match Mark.remove (evaluate_operator Eq pos lang [e1; e2]) with
           | ELit (LBool b) -> b
           | _ -> assert false
           (* should not happen *))
@@ -126,7 +126,7 @@ let handle_eq evaluate_operator pos e1 e2 =
     StructName.equal s1 s2
     && StructField.Map.equal
          (fun e1 e2 ->
-           match Mark.remove (evaluate_operator Eq pos [e1; e2]) with
+           match Mark.remove (evaluate_operator Eq pos lang [e1; e2]) with
            | ELit (LBool b) -> b
            | _ -> assert false
            (* should not happen *))
@@ -137,7 +137,7 @@ let handle_eq evaluate_operator pos e1 e2 =
       EnumName.equal en1 en2
       && EnumConstructor.equal i1 i2
       &&
-      match Mark.remove (evaluate_operator Eq pos [e1; e2]) with
+      match Mark.remove (evaluate_operator Eq pos lang [e1; e2]) with
       | ELit (LBool b) -> b
       | _ -> assert false
       (* should not happen *)
@@ -149,6 +149,7 @@ let rec evaluate_operator
     evaluate_expr
     (op : < overloaded : no ; .. > operator)
     m
+    lang
     args =
   let pos = Expr.mark_pos m in
   let protect f x y =
@@ -183,7 +184,8 @@ let rec evaluate_operator
           (fun i arg ->
             ( Some
                 (Format.asprintf "Argument n°%d, value %a" (i + 1)
-                   (Print.expr ()) arg),
+                   (Print.UserFacing.expr lang)
+                   arg),
               Expr.pos arg ))
           args)
       "Operator %a applied to the wrong arguments\n\
@@ -210,7 +212,7 @@ let rec evaluate_operator
     Mark.remove e'
   | (ToClosureEnv | FromClosureEnv), _ -> err ()
   | Eq, [(e1, _); (e2, _)] ->
-    ELit (LBool (handle_eq (evaluate_operator evaluate_expr) m e1 e2))
+    ELit (LBool (handle_eq (evaluate_operator evaluate_expr) m lang e1 e2))
   | Map, [f; (EArray es, _)] ->
     EArray
       (List.map
@@ -539,8 +541,11 @@ and val_to_runtime :
 
 let rec evaluate_expr :
     type d e.
-    decl_ctx -> ((d, e, yes) astk, 't) gexpr -> ((d, e, yes) astk, 't) gexpr =
- fun ctx e ->
+    decl_ctx ->
+    Cli.backend_lang ->
+    ((d, e, yes) astk, 't) gexpr ->
+    ((d, e, yes) astk, 't) gexpr =
+ fun ctx lang e ->
   let m = Mark.get e in
   let pos = Expr.mark_pos m in
   match Mark.remove e with
@@ -578,32 +583,33 @@ let rec evaluate_expr :
          have different capitalisation rules inherited from the input *)
     in
     let o = Runtime.lookup_value runtime_path in
-    runtime_to_val evaluate_expr ctx m ty o
+    runtime_to_val (fun ctx -> evaluate_expr ctx lang) ctx m ty o
   | EApp { f = e1; args } -> (
-    let e1 = evaluate_expr ctx e1 in
-    let args = List.map (evaluate_expr ctx) args in
+    let e1 = evaluate_expr ctx lang e1 in
+    let args = List.map (evaluate_expr ctx lang) args in
     propagate_empty_error e1
     @@ fun e1 ->
     match Mark.remove e1 with
     | EAbs { binder; _ } ->
       if Bindlib.mbinder_arity binder = List.length args then
-        evaluate_expr ctx
+        evaluate_expr ctx lang
           (Bindlib.msubst binder (Array.of_list (List.map Mark.remove args)))
       else
         Message.raise_spanned_error pos
           "wrong function call, expected %d arguments, got %d"
           (Bindlib.mbinder_arity binder)
           (List.length args)
-    | EOp { op; _ } -> evaluate_operator (evaluate_expr ctx) op m args
+    | EOp { op; _ } -> evaluate_operator (evaluate_expr ctx lang) op m lang args
     | ECustom { obj; targs; tret } ->
       (* Applies the arguments one by one to the curried form *)
       List.fold_left2
         (fun fobj targ arg ->
           (Obj.obj fobj : Obj.t -> Obj.t)
-            (val_to_runtime evaluate_expr ctx targ arg))
+            (val_to_runtime (fun ctx -> evaluate_expr ctx lang) ctx targ arg))
         obj targs args
       |> Obj.obj
-      |> fun o -> runtime_to_val evaluate_expr ctx m tret o
+      |> fun o ->
+      runtime_to_val (fun ctx -> evaluate_expr ctx lang) ctx m tret o
     | _ ->
       Message.raise_spanned_error pos
         "function has not been reduced to a lambda at evaluation (should not \
@@ -614,7 +620,7 @@ let rec evaluate_expr :
   (* | EAbs _ as e -> Marked.mark m e (* these are values *) *)
   | EStruct { fields = es; name } ->
     let fields, es = List.split (StructField.Map.bindings es) in
-    let es = List.map (evaluate_expr ctx) es in
+    let es = List.map (evaluate_expr ctx lang) es in
     propagate_empty_error_list es
     @@ fun es ->
     Mark.add m
@@ -626,7 +632,7 @@ let rec evaluate_expr :
            name;
          })
   | EStructAccess { e; name = s; field } -> (
-    propagate_empty_error (evaluate_expr ctx e)
+    propagate_empty_error (evaluate_expr ctx lang e)
     @@ fun e ->
     match Mark.remove e with
     | EStruct { fields = es; name } -> (
@@ -646,21 +652,23 @@ let rec evaluate_expr :
       Message.raise_spanned_error (Expr.pos e)
         "The expression %a should be a struct %a but is not (should not happen \
          if the term was well-typed)"
-        (Print.expr ()) e StructName.format s)
-  | ETuple es -> Mark.add m (ETuple (List.map (evaluate_expr ctx) es))
+        (Print.UserFacing.expr lang)
+        e StructName.format s)
+  | ETuple es -> Mark.add m (ETuple (List.map (evaluate_expr ctx lang) es))
   | ETupleAccess { e = e1; index; size } -> (
-    match evaluate_expr ctx e1 with
+    match evaluate_expr ctx lang e1 with
     | ETuple es, _ when List.length es = size -> List.nth es index
     | e ->
       Message.raise_spanned_error (Expr.pos e)
         "The expression %a was expected to be a tuple of size %d (should not \
          happen if the term was well-typed)"
-        (Print.expr ()) e size)
+        (Print.UserFacing.expr lang)
+        e size)
   | EInj { e; name; cons } ->
-    propagate_empty_error (evaluate_expr ctx e)
+    propagate_empty_error (evaluate_expr ctx lang e)
     @@ fun e -> Mark.add m (EInj { e; name; cons })
   | EMatch { e; cases; name } -> (
-    propagate_empty_error (evaluate_expr ctx e)
+    propagate_empty_error (evaluate_expr ctx lang e)
     @@ fun e ->
     match Mark.remove e with
     | EInj { e = e1; cons; name = name' } ->
@@ -678,32 +686,32 @@ let rec evaluate_expr :
              well-typed)"
       in
       let new_e = Mark.add m (EApp { f = es_n; args = [e1] }) in
-      evaluate_expr ctx new_e
+      evaluate_expr ctx lang new_e
     | _ ->
       Message.raise_spanned_error (Expr.pos e)
         "Expected a term having a sum type as an argument to a match (should \
          not happen if the term was well-typed")
   | EIfThenElse { cond; etrue; efalse } -> (
-    propagate_empty_error (evaluate_expr ctx cond)
+    propagate_empty_error (evaluate_expr ctx lang cond)
     @@ fun cond ->
     match Mark.remove cond with
-    | ELit (LBool true) -> evaluate_expr ctx etrue
-    | ELit (LBool false) -> evaluate_expr ctx efalse
+    | ELit (LBool true) -> evaluate_expr ctx lang etrue
+    | ELit (LBool false) -> evaluate_expr ctx lang efalse
     | _ ->
       Message.raise_spanned_error (Expr.pos cond)
         "Expected a boolean literal for the result of this condition (should \
          not happen if the term was well-typed)")
   | EArray es ->
-    propagate_empty_error_list (List.map (evaluate_expr ctx) es)
+    propagate_empty_error_list (List.map (evaluate_expr ctx lang) es)
     @@ fun es -> Mark.add m (EArray es)
   | EAssert e' ->
-    propagate_empty_error (evaluate_expr ctx e') (fun e ->
+    propagate_empty_error (evaluate_expr ctx lang e') (fun e ->
         match Mark.remove e with
         | ELit (LBool true) -> Mark.add m (ELit LUnit)
         | ELit (LBool false) ->
           Message.raise_spanned_error (Expr.pos e') "Assertion failed:@\n%a"
-            (Print.expr ())
-            (partially_evaluate_expr_for_assertion_failure_message ctx
+            (Print.UserFacing.expr (assert false))
+            (partially_evaluate_expr_for_assertion_failure_message ctx lang
                (Expr.skip_wrappers e'))
         | _ ->
           Message.raise_spanned_error (Expr.pos e')
@@ -712,21 +720,21 @@ let rec evaluate_expr :
   | ECustom _ -> e
   | EEmptyError -> Mark.copy e EEmptyError
   | EErrorOnEmpty e' -> (
-    match evaluate_expr ctx e' with
+    match evaluate_expr ctx lang e' with
     | EEmptyError, _ ->
       Message.raise_spanned_error (Expr.pos e')
         "This variable evaluated to an empty term (no rule that defined it \
          applied in this situation)"
     | e -> e)
   | EDefault { excepts; just; cons } -> (
-    let excepts = List.map (evaluate_expr ctx) excepts in
+    let excepts = List.map (evaluate_expr ctx lang) excepts in
     let empty_count = List.length (List.filter is_empty_error excepts) in
     match List.length excepts - empty_count with
     | 0 -> (
-      let just = evaluate_expr ctx just in
+      let just = evaluate_expr ctx lang just in
       match Mark.remove just with
       | EEmptyError -> Mark.add m EEmptyError
-      | ELit (LBool true) -> evaluate_expr ctx cons
+      | ELit (LBool true) -> evaluate_expr ctx lang cons
       | ELit (LBool false) -> Mark.copy e EEmptyError
       | _ ->
         Message.raise_spanned_error (Expr.pos e)
@@ -743,15 +751,18 @@ let rec evaluate_expr :
          the same variable.")
   | ERaise exn -> raise (CatalaException exn)
   | ECatch { body; exn; handler } -> (
-    try evaluate_expr ctx body
+    try evaluate_expr ctx lang body
     with CatalaException caught when Expr.equal_except caught exn ->
-      evaluate_expr ctx handler)
+      evaluate_expr ctx lang handler)
   | _ -> .
 
 and partially_evaluate_expr_for_assertion_failure_message :
     type d e.
-    decl_ctx -> ((d, e, yes) astk, 't) gexpr -> ((d, e, yes) astk, 't) gexpr =
- fun ctx e ->
+    decl_ctx ->
+    Cli.backend_lang ->
+    ((d, e, yes) astk, 't) gexpr ->
+    ((d, e, yes) astk, 't) gexpr =
+ fun ctx lang e ->
   (* Here we want to print an expression that explains why an assertion has
      failed. Since assertions have type [bool] and are usually constructed with
      comparisons and logical operators, we leave those unevaluated at the top of
@@ -773,12 +784,12 @@ and partially_evaluate_expr_for_assertion_failure_message :
           f = EOp op, m;
           args =
             [
-              partially_evaluate_expr_for_assertion_failure_message ctx e1;
-              partially_evaluate_expr_for_assertion_failure_message ctx e2;
+              partially_evaluate_expr_for_assertion_failure_message ctx lang e1;
+              partially_evaluate_expr_for_assertion_failure_message ctx lang e2;
             ];
         },
       Mark.get e )
-  | _ -> evaluate_expr ctx e
+  | _ -> evaluate_expr ctx lang e
 
 (* Typing shenanigan to add custom terms to the AST type. This is an identity
    and could be optimised into [Obj.magic]. *)
@@ -827,7 +838,7 @@ let interpret_program_lcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
     =
   let e = Expr.unbox @@ Program.to_expr p s in
   let ctx = p.decl_ctx in
-  match evaluate_expr ctx (addcustom e) with
+  match evaluate_expr ctx p.lang (addcustom e) with
   | (EAbs { tys = [((TStruct s_in, _) as _targs)]; _ }, mark_e) as e -> begin
     (* At this point, the interpreter seeks to execute the scope but does not
        have a way to retrieve input values from the command line. [taus] contain
@@ -857,7 +868,7 @@ let interpret_program_lcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
         [Expr.estruct ~name:s_in ~fields:application_term mark_e]
         (Expr.pos e)
     in
-    match Mark.remove (evaluate_expr ctx (Expr.unbox to_interpret)) with
+    match Mark.remove (evaluate_expr ctx p.lang (Expr.unbox to_interpret)) with
     | EStruct { fields; _ } ->
       List.map
         (fun (fld, e) -> StructField.get_info fld, delcustom e)
@@ -877,7 +888,7 @@ let interpret_program_dcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
     =
   let ctx = p.decl_ctx in
   let e = Expr.unbox (Program.to_expr p s) in
-  match evaluate_expr p.decl_ctx (addcustom e) with
+  match evaluate_expr p.decl_ctx p.lang (addcustom e) with
   | (EAbs { tys = [((TStruct s_in, _) as _targs)]; _ }, mark_e) as e -> begin
     (* At this point, the interpreter seeks to execute the scope but does not
        have a way to retrieve input values from the command line. [taus] contain
@@ -908,7 +919,7 @@ let interpret_program_dcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
         [Expr.estruct ~name:s_in ~fields:application_term mark_e]
         (Expr.pos e)
     in
-    match Mark.remove (evaluate_expr ctx (Expr.unbox to_interpret)) with
+    match Mark.remove (evaluate_expr ctx p.lang (Expr.unbox to_interpret)) with
     | EStruct { fields; _ } ->
       List.map
         (fun (fld, e) -> StructField.get_info fld, delcustom e)
@@ -927,7 +938,7 @@ let interpret_program_dcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
    external functions), straying away from the DCalc and LCalc ASTS. [addcustom]
    and [delcustom] are needed to expand and shrink the type of the terms to
    reflect that. *)
-let evaluate_expr ctx e = delcustom (evaluate_expr ctx (addcustom e))
+let evaluate_expr ctx lang e = delcustom (evaluate_expr ctx lang (addcustom e))
 
 let load_runtime_modules = function
   | [] -> ()

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -710,7 +710,7 @@ let rec evaluate_expr :
         | ELit (LBool true) -> Mark.add m (ELit LUnit)
         | ELit (LBool false) ->
           Message.raise_spanned_error (Expr.pos e') "Assertion failed:@\n%a"
-            (Print.UserFacing.expr (assert false))
+            (Print.UserFacing.expr lang)
             (partially_evaluate_expr_for_assertion_failure_message ctx lang
                (Expr.skip_wrappers e'))
         | _ ->

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -752,6 +752,11 @@ and partially_evaluate_expr_for_assertion_failure_message :
     type d e.
     decl_ctx -> ((d, e, yes) astk, 't) gexpr -> ((d, e, yes) astk, 't) gexpr =
  fun ctx e ->
+  (* Here we want to print an expression that explains why an assertion has
+     failed. Since assertions have type [bool] and are usually constructed with
+     comparisons and logical operators, we leave those unevaluated at the top of
+     the AST while evaluating everything below. This makes for a good error
+     message. *)
   match Mark.remove e with
   | EApp { f = EOp ({ op = op_kind; _ } as op), m; args = [e1; e2] }
     when match op_kind with

--- a/compiler/shared_ast/interpreter.mli
+++ b/compiler/shared_ast/interpreter.mli
@@ -39,6 +39,7 @@ val evaluate_operator :
   (((< features ; .. > as 'a), 'm) gexpr -> ('a, 'm) gexpr) ->
   'a operator ->
   'm mark ->
+  Cli.backend_lang ->
   ('a, 'm) gexpr list ->
   ('a, 'm) gexpr
 (** Evaluates the result of applying the given operator to the given arguments,
@@ -47,7 +48,10 @@ val evaluate_operator :
     operator. *)
 
 val evaluate_expr :
-  decl_ctx -> (((_, _) dcalc_lcalc as 'a), 'm) gexpr -> ('a, 'm) gexpr
+  decl_ctx ->
+  Cli.backend_lang ->
+  (((_, _) dcalc_lcalc as 'a), 'm) gexpr ->
+  ('a, 'm) gexpr
 (** Evaluates an expression according to the semantics of the default calculus. *)
 
 val interpret_program_dcalc :

--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -228,7 +228,12 @@ let rec optimize_expr :
         (* at this point we know a conflict error will be triggered so we just
            feed the expression to the interpreter that will print the beautiful
            right error message *)
-        let (_ : _ gexpr) = Interpreter.evaluate_expr ctx.decl_ctx e in
+        let (_ : _ gexpr) =
+          Interpreter.evaluate_expr ctx.decl_ctx Cli.En
+            (* Default language to English, no errors should be raised normally
+               so we don't care *)
+            e
+        in
         assert false
       else
         match excepts, just with

--- a/compiler/shared_ast/program.ml
+++ b/compiler/shared_ast/program.ml
@@ -17,15 +17,15 @@
 
 open Definitions
 
-let map_exprs ~f ~varf { code_items; decl_ctx } =
+let map_exprs ~f ~varf { code_items; decl_ctx; lang } =
   Bindlib.box_apply
-    (fun code_items -> { code_items; decl_ctx })
+    (fun code_items -> { code_items; decl_ctx; lang })
     (Scope.map_exprs ~f ~varf code_items)
 
-let fold_left_exprs ~f ~init { code_items; decl_ctx = _ } =
+let fold_left_exprs ~f ~init { code_items; _ } =
   Scope.fold_left ~f:(fun acc e _ -> f acc e) ~init code_items
 
-let fold_right_exprs ~f ~init { code_items; decl_ctx = _ } =
+let fold_right_exprs ~f ~init { code_items; _ } =
   Scope.fold_right ~f:(fun e _ acc -> f e acc) ~init code_items
 
 let empty_ctx =

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -1041,6 +1041,7 @@ let program ~leave_unresolved prg =
       prg.A.code_items
   in
   {
+    A.lang = prg.lang;
     A.code_items = Bindlib.unbox code_items;
     decl_ctx =
       {

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -318,6 +318,7 @@ and program = {
   program_items : law_structure list;
   program_source_files : (string[@opaque]) list;
   program_modules : (uident * interface) list;
+  program_lang : Cli.backend_lang; [@opaque]
 }
 
 and source_file = law_structure list

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -232,6 +232,7 @@ let rec parse_source_file
     program_items = program.Ast.program_items;
     program_source_files = source_file_name :: program.Ast.program_source_files;
     program_modules = [];
+    program_lang = language;
   }
 
 (** Expands the include directives in a parsing result, thus parsing new source
@@ -254,12 +255,14 @@ and expand_includes
             acc.Ast.program_items @ includ_program.program_items;
           Ast.program_modules =
             acc.Ast.program_modules @ includ_program.program_modules;
+          Ast.program_lang = language;
         }
       | Ast.LawHeading (heading, commands') ->
         let {
           Ast.program_items = commands';
           Ast.program_source_files = new_sources;
           Ast.program_modules = new_modules;
+          Ast.program_lang = _;
         } =
           expand_includes source_file commands' language
         in
@@ -268,12 +271,14 @@ and expand_includes
           Ast.program_items =
             acc.Ast.program_items @ [Ast.LawHeading (heading, commands')];
           Ast.program_modules = acc.Ast.program_modules @ new_modules;
+          Ast.program_lang = language;
         }
       | i -> { acc with Ast.program_items = acc.Ast.program_items @ [i] })
     {
       Ast.program_source_files = [];
       Ast.program_items = [];
       Ast.program_modules = [];
+      Ast.program_lang = language;
     }
     commands
 


### PR DESCRIPTION
By partially evaluating the assertion failed and leaving the top-most comparison and logical operators intact, the error message now helps the user quickly locate which part of the assertion failed. Example : 

```text
[ERROR]
Assertion failed:
[ ¤1874.09; ¤2248.91 ] = [ ¤1874.09; ¤2247.91 ] && (1 >! 3 || 8 = 1)

┌─⯈ tests/traitements_salaires.catala_fr:262.5-264.49:
└───┐
262 │     résultats.abattement_pensions_retraites_rentes pour résultats parmi
    │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
263 │       calcul.déclarations_avec_résultats_traitements_salaires
    │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
264 │     = [1874,09 €; 2247,91 €] et (1 > 3 ou 8 = 1)
    │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    └┬ Le
     └─ Cas de test 4
``` 

To enable the printing of money sums with the correct localized printer, this PR also stores the surface language (English, French, etc. in the module and propagates it through the compilation chain).