### PR TITLE
Internally type default terms in the compiler

### DIFF
--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -346,6 +346,10 @@ module Flags = struct
     & flag
     & info ["check_invariants"] ~doc:"Check structural invariants on the AST."
 
+  let no_typing =
+    value & flag & info ["no-typing"] ~doc:
+      "Don't check the consistency of types"
+
   let wrap_weaved_output =
     value
     & flag

--- a/compiler/catala_utils/cli.mli
+++ b/compiler/catala_utils/cli.mli
@@ -113,6 +113,7 @@ module Flags : sig
   (** Parsers for all flags and options that commands can use *)
 
   val check_invariants : bool Term.t
+  val no_typing : bool Term.t
   val wrap_weaved_output : bool Term.t
   val print_only_law : bool Term.t
   val ex_scope : string Term.t

--- a/compiler/catala_web_interpreter.ml
+++ b/compiler/catala_web_interpreter.ml
@@ -25,7 +25,7 @@ let () =
          in
          let prg, ctx, _type_order =
            Passes.dcalc options ~includes:[] ~optimize:false
-             ~check_invariants:false
+             ~check_invariants:false ~typed:Shared_ast.Expr.typed
          in
          Shared_ast.Interpreter.interpret_program_dcalc prg
            (Commands.get_scope_uid ctx scope)

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -293,11 +293,13 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm Scopelang.Ast.expr) :
               ]
               "Definition of input variable '%a' missing in this scope call"
               ScopeVar.format var_name
-          | None, Some _ ->
-            Message.raise_multispanned_error
+          | None, Some e ->
+            Message.raise_multispanned_error_full
+              ~suggestion:(List.map (fun v -> Mark.remove (ScopeVar.get_info v))
+                             (ScopeVar.Map.keys sc_sig.scope_sig_in_fields))
               [
-                None, pos;
-                ( Some "Declaration of scope '%a'",
+                None, Expr.pos e;
+                ( Some (fun ppf -> Format.fprintf ppf "Declaration of scope %a" ScopeName.format scope),
                   Mark.get (ScopeName.get_info scope) );
               ]
               "Unknown input variable '%a' in scope call of '%a'"

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -117,9 +117,12 @@ let merge_defaults
           (Expr.with_ty m_callee
              (Mark.add (Expr.mark_pos m_callee) (TLit TBool)))
       in
-      let d = Expr.edefault [caller] ltrue (Expr.rebox body) m_body in
+      let d =
+        Expr.edefault [caller] ltrue (Expr.rebox body)
+          (Expr.map_ty (fun (_, pos as t) -> TDefault t, pos) m_body)
+      in
       Expr.make_abs vars
-        (Expr.eerroronempty d m_body)
+        (Expr.make_erroronempty d)
         tys (Expr.mark_pos m_callee)
     | _ -> assert false
     (* should not happen because there should always be a lambda at the
@@ -138,7 +141,8 @@ let merge_defaults
         Expr.elit (LBool true)
           (Expr.with_ty m (Mark.add (Expr.mark_pos m) (TLit TBool)))
       in
-      Expr.eerroronempty (Expr.edefault [caller] ltrue callee m) m
+      Expr.make_erroronempty (Expr.edefault [caller] ltrue callee
+          (Expr.map_ty (fun (_, pos as t) -> TDefault t, pos) m))
     in
     body
 
@@ -216,7 +220,7 @@ let input_var_typ typ io_in =
 let thunk_scope_arg var_ctx e =
   match var_ctx.scope_input_io, var_ctx.scope_input_thunked with
   | (Runtime.NoInput, _), _ -> invalid_arg "thunk_scope_arg"
-  | (Runtime.OnlyInput, _), false -> Expr.eerroronempty e (Mark.get e)
+  | (Runtime.OnlyInput, _), false -> Expr.make_erroronempty e
   | (Runtime.Reentrant, _), false -> e
   | (Runtime.Reentrant, pos), true ->
     Expr.make_abs [| Var.make "_" |] e [TLit TUnit, pos] pos
@@ -626,8 +630,7 @@ let translate_rule
       | OnlyInput -> failwith "should not happen"
       (* scopelang should not contain any definitions of input only variables *)
       | Reentrant -> merge_defaults ~is_func a_expr new_e
-      | NoInput ->
-        if is_func then new_e else Expr.eerroronempty new_e (pos_mark_as a_name)
+      | NoInput -> new_e
     in
     let merged_expr =
       tag_with_log_entry merged_expr
@@ -682,11 +685,11 @@ let translate_rule
     let thunked_or_nonempty_new_e =
       match a_io.Desugared.Ast.io_input with
       | Runtime.NoInput, _ -> assert false
-      | Runtime.OnlyInput, _ -> Expr.eerroronempty new_e (Mark.get new_e)
+      | Runtime.OnlyInput, _ -> Expr.make_erroronempty (new_e)
       | Runtime.Reentrant, pos -> (
         match Mark.remove tau with
-        | TArrow _ -> new_e
-        | _ -> Expr.thunk_term new_e (Expr.with_pos pos (Mark.get new_e)))
+        | TArrow _ -> (new_e)
+        | _ -> Expr.thunk_term (new_e) (Expr.with_pos pos (Mark.get new_e)))
     in
     ( (fun next ->
         Bindlib.box_apply2
@@ -890,7 +893,7 @@ let translate_rule
                      defined, we add an check "ErrorOnEmpty" here. *)
                   Mark.add
                     (Expr.map_ty (fun _ -> scope_let_typ) (Mark.get e))
-                    (EAssert (Mark.copy e (EErrorOnEmpty new_e)));
+                    (EAssert (Expr.unbox (Expr.make_erroronempty (Expr.box new_e))));
                 scope_let_kind = Assertion;
               })
           (Bindlib.bind_var (Var.make "_") next)

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -739,10 +739,22 @@ let translate_rule
           | _ -> true)
         all_subscope_vars
     in
+    let called_scope_input_struct = subscope_sig.scope_sig_input_struct in
+    let called_scope_return_struct = subscope_sig.scope_sig_output_struct in
     let all_subscope_output_vars =
-      List.filter
+      List.filter_map
         (fun var_ctx ->
-          Mark.remove var_ctx.scope_var_io.Desugared.Ast.io_output)
+           if Mark.remove var_ctx.scope_var_io.Desugared.Ast.io_output then
+             (* Retrieve the actual expected output type through the scope output struct definition *)
+             let str =
+               StructName.Map.find called_scope_return_struct ctx.decl_ctx.ctx_structs
+             in
+             let fld =
+               ScopeVar.Map.find var_ctx.scope_var_name scope_sig_decl.out_struct_fields
+             in
+             let ty = StructField.Map.find fld str in
+             Some {var_ctx with scope_var_typ = Mark.remove ty}
+           else None)
         all_subscope_vars
     in
     let pos_call = Mark.get (SubScopeName.get_info subindex) in
@@ -753,8 +765,6 @@ let translate_rule
       | External_scope_ref name ->
         Expr.eexternal ~name:(Mark.map (fun n -> External_scope n) name) m
     in
-    let called_scope_input_struct = subscope_sig.scope_sig_input_struct in
-    let called_scope_return_struct = subscope_sig.scope_sig_output_struct in
     let subscope_vars_defined =
       try SubScopeName.Map.find subindex ctx.subscope_vars
       with SubScopeName.Map.Not_found _ -> ScopeVar.Map.empty
@@ -891,7 +901,7 @@ let translate_rule
                      defined, we add an check "ErrorOnEmpty" here. *)
                   Mark.add
                     (Expr.map_ty (fun _ -> scope_let_typ) (Mark.get e))
-                    (EAssert (Expr.unbox (Expr.make_erroronempty (Expr.box new_e))));
+                    (EAssert new_e);
                 scope_let_kind = Assertion;
               })
           (Bindlib.bind_var (Var.make "_") next)

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -220,7 +220,7 @@ let input_var_typ typ io_in =
 let thunk_scope_arg var_ctx e =
   match var_ctx.scope_input_io, var_ctx.scope_input_thunked with
   | (Runtime.NoInput, _), _ -> invalid_arg "thunk_scope_arg"
-  | (Runtime.OnlyInput, _), false -> Expr.make_erroronempty e
+  | (Runtime.OnlyInput, _), false -> e
   | (Runtime.Reentrant, _), false -> e
   | (Runtime.Reentrant, pos), true ->
     Expr.make_abs [| Var.make "_" |] e [TLit TUnit, pos] pos
@@ -619,7 +619,7 @@ let translate_rule
     * 'm ctx =
   match rule with
   | Definition ((ScopelangScopeVar { name = a }, var_def_pos), tau, a_io, e) ->
-    let pos_mark, pos_mark_as = pos_mark_mk e in
+    let pos_mark, _ = pos_mark_mk e in
     let a_name = ScopeVar.get_info (Mark.remove a) in
     let a_var = Var.make (Mark.remove a_name) in
     let new_e = translate_expr ctx e in
@@ -685,7 +685,7 @@ let translate_rule
     let thunked_or_nonempty_new_e =
       match a_io.Desugared.Ast.io_input with
       | Runtime.NoInput, _ -> assert false
-      | Runtime.OnlyInput, _ -> Expr.make_erroronempty (new_e)
+      | Runtime.OnlyInput, _ -> new_e
       | Runtime.Reentrant, pos -> (
         match Mark.remove tau with
         | TArrow _ -> (new_e)

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -118,8 +118,7 @@ let merge_defaults
              (Mark.add (Expr.mark_pos m_callee) (TLit TBool)))
       in
       let d =
-        Expr.edefault [caller] ltrue (Expr.rebox body)
-          (Expr.map_ty (fun (_, pos as t) -> TDefault t, pos) m_body)
+        Expr.make_default [caller] ltrue (Expr.rebox body)
       in
       Expr.make_abs vars
         (Expr.make_erroronempty d)
@@ -141,8 +140,7 @@ let merge_defaults
         Expr.elit (LBool true)
           (Expr.with_ty m (Mark.add (Expr.mark_pos m) (TLit TBool)))
       in
-      Expr.make_erroronempty (Expr.edefault [caller] ltrue callee
-          (Expr.map_ty (fun (_, pos as t) -> TDefault t, pos) m))
+      Expr.make_erroronempty (Expr.make_default [caller] ltrue callee)
     in
     body
 

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -1093,9 +1093,10 @@ let translate_program (prgm : 'm Scopelang.Ast.program) : 'm Ast.program =
            as the return type of ScopeCalls) ; but input fields are used purely
            internally and need to be created here to implement the call
            convention for scopes. *)
+        let module S = Scopelang.Ast in
         ScopeVar.Map.filter_map
-          (fun dvar (typ, vis) ->
-            match Mark.remove vis.Desugared.Ast.io_input with
+          (fun dvar svar ->
+            match Mark.remove svar.S.svar_io.Desugared.Ast.io_input with
             | NoInput -> None
             | OnlyInput | Reentrant ->
               let info = ScopeVar.get_info dvar in
@@ -1103,22 +1104,22 @@ let translate_program (prgm : 'm Scopelang.Ast.program) : 'm Ast.program =
               Some
                 {
                   scope_input_name = StructField.fresh (s, Mark.get info);
-                  scope_input_io = vis.Desugared.Ast.io_input;
+                  scope_input_io = svar.S.svar_io.Desugared.Ast.io_input;
                   scope_input_typ =
-                    Mark.remove (input_var_typ (Mark.remove typ) vis);
+                    Mark.remove (input_var_typ (Mark.remove svar.S.svar_in_ty) svar.S.svar_io);
                   scope_input_thunked =
-                    input_var_needs_thunking (Mark.remove typ) vis;
+                    input_var_needs_thunking (Mark.remove svar.S.svar_in_ty) svar.S.svar_io;
                 })
-          scope.Scopelang.Ast.scope_sig
+          scope.S.scope_sig
       in
       {
         scope_sig_local_vars =
           List.map
-            (fun (scope_var, (tau, vis)) ->
+            (fun (scope_var, svar) ->
               {
                 scope_var_name = scope_var;
-                scope_var_typ = Mark.remove tau;
-                scope_var_io = vis;
+                scope_var_typ = Mark.remove svar.Scopelang.Ast.svar_in_ty;
+                scope_var_io = svar.Scopelang.Ast.svar_io;
               })
             (ScopeVar.Map.bindings scope.scope_sig);
         scope_sig_scope_ref = scope_ref;

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -174,7 +174,7 @@ let empty_rule
     (parameters : (Uid.MarkedString.info * typ) list Mark.pos option) : rule =
   {
     rule_just = Expr.box (ELit (LBool false), Untyped { pos });
-    rule_cons = Expr.box (EEmptyError, Untyped { pos });
+    rule_cons = Expr.eerroronempty (Expr.box (EEmptyError, Untyped { pos })) (Untyped { pos });
     rule_parameter =
       Option.map
         (Mark.map (List.map (fun (lbl, typ) -> Mark.map Var.make lbl, typ)))

--- a/compiler/desugared/disambiguate.ml
+++ b/compiler/desugared/disambiguate.ml
@@ -78,11 +78,14 @@ let program prg =
             ScopeDef.Map.fold
               (fun var def vars ->
                 match var with
-                | Var (v, _states) -> ScopeVar.Map.add v def.scope_def_typ vars
-                | SubScopeVar _ -> vars)
+                | Var (v, _states) ->
+                  ScopeVar.Map.add v def.scope_def_typ vars
+                | SubScopeVar _ ->
+                  vars)
               scope.scope_defs ScopeVar.Map.empty
           in
-          Typing.Env.add_scope scope_name ~vars env)
+          (* at this stage, rule resolution and the corresponding encapsulation into default terms hasn't taken place, so input and output variables don't need different typing *)
+          Typing.Env.add_scope scope_name ~vars ~in_vars:vars env)
         prg.program_scopes env
     in
     env

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -446,6 +446,7 @@ let rec translate_expr
             | Some (ScopeVar v) -> v
             | Some (SubScope _) | None ->
               Message.raise_multispanned_error
+                ~suggestion:(Ident.Map.keys scope_def.var_idmap)
                 [
                   None, Mark.get fld_id;
                   ( Some

--- a/compiler/driver.mli
+++ b/compiler/driver.mli
@@ -44,7 +44,8 @@ module Passes : sig
     includes:Cli.raw_file list ->
     optimize:bool ->
     check_invariants:bool ->
-    Shared_ast.typed Dcalc.Ast.program
+    typed:'m Shared_ast.mark ->
+    'm Dcalc.Ast.program
     * Desugared.Name_resolution.context
     * Scopelang.Dependency.TVertex.t list
 
@@ -53,6 +54,7 @@ module Passes : sig
     includes:Cli.raw_file list ->
     optimize:bool ->
     check_invariants:bool ->
+    typed:'m Shared_ast.mark ->
     avoid_exceptions:bool ->
     closure_conversion:bool ->
     Shared_ast.untyped Lcalc.Ast.program

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -326,7 +326,7 @@ let transform_closures_program (p : 'm program) : 'm program Bindlib.box =
       match Mark.remove t with
       | TArrow _ -> true
       | TAny -> true
-      | TOption t' -> type_contains_arrow t'
+      | TDefault t' | TOption t' -> type_contains_arrow t'
       | TClosureEnv | TLit _ -> false
       | TArray ts -> type_contains_arrow ts
       | TTuple ts -> List.exists type_contains_arrow ts

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -61,6 +61,7 @@ let rec trans_typ_keep (tau : typ) : typ =
           "The types option and closure_env should not appear before the dcalc \
            -> lcalc translation step."
       | TAny -> TAny
+      | TDefault t -> TDefault t
       | TArray ts ->
         TArray (TOption (trans_typ_keep ts), m) (* catala is not polymorphic *)
       | TArrow ([(TLit TUnit, _)], t2) -> Mark.remove (trans_typ_keep t2)

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -202,6 +202,7 @@ let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
   | TOption t ->
     Format.fprintf fmt "@[<hov 2>(%a)@] %a" format_typ_with_parens t
       format_enum_name Expr.option_enum
+  | TDefault t -> format_typ fmt t
   | TEnum e -> Format.fprintf fmt "%a.t" format_to_module_name (`Ename e)
   | TArrow (t1, t2) ->
     Format.fprintf fmt "@[<hov 2>%a@]"

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -67,6 +67,7 @@ module To_jsoo = struct
     | TOption t ->
       Format.fprintf fmt "@[<hov 2>(%a)@] %a" format_typ_with_parens t
         format_enum_name Expr.option_enum
+    | TDefault t -> format_typ fmt t
     | TEnum e -> Format.fprintf fmt "%a Js.t" format_enum_name e
     | TArray t1 ->
       Format.fprintf fmt "@[%a@ Js.js_array Js.t@]" format_typ_with_parens t1
@@ -439,7 +440,7 @@ let run
     Message.raise_error "This plugin requires the --trace flag.";
   let prg, _, type_ordering =
     Driver.Passes.lcalc options ~includes ~optimize ~check_invariants
-      ~avoid_exceptions ~closure_conversion
+      ~avoid_exceptions ~closure_conversion ~typed:Expr.typed
   in
   let modname =
     (* TODO: module directive support *)

--- a/compiler/plugins/explain.ml
+++ b/compiler/plugins/explain.ml
@@ -1388,7 +1388,7 @@ let options =
 let run includes optimize ex_scope explain_options global_options =
   let prg, ctx, _ =
     Driver.Passes.dcalc global_options ~includes ~optimize
-      ~check_invariants:false
+      ~check_invariants:false ~typed:Expr.typed
   in
   Interpreter.load_runtime_modules prg;
   let scope = Driver.Commands.get_scope_uid ctx ex_scope in

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -216,7 +216,7 @@ let run
     options =
   let prg, ctx, _ =
     Driver.Passes.lcalc options ~includes ~optimize ~check_invariants
-      ~avoid_exceptions ~closure_conversion
+      ~avoid_exceptions ~closure_conversion ~typed:Expr.typed
   in
   let output_file, with_output =
     Driver.Commands.get_output_format options ~ext:"_schema.json" output

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -259,7 +259,7 @@ let interpret_program (prg : ('dcalc, 'm) gexpr program) (scope : ScopeName.t) :
 
 let run includes optimize check_invariants ex_scope options =
   let prg, ctx, _ =
-    Driver.Passes.dcalc options ~includes ~optimize ~check_invariants
+    Driver.Passes.dcalc options ~includes ~optimize ~check_invariants ~typed:Expr.typed
   in
   Interpreter.load_runtime_modules prg;
   let scope = Driver.Commands.get_scope_uid ctx ex_scope in

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -176,6 +176,7 @@ let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
   | TOption some_typ ->
     (* We translate the option type with an overloading by Python's [None] *)
     Format.fprintf fmt "Optional[%a]" format_typ some_typ
+  | TDefault t -> format_typ fmt t
   | TEnum e -> Format.fprintf fmt "%a" format_enum_name e
   | TArrow (t1, t2) ->
     Format.fprintf fmt "Callable[[%a], %a]"

--- a/compiler/scalc/to_r.ml
+++ b/compiler/scalc/to_r.ml
@@ -172,7 +172,7 @@ let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
          format_typ)
       ts
   | TStruct s -> Format.fprintf fmt "\"catala_struct_%a\"" format_struct_name s
-  | TOption some_typ ->
+  | TOption some_typ | TDefault some_typ ->
     (* We loose track of optional value as they're crammed into NULL *)
     format_typ fmt some_typ
   | TEnum e -> Format.fprintf fmt "\"catala_enum_%a\"" format_enum_name e

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -43,9 +43,15 @@ type 'm rule =
   | Assertion of 'm expr
   | Call of ScopeName.t * SubScopeName.t * 'm mark
 
+type scope_var_ty = {
+  svar_in_ty: typ;
+  svar_out_ty: typ;
+  svar_io: Desugared.Ast.io;
+}
+
 type 'm scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (typ * Desugared.Ast.io) ScopeVar.Map.t;
+  scope_sig : scope_var_ty ScopeVar.Map.t;
   scope_decl_rules : 'm rule list;
   scope_options : Desugared.Ast.catala_option Mark.pos list;
 }
@@ -84,7 +90,10 @@ let type_program (prg : 'm program) : typed program =
     let env =
       ScopeName.Map.fold
         (fun scope_name scope_decl env ->
-          let vars = ScopeVar.Map.map fst (Mark.remove scope_decl).scope_sig in
+          let vars =
+            ScopeVar.Map.map (fun {svar_out_ty; _} -> svar_out_ty)
+              (Mark.remove scope_decl).scope_sig
+          in
           Typing.Env.add_scope scope_name ~vars env)
         prg.program_scopes env
     in
@@ -115,7 +124,8 @@ let type_program (prg : 'm program) : typed program =
       (Mark.map (fun scope_decl ->
            let env =
              ScopeVar.Map.fold
-               (fun svar (typ, _) env -> Typing.Env.add_scope_var svar typ env)
+               (fun svar {svar_out_ty; _} env ->
+                  Typing.Env.add_scope_var svar svar_out_ty env)
                scope_decl.scope_sig env
            in
            let scope_decl_rules =

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -90,11 +90,14 @@ let type_program (prg : 'm program) : typed program =
     let env =
       ScopeName.Map.fold
         (fun scope_name scope_decl env ->
-          let vars =
-            ScopeVar.Map.map (fun {svar_out_ty; _} -> svar_out_ty)
-              (Mark.remove scope_decl).scope_sig
-          in
-          Typing.Env.add_scope scope_name ~vars env)
+           let sg = (Mark.remove scope_decl).scope_sig in
+           let vars =
+             ScopeVar.Map.map (fun {svar_out_ty; _} -> svar_out_ty) sg
+           in
+           let in_vars =
+             ScopeVar.Map.map (fun {svar_in_ty; _} -> svar_in_ty) sg
+           in
+           Typing.Env.add_scope scope_name ~vars ~in_vars env)
         prg.program_scopes env
     in
     env

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -36,9 +36,15 @@ type 'm rule =
   | Assertion of 'm expr
   | Call of ScopeName.t * SubScopeName.t * 'm mark
 
+type scope_var_ty = {
+  svar_in_ty: typ;
+  svar_out_ty: typ;
+  svar_io: Desugared.Ast.io;
+}
+
 type 'm scope_decl = {
   scope_decl_name : ScopeName.t;
-  scope_sig : (typ * Desugared.Ast.io) ScopeVar.Map.t;
+  scope_sig : scope_var_ty ScopeVar.Map.t;
   scope_decl_rules : 'm rule list;
   scope_options : Desugared.Ast.catala_option Mark.pos list;
 }

--- a/compiler/scopelang/dependency.ml
+++ b/compiler/scopelang/dependency.ml
@@ -265,7 +265,7 @@ let rec get_structs_or_enums_in_type (t : typ) : TVertexSet.t =
       |> List.fold_left TVertexSet.union TVertexSet.empty)
       (get_structs_or_enums_in_type t2)
   | TClosureEnv | TLit _ | TAny -> TVertexSet.empty
-  | TOption t1 | TArray t1 -> get_structs_or_enums_in_type t1
+  | TOption t1 | TArray t1 | TDefault t1 -> get_structs_or_enums_in_type t1
   | TTuple ts ->
     List.fold_left
       (fun acc t -> TVertexSet.union acc (get_structs_or_enums_in_type t))

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -620,6 +620,17 @@ let translate_rule
                 (D.ScopeDef.Map.find def_key exc_graphs)
                 ~is_cond ~is_subscope_var:true
             in
+            let def_typ =
+              match scope_def.D.scope_def_io.D.io_input with
+              | Runtime.NoInput, _ -> assert false
+              | Runtime.OnlyInput, _ -> def_typ
+              | Runtime.Reentrant, pos ->
+                match def_typ with
+                | TArrow (args, ret), tpos ->
+                  TArrow (args, (TDefault ret, pos)), tpos
+                | _ ->
+                  TDefault def_typ, pos
+            in
             let subscop_real_name =
               SubScopeName.Map.find sub_scope_index scope.scope_sub_scopes
             in

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -29,6 +29,7 @@ type target_scope_vars =
 type ctx = {
   decl_ctx : decl_ctx;
   scope_var_mapping : target_scope_vars ScopeVar.Map.t;
+  reentrant_vars : ScopeVar.Set.t;
   var_mapping : (D.expr, untyped Ast.expr Var.t) Var.Map.t;
   modules : ctx ModuleName.Map.t;
 }
@@ -131,7 +132,13 @@ let rec translate_expr (ctx : ctx) (e : D.expr) : untyped Ast.expr boxed =
                  v'
                | States [] -> assert false
              in
-             ScopeVar.Map.add v' (translate_expr ctx e) args')
+             let e' = translate_expr ctx e in
+             let e' =
+               if ScopeVar.Set.mem v ctx.reentrant_vars then
+                 Expr.edefault [] (Expr.elit (LBool false) m) e' m
+               else e'
+             in
+             ScopeVar.Map.add v' e' args')
            args ScopeVar.Map.empty)
       m
   | EApp { f = EOp { op; tys }, m1; args } ->
@@ -786,16 +793,34 @@ let translate_program
                 in
                 States (List.map (fun state -> state, state_var state) states)
             in
+            let reentrant =
+              let state = match states with
+                | D.WholeVar -> None
+                | States (s::_) -> Some s
+                | States [] -> assert false
+              in
+              match
+                D.ScopeDef.Map.find_opt (Var (scope_var, state))
+                  scope_decl.D.scope_defs
+              with
+              | Some {scope_def_io = {io_input = (Runtime.Reentrant, _); _}; _} ->
+                true
+              | _ -> false
+            in
             {
               ctx with
               scope_var_mapping =
                 ScopeVar.Map.add scope_var new_var ctx.scope_var_mapping;
+              reentrant_vars =
+                if reentrant then ScopeVar.Set.add scope_var ctx.reentrant_vars
+                else ctx.reentrant_vars
             })
           scope_decl.D.scope_vars ctx)
       desugared.D.program_scopes
       {
         scope_var_mapping = ScopeVar.Map.empty;
         var_mapping = Var.Map.empty;
+        reentrant_vars = ScopeVar.Set.empty;
         decl_ctx = desugared.program_ctx;
         modules;
       }

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -412,12 +412,11 @@ let rec rule_tree_to_expr
              (* Here we insert the logging command that records when a decision
                 is taken for the value of a variable. *)
              (tag_with_log_entry base_just PosRecordIfTrueBool [])
-             base_cons emark)
+             base_cons)
          (translate_and_unbox_list base_just_list)
          (translate_and_unbox_list base_cons_list))
       (Expr.elit (LBool false) emark)
       (Expr.eerroronempty (Expr.eemptyerror emark) emark)
-      emark
   in
   let exceptions =
     List.map
@@ -431,7 +430,6 @@ let rec rule_tree_to_expr
     Expr.make_default exceptions
       (Expr.elit (LBool true) emark)
       (Expr.eerroronempty default_containing_base_cases emark)
-      emark
   in
   let default =
     if toplevel && subscope && is_reentrant_var then default

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -690,13 +690,20 @@ let translate_scope_interface ctx scope =
   let scope_sig =
     ScopeVar.Map.fold
       (fun var (states : D.var_or_states) acc ->
-        let get_typ scope_def =
-          match scope_def.D.scope_def_io.io_input, scope_def.D.scope_def_typ with
-          | (Runtime.Reentrant, iopos), (TArrow (args, ret), tpos) ->
-            TArrow (args, (TDefault ret, iopos)), tpos
-          | (Runtime.Reentrant, iopos), (ty, tpos) ->
-            TDefault (ty, tpos), iopos
-          | _, ty -> ty
+        let get_svar scope_def =
+          let svar_in_ty =
+            match scope_def.D.scope_def_io.io_input, scope_def.D.scope_def_typ with
+            | (Runtime.Reentrant, iopos), (TArrow (args, ret), tpos) ->
+              TArrow (args, (TDefault ret, iopos)), tpos
+            | (Runtime.Reentrant, iopos), (ty, tpos) ->
+              TDefault (ty, tpos), iopos
+            | _, ty -> ty
+          in
+          { Ast.
+            svar_in_ty;
+            svar_out_ty = scope_def.D.scope_def_typ;
+            svar_io = scope_def.scope_def_io;
+          }
         in
         match states with
         | WholeVar ->
@@ -707,7 +714,7 @@ let translate_scope_interface ctx scope =
             (match ScopeVar.Map.find var ctx.scope_var_mapping with
             | WholeVar v -> v
             | States _ -> failwith "should not happen")
-            (get_typ scope_def, scope_def.scope_def_io)
+            (get_svar scope_def)
             acc
         | States states ->
           (* What happens in the case of variables with multiple states is
@@ -724,7 +731,7 @@ let translate_scope_interface ctx scope =
                 (match ScopeVar.Map.find var ctx.scope_var_mapping with
                 | WholeVar _ -> failwith "should not happen"
                 | States states' -> List.assoc state states')
-                (get_typ scope_def, scope_def.scope_def_io)
+                (get_svar scope_def)
                 acc)
             acc states)
       scope.scope_vars ScopeVar.Map.empty

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -333,6 +333,7 @@ let def_map_to_tree
 let rec rule_tree_to_expr
     ~(toplevel : bool)
     ~(is_reentrant_var : bool)
+    ~(subscope : bool)
     (ctx : ctx)
     (def_pos : Pos.t)
     (params : D.expr Var.t list option)
@@ -408,17 +409,26 @@ let rec rule_tree_to_expr
          (translate_and_unbox_list base_just_list)
          (translate_and_unbox_list base_cons_list))
       (Expr.elit (LBool false) emark)
-      (Expr.eemptyerror emark) emark
+      (Expr.eerroronempty (Expr.eemptyerror emark) emark)
+      emark
   in
   let exceptions =
     List.map
-      (rule_tree_to_expr ~toplevel:false ~is_reentrant_var ctx def_pos params)
+      (rule_tree_to_expr ~toplevel:false ~is_reentrant_var ~subscope
+         ctx def_pos params)
       exceptions
   in
   let default =
+    if exceptions = [] then default_containing_base_cases
+    else
     Expr.make_default exceptions
       (Expr.elit (LBool true) emark)
-      default_containing_base_cases emark
+      (Expr.eerroronempty default_containing_base_cases emark)
+      emark
+  in
+  let default =
+    if toplevel && subscope && is_reentrant_var then default
+    else Expr.eerroronempty default emark
   in
   match params, (List.hd base_rules).D.rule_parameter with
   | None, None -> default
@@ -430,9 +440,6 @@ let rec rule_tree_to_expr
          dealing with a context variable which is reentrant (either in the
          caller or callee). In this case the ErrorOnEmpty will be added later in
          the scopelang->dcalc translation. *)
-      let default =
-        if is_reentrant_var then default else Expr.eerroronempty default emark
-      in
 
       Expr.make_abs
         (new_params
@@ -510,7 +517,8 @@ let translate_def
         empty_error tys (Expr.mark_pos m)
     | _ -> empty_error
   else
-    rule_tree_to_expr ~toplevel:true ~is_reentrant_var:is_reentrant ctx
+    rule_tree_to_expr ~toplevel:true ~is_reentrant_var:is_reentrant
+      ~subscope:is_subscope_var ctx
       (D.ScopeDef.get_position def_info)
       (Option.map
          (fun (ps, _) ->
@@ -677,17 +685,24 @@ let translate_scope_interface ctx scope =
   let scope_sig =
     ScopeVar.Map.fold
       (fun var (states : D.var_or_states) acc ->
+        let get_typ scope_def =
+          match scope_def.D.scope_def_io.io_input, scope_def.D.scope_def_typ with
+          | (Runtime.Reentrant, iopos), (TArrow (args, ret), tpos) ->
+            TArrow (args, (TDefault ret, iopos)), tpos
+          | (Runtime.Reentrant, iopos), (ty, tpos) ->
+            TDefault (ty, tpos), iopos
+          | _, ty -> ty
+        in
         match states with
         | WholeVar ->
           let scope_def =
             D.ScopeDef.Map.find (D.ScopeDef.Var (var, None)) scope.D.scope_defs
           in
-          let typ = scope_def.scope_def_typ in
           ScopeVar.Map.add
             (match ScopeVar.Map.find var ctx.scope_var_mapping with
             | WholeVar v -> v
             | States _ -> failwith "should not happen")
-            (typ, scope_def.scope_def_io)
+            (get_typ scope_def, scope_def.scope_def_io)
             acc
         | States states ->
           (* What happens in the case of variables with multiple states is
@@ -704,7 +719,7 @@ let translate_scope_interface ctx scope =
                 (match ScopeVar.Map.find var ctx.scope_var_mapping with
                 | WholeVar _ -> failwith "should not happen"
                 | States states' -> List.assoc state states')
-                (scope_def.scope_def_typ, scope_def.scope_def_io)
+                (get_typ scope_def, scope_def.scope_def_io)
                 acc)
             acc states)
       scope.scope_vars ScopeVar.Map.empty

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -29,7 +29,7 @@ type target_scope_vars =
 type ctx = {
   decl_ctx : decl_ctx;
   scope_var_mapping : target_scope_vars ScopeVar.Map.t;
-  reentrant_vars : ScopeVar.Set.t;
+  reentrant_vars : typ ScopeVar.Map.t;
   var_mapping : (D.expr, untyped Ast.expr Var.t) Var.Map.t;
   modules : ctx ModuleName.Map.t;
 }
@@ -133,10 +133,23 @@ let rec translate_expr (ctx : ctx) (e : D.expr) : untyped Ast.expr boxed =
                | States [] -> assert false
              in
              let e' = translate_expr ctx e in
+             let m = Mark.get e in
              let e' =
-               if ScopeVar.Set.mem v ctx.reentrant_vars then
-                 Expr.edefault [] (Expr.elit (LBool false) m) e' m
-               else e'
+               match ScopeVar.Map.find_opt v ctx.reentrant_vars with
+               | Some (TArrow (targs, _), _) ->
+                 (* Functions are treated specially: the default only applies to their return type *)
+                 let arg = Var.make "arg" in
+                 let pos = Expr.mark_pos m in
+                 Expr.make_abs [|arg|]
+                   (Expr.edefault [] (Expr.elit (LBool true) m)
+                      (Expr.make_app e' [Expr.evar arg m] pos)
+                      m)
+                   targs
+                   pos
+               | Some _ ->
+                 Expr.edefault [] (Expr.elit (LBool true) m) e' m
+               | None ->
+                 e'
              in
              ScopeVar.Map.add v' e' args')
            args ScopeVar.Map.empty)
@@ -634,15 +647,7 @@ let translate_rule
                 ~is_cond ~is_subscope_var:true
             in
             let def_typ =
-              match scope_def.D.scope_def_io.D.io_input with
-              | Runtime.NoInput, _ -> assert false
-              | Runtime.OnlyInput, _ -> def_typ
-              | Runtime.Reentrant, pos ->
-                match def_typ with
-                | TArrow (args, ret), tpos ->
-                  TArrow (args, (TDefault ret, pos)), tpos
-                | _ ->
-                  TDefault def_typ, pos
+              Scope.input_type def_typ scope_def.D.scope_def_io.D.io_input
             in
             let subscop_real_name =
               SubScopeName.Map.find sub_scope_index scope.scope_sub_scopes
@@ -692,12 +697,7 @@ let translate_scope_interface ctx scope =
       (fun var (states : D.var_or_states) acc ->
         let get_svar scope_def =
           let svar_in_ty =
-            match scope_def.D.scope_def_io.io_input, scope_def.D.scope_def_typ with
-            | (Runtime.Reentrant, iopos), (TArrow (args, ret), tpos) ->
-              TArrow (args, (TDefault ret, iopos)), tpos
-            | (Runtime.Reentrant, iopos), (ty, tpos) ->
-              TDefault (ty, tpos), iopos
-            | _, ty -> ty
+            Scope.input_type scope_def.D.scope_def_typ scope_def.D.scope_def_io.io_input
           in
           { Ast.
             svar_in_ty;
@@ -808,24 +808,27 @@ let translate_program
                 D.ScopeDef.Map.find_opt (Var (scope_var, state))
                   scope_decl.D.scope_defs
               with
-              | Some {scope_def_io = {io_input = (Runtime.Reentrant, _); _}; _} ->
-                true
-              | _ -> false
+              | Some {scope_def_io = {io_input = (Runtime.Reentrant, _); _};
+                      scope_def_typ; _} ->
+                Some scope_def_typ
+              | _ -> None
             in
             {
               ctx with
               scope_var_mapping =
                 ScopeVar.Map.add scope_var new_var ctx.scope_var_mapping;
               reentrant_vars =
-                if reentrant then ScopeVar.Set.add scope_var ctx.reentrant_vars
-                else ctx.reentrant_vars
+                Option.fold reentrant
+                  ~some:(fun ty -> ScopeVar.Map.add scope_var ty
+                            ctx.reentrant_vars)
+                  ~none:ctx.reentrant_vars
             })
           scope_decl.D.scope_vars ctx)
       desugared.D.program_scopes
       {
         scope_var_mapping = ScopeVar.Map.empty;
         var_mapping = Var.Map.empty;
-        reentrant_vars = ScopeVar.Set.empty;
+        reentrant_vars = ScopeVar.Map.empty;
         decl_ctx = desugared.program_ctx;
         modules;
       }

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -445,8 +445,9 @@ let rec rule_tree_to_expr
       (Expr.eerroronempty default_containing_base_cases emark)
   in
   let default =
-    if toplevel && subscope && is_reentrant_var then default
-    else Expr.eerroronempty default emark
+    if toplevel && not (subscope && is_reentrant_var)
+    then Expr.eerroronempty default emark
+    else default
   in
   match params, (List.hd base_rules).D.rule_parameter with
   | None, None -> default

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -52,15 +52,16 @@ let scope ?debug ctx fmt (name, (decl, _pos)) =
   Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@ %a@ %a@]@\n@[<v 2>  %a@]"
     Print.keyword "let" Print.keyword "scope" ScopeName.format name
     (Format.pp_print_list ~pp_sep:Format.pp_print_space
-       (fun fmt (scope_var, (typ, vis)) ->
+       (fun fmt (scope_var, svar) ->
          Format.fprintf fmt "%a%a%a %a%a%a%a%a" Print.punctuation "("
-           ScopeVar.format scope_var Print.punctuation ":" (Print.typ ctx) typ
+           ScopeVar.format scope_var Print.punctuation ":"
+           (Print.typ ctx) svar.svar_in_ty
            Print.punctuation "|" Print.keyword
-           (match Mark.remove vis.Desugared.Ast.io_input with
+           (match Mark.remove svar.svar_io.Desugared.Ast.io_input with
            | NoInput -> "internal"
            | OnlyInput -> "input"
            | Reentrant -> "context")
-           (if Mark.remove vis.Desugared.Ast.io_output then fun fmt () ->
+           (if Mark.remove svar.svar_io.Desugared.Ast.io_output then fun fmt () ->
               Format.fprintf fmt "%a@,%a" Print.punctuation "|" Print.keyword
                 "output"
             else fun fmt () -> Format.fprintf fmt "@<0>")
@@ -81,8 +82,8 @@ let scope ?debug ctx fmt (name, (decl, _pos)) =
                | ScopelangScopeVar { name = v } -> (
                  match
                    Mark.remove
-                     (snd (ScopeVar.Map.find (Mark.remove v) decl.scope_sig))
-                       .io_input
+                     (ScopeVar.Map.find (Mark.remove v) decl.scope_sig)
+                     .svar_io.io_input
                  with
                  | Reentrant ->
                    Format.fprintf fmt "%a@ %a" Print.op_style

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -229,6 +229,7 @@ and naked_typ =
   | TOption of typ
   | TArrow of typ list * typ
   | TArray of typ
+  | TDefault of typ
   | TAny
   | TClosureEnv  (** Hides an existential type needed for closure conversion *)
 

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -248,6 +248,9 @@ let maybe_ty (type m) ?(typ = TAny) (m : m mark) : typ =
   | Untyped { pos } | Custom { pos; _ } -> Mark.add pos typ
   | Typed { ty; _ } -> ty
 
+let untyped = Untyped { pos = Pos.no_pos }
+let typed = Typed { pos = Pos.no_pos; ty = TLit TUnit, Pos.no_pos }
+
 (* - Predefined types (option) - *)
 
 let option_enum = EnumName.fresh [] ("eoption", Pos.no_pos)

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -928,6 +928,22 @@ let make_app e args pos =
   in
   eapp e args mark
 
+let make_erroronempty e =
+  let mark =
+    map_mark
+      (fun pos -> pos)
+      (function
+        | TDefault ty, _ -> ty
+        | TAny, pos -> TAny, pos
+        | ty ->
+          Message.raise_internal_error
+            "wrong type: found %a while expecting a TDefault on@;<1 2>%a"
+            Print.typ_debug ty
+            format (unbox e))
+      (Mark.get e)
+  in
+  eerroronempty e mark
+
 let thunk_term term mark =
   let silent = Var.make "_" in
   let pos = mark_pos mark in

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -960,25 +960,15 @@ let make_let_in x tau e1 e2 mpos =
 let make_multiple_let_in xs taus e1s e2 mpos =
   make_app (make_abs xs e2 taus mpos) e1s (pos e2)
 
-let make_default_unboxed excepts just cons =
-  let rec bool_value = function
-    | ELit (LBool b), _ -> Some b
-    | EApp { f = EOp { op = Log (l, _); _ }, _; args = [e]; _ }, _
-      when l <> PosRecordIfTrueBool
-           (* we don't remove the log calls corresponding to source code
-              definitions !*) ->
-      bool_value e
-    | _ -> None
+let make_default exc just cons =
+  let mark =
+    map_mark
+      (fun pos -> pos)
+      (fun cty -> TDefault cty, (Mark.get cty))
+      (Mark.get cons)
   in
-  match excepts, bool_value just, cons with
-  | excepts, Some true, (EDefault { excepts = []; just; cons }, _) ->
-    EDefault { excepts; just; cons }
-  | [((EDefault _, _) as except)], Some false, _ -> Mark.remove except
-  | excepts, _, cons -> EDefault { excepts; just; cons }
+  edefault exc just cons mark
 
-let make_default exceptions just cons =
-  Box.app2n just cons exceptions
-  @@ fun just cons exceptions -> make_default_unboxed exceptions just cons
 
 let make_tuple el m0 =
   match el with

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -193,6 +193,9 @@ val maybe_ty : ?typ:naked_typ -> 'm mark -> typ
 (** Returns the corresponding type on a typed expr, or [typ] (defaulting to
     [TAny]) at the current position on an untyped one *)
 
+val untyped : untyped mark (** Type witness for untyped marks *)
+val typed : typed mark (** Type witness for untyped marks *)
+
 (** {2 Predefined types} *)
 
 val option_enum : EnumName.t

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -194,6 +194,7 @@ val maybe_ty : ?typ:naked_typ -> 'm mark -> typ
     [TAny]) at the current position on an untyped one *)
 
 val untyped : untyped mark (** Type witness for untyped marks *)
+
 val typed : typed mark (** Type witness for untyped marks *)
 
 (** {2 Predefined types} *)
@@ -313,6 +314,10 @@ val make_app :
   ('a, 'm) boxed_gexpr list ->
   Pos.t ->
   ('a any, 'm) boxed_gexpr
+
+val make_erroronempty :
+  ('a, 'm) boxed_gexpr ->
+  ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
 
 val empty_thunked_term :
   'm mark -> (< defaultTerms : yes ; .. >, 'm) boxed_gexpr

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -345,20 +345,8 @@ val make_default :
   ('a, 'm) boxed_gexpr list ->
   ('a, 'm) boxed_gexpr ->
   ('a, 'm) boxed_gexpr ->
-  'm mark ->
+  (* 'm mark -> *)
   ((< polymorphic : yes ; defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
-(** [make_default ?pos exceptions just cons] builds a term semantically
-    equivalent to [<exceptions | just :- cons>] (the [EDefault] constructor)
-    while avoiding redundant nested constructions. The position is extracted
-    from [just] by default.
-
-    Note that some simplifications take place here, even though all of them
-    return an [EDefault] term:
-
-    - [<ex | true :- def>], when [def] is a default term [<j :- c>] without
-      exceptions, is collapsed into [<ex | def>]
-    - [<ex | false :- _>], when [ex] is a single exception of the form
-      [EDefault], is rewritten as [ex] *)
 
 val make_tuple :
   ('a any, 'm) boxed_gexpr list -> 'm mark -> ('a, 'm) boxed_gexpr

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -457,6 +457,7 @@ let rec runtime_to_val :
            (Array.to_list (Obj.obj o))),
       m )
   | TArrow (targs, tret) -> ECustom { obj = o; targs; tret }, m
+  | TDefault ty -> runtime_to_val eval_expr ctx m ty o
   | TAny -> assert false
 
 and val_to_runtime :

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -522,6 +522,7 @@ and val_to_runtime :
             curry (runtime_to_val eval_expr ctx m targ x :: acc) targs)
     in
     curry [] targs
+  | TDefault ty, _ -> val_to_runtime eval_expr ctx ty v
   | _ ->
     Message.raise_internal_error
       "Could not convert value of type %a to runtime: %a" (Print.typ ctx) ty

--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -215,6 +215,14 @@ let rec optimize_expr :
       Mark.remove (StructField.Map.find field fields)
     | EErrorOnEmpty
         (EDefault { excepts = [];  just = ELit (LBool true), _; cons}, _) ->
+      (* No exceptions, always true *)
+      Mark.remove cons
+    | EErrorOnEmpty
+        (EDefault {
+            excepts =
+              [EDefault { excepts = []; just = ELit (LBool true), _; cons }, _];
+            _}, _) ->
+      (* Single, always true exception *)
       Mark.remove cons
     | EDefault { excepts; just; cons } -> (
       (* TODO: mechanically prove each of these optimizations correct *)
@@ -240,10 +248,9 @@ let rec optimize_expr :
         assert false
       else
         match excepts, just with
-        | [except], _ when Expr.is_value except ->
-          (* if there is only one exception and it is a non-empty value it is
-             always chosen *)
-          Mark.remove except
+        | [EDefault { excepts = []; just = ELit (LBool true), _; _} as dft, _], _ ->
+          (* Single exception with condition [true] *)
+          dft
         | ( [],
             ( ( ELit (LBool false)
               | EApp
@@ -252,6 +259,7 @@ let rec optimize_expr :
                     args = [(ELit (LBool false), _)];
                   } ),
               _ ) ) ->
+          (* No exceptions and condition false *)
           EEmptyError
         | excepts, just -> EDefault { excepts; just; cons })
     | EIfThenElse

--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -214,7 +214,10 @@ let rec optimize_expr :
       when StructName.equal name name1 ->
       Mark.remove (StructField.Map.find field fields)
     | EErrorOnEmpty
-        (EDefault { excepts = [];  just = ELit (LBool true), _; cons}, _) ->
+        (EDefault { excepts = [];  just = ELit (LBool true), _; cons}, _)
+      when false
+      (* FIXME: this optimisation is correct and useful, but currently breaks expectations of the without-exceptions backend *)
+      ->
       (* No exceptions, always true *)
       Mark.remove cons
     | EErrorOnEmpty

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -164,6 +164,10 @@ let rec typ_gen
   | TArray t1 ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" base_type "collection" (typ ~colors)
       t1
+  | TDefault t1 ->
+    punctuation fmt "⟨";
+    typ ~colors fmt t1;
+    punctuation fmt "⟩"
   | TAny -> base_type fmt "any"
   | TClosureEnv -> base_type fmt "closure_env"
 

--- a/compiler/shared_ast/scope.ml
+++ b/compiler/shared_ast/scope.ml
@@ -166,6 +166,14 @@ let build_typ_from_sig
   let result_typ = Mark.add pos (TStruct scope_return_struct_name) in
   Mark.add pos (TArrow ([input_typ], result_typ))
 
+let input_type ty io =
+  match io, ty with
+  | (Runtime.Reentrant, iopos), (TArrow (args, ret), tpos) ->
+    TArrow (args, (TDefault ret, iopos)), tpos
+  | (Runtime.Reentrant, iopos), (ty, tpos) ->
+    TDefault (ty, tpos), iopos
+  | _, ty -> ty
+
 type 'e scope_name_or_var = ScopeName of ScopeName.t | ScopeVar of 'e Var.t
 
 let to_expr (ctx : decl_ctx) (body : 'e scope_body) (mark_scope : 'm) : 'e boxed

--- a/compiler/shared_ast/scope.mli
+++ b/compiler/shared_ast/scope.mli
@@ -130,6 +130,9 @@ val build_typ_from_sig :
 (** [build_typ_from_sig ctx in_struct out_struct pos] builds the arrow type for
     the specified scope *)
 
+val input_type : typ -> Runtime.io_input Mark.pos -> typ
+(** Returns the correct input type for scope input variables: this is [typ] for non-reentrant variables, but for reentrant variables, it is nested in a [TDefault], which only applies to the return type on functions. Note that this doesn't take thunking into account (thunking is added during the scopelang->dcalc translation) *)
+
 (** {2 Analysis and tests} *)
 
 val free_vars_body_expr : 'e scope_body_expr -> 'e Var.Set.t

--- a/compiler/shared_ast/type.ml
+++ b/compiler/shared_ast/type.ml
@@ -31,9 +31,10 @@ let rec equal ty1 ty2 =
   | TOption t1, TOption t2 -> equal t1 t2
   | TArrow (t1, t1'), TArrow (t2, t2') -> equal_list t1 t2 && equal t1' t2'
   | TArray t1, TArray t2 -> equal t1 t2
+  | TDefault t1, TDefault t2 -> equal t1 t2
   | TClosureEnv, TClosureEnv | TAny, TAny -> true
   | ( ( TLit _ | TTuple _ | TStruct _ | TEnum _ | TOption _ | TArrow _
-      | TArray _ | TAny | TClosureEnv ),
+      | TArray _ | TDefault _ | TAny | TClosureEnv ),
       _ ) ->
     false
 
@@ -52,9 +53,10 @@ let rec unifiable ty1 ty2 =
   | TArrow (t1, t1'), TArrow (t2, t2') ->
     unifiable_list t1 t2 && unifiable t1' t2'
   | TArray t1, TArray t2 -> unifiable t1 t2
+  | TDefault t1, TDefault t2 -> unifiable t1 t2
   | TClosureEnv, TClosureEnv -> true
   | ( ( TLit _ | TTuple _ | TStruct _ | TEnum _ | TOption _ | TArrow _
-      | TArray _ | TClosureEnv ),
+      | TArray _ | TDefault _ | TClosureEnv ),
       _ ) ->
     false
 
@@ -86,6 +88,8 @@ let rec compare ty1 ty2 =
   | _, TArrow _ -> 1
   | TArray _, _ -> -1
   | _, TArray _ -> 1
+  | TDefault _, _ -> -1
+  | _, TDefault _ -> 1
   | TClosureEnv, _ -> -1
   | _, TClosureEnv -> 1
 

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -341,6 +341,7 @@ module Env = struct
     vars : ('e, unionfind_typ) Var.Map.t;
     scope_vars : A.typ A.ScopeVar.Map.t;
     scopes : A.typ A.ScopeVar.Map.t A.ScopeName.Map.t;
+    scopes_input : A.typ A.ScopeVar.Map.t A.ScopeName.Map.t;
     toplevel_vars : A.typ A.TopdefName.Map.t;
     modules : 'e t A.ModuleName.Map.t;
   }
@@ -360,6 +361,7 @@ module Env = struct
       vars = Var.Map.empty;
       scope_vars = A.ScopeVar.Map.empty;
       scopes = A.ScopeName.Map.empty;
+      scopes_input = A.ScopeName.Map.empty;
       toplevel_vars = A.TopdefName.Map.empty;
       modules = A.ModuleName.Map.empty;
     }
@@ -381,8 +383,10 @@ module Env = struct
   let add_scope_var v typ t =
     { t with scope_vars = A.ScopeVar.Map.add v typ t.scope_vars }
 
-  let add_scope scope_name ~vars t =
-    { t with scopes = A.ScopeName.Map.add scope_name vars t.scopes }
+  let add_scope scope_name ~vars ~in_vars t =
+    { t with
+      scopes = A.ScopeName.Map.add scope_name vars t.scopes;
+      scopes_input = A.ScopeName.Map.add scope_name in_vars t.scopes_input }
 
   let add_toplevel_var v typ t =
     { t with toplevel_vars = A.TopdefName.Map.add v typ t.toplevel_vars }
@@ -694,7 +698,7 @@ and typecheck_expr_top_down :
     let mark = mark_with_tau_and_unify (unionfind (TStruct scope_out_struct)) in
     let vars =
       let env = Env.module_env path env in
-      A.ScopeName.Map.find scope env.scopes
+      A.ScopeName.Map.find scope env.scopes_input
     in
     let args' =
       A.ScopeVar.Map.mapi

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -48,6 +48,7 @@ and naked_typ =
   | TEnum of A.EnumName.t
   | TOption of unionfind_typ
   | TArray of unionfind_typ
+  | TDefault of unionfind_typ
   | TAny of Any.t
   | TClosureEnv
 
@@ -62,6 +63,7 @@ let rec typ_to_ast ~leave_unresolved (ty : unionfind_typ) : A.typ =
   | TOption t -> A.TOption (typ_to_ast t), pos
   | TArrow (t1, t2) -> A.TArrow (List.map typ_to_ast t1, typ_to_ast t2), pos
   | TArray t1 -> A.TArray (typ_to_ast t1), pos
+  | TDefault t1 -> A.TDefault (typ_to_ast t1), pos
   | TAny _ ->
     if leave_unresolved then A.TAny, pos
     else
@@ -82,6 +84,7 @@ let rec ast_to_typ (ty : A.typ) : unionfind_typ =
     | A.TEnum e -> TEnum e
     | A.TOption t -> TOption (ast_to_typ t)
     | A.TArray t -> TArray (ast_to_typ t)
+    | A.TDefault t -> TDefault (ast_to_typ t)
     | A.TAny -> TAny (Any.fresh ())
     | A.TClosureEnv -> TClosureEnv
   in
@@ -157,6 +160,10 @@ let rec format_typ
     | TAny _ when not Cli.globals.debug ->
       Format.pp_print_string fmt "collection"
     | _ -> Format.fprintf fmt "@[collection@ %a@]" (format_typ ~colors) t1)
+  | TDefault t1 ->
+    Format.pp_print_as fmt 1 "⟨";
+    format_typ ~colors fmt t1;
+    Format.pp_print_as fmt 1 "⟩"
   | TAny v ->
     if Cli.globals.debug then Format.fprintf fmt "<a%d>" (Any.hash v)
     else Format.pp_print_string fmt "<any>"
@@ -199,10 +206,11 @@ let rec unify
       if not (A.EnumName.equal e1 e2) then raise_type_error ()
     | TOption t1, TOption t2 -> unify e t1 t2
     | TArray t1', TArray t2' -> unify e t1' t2'
+    | TDefault t1', TDefault t2' -> unify e t1' t2'
     | TClosureEnv, TClosureEnv -> ()
     | TAny _, _ | _, TAny _ -> ()
     | ( ( TLit _ | TArrow _ | TTuple _ | TStruct _ | TEnum _ | TOption _
-        | TArray _ | TClosureEnv ),
+        | TArray _ | TDefault _ | TClosureEnv ),
         _ ) ->
       raise_type_error ()
   in
@@ -862,7 +870,9 @@ and typecheck_expr_top_down :
     in
     Expr.eop op tys mark
   | A.EDefault { excepts; just; cons } ->
-    let cons' = typecheck_expr_top_down ~leave_unresolved ctx env tau cons in
+    let inner_ty = unionfind (TAny (Any.fresh ())) in
+    unify ctx e (unionfind (TDefault inner_ty)) tau;
+    let cons' = typecheck_expr_top_down ~leave_unresolved ctx env inner_ty cons in
     let just' =
       typecheck_expr_top_down ~leave_unresolved ctx env
         (unionfind ~pos:just (TLit TBool))
@@ -889,9 +899,11 @@ and typecheck_expr_top_down :
         e1
     in
     Expr.eassert e1' mark
-  | A.EEmptyError -> Expr.eemptyerror (ty_mark (TAny (Any.fresh ())))
+  | A.EEmptyError ->
+    Expr.eemptyerror (ty_mark (TDefault (unionfind (TAny (Any.fresh ())))))
   | A.EErrorOnEmpty e1 ->
-    let e1' = typecheck_expr_top_down ~leave_unresolved ctx env tau e1 in
+    let tau' = unionfind (TDefault tau) in
+    let e1' = typecheck_expr_top_down ~leave_unresolved ctx env tau' e1 in
     Expr.eerroronempty e1' context_mark
   | A.EArray es ->
     let cell_type = unionfind (TAny (Any.fresh ())) in

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -224,28 +224,45 @@ let handle_type_error ctx (A.AnyExpr e) t1 t2 =
      persistent version of the union-find data structure. *)
   let t1_repr = UnionFind.get (UnionFind.find t1) in
   let t2_repr = UnionFind.get (UnionFind.find t2) in
+  let e_pos = Expr.pos e in
   let t1_pos = Mark.get t1_repr in
   let t2_pos = Mark.get t2_repr in
-  Message.raise_multispanned_error_full
-    [
-      ( Some
-          (fun ppf ->
-            Format.fprintf ppf
-              "@[<hv 2>Error coming from typechecking the following expression:";
+  let pos_msgs =
+    if e_pos = t1_pos then
+      [ (fun ppf ->
+            Format.fprintf ppf "@[<hv 2>@[<hov>%a@ %a@]:"
+              Format.pp_print_text "This expression has type"
+              (format_typ ctx) t1;
             if Cli.globals.debug then Format.fprintf ppf "@ %a@]" Expr.format e
-            else Format.pp_close_box ppf ()),
-        Expr.pos e );
-      ( Some
-          (fun ppf ->
-            Format.fprintf ppf "Type @{<yellow>%a@} coming from expression:"
-              (format_typ ctx) t1),
-        t1_pos );
-      ( Some
-          (fun ppf ->
-            Format.fprintf ppf "Type @{<yellow>%a@} coming from expression:"
-              (format_typ ctx) t2),
-        t2_pos );
-    ]
+             else Format.pp_close_box ppf ()),
+        e_pos;
+        (fun ppf ->
+           Format.fprintf ppf "@[<hov>Expected@ type@ %a@ coming@ from@ expression:@]"
+             (format_typ ctx) t2),
+        t2_pos;
+      ]
+     else [
+       ( (fun ppf ->
+             Format.fprintf ppf
+               "@[<hv 2>@[<hov>%a:@]"
+               Format.pp_print_text
+               "While typechecking the following expression";
+             if Cli.globals.debug then Format.fprintf ppf "@ %a@]" Expr.format e
+             else Format.pp_close_box ppf ()),
+         e_pos );
+       (fun ppf ->
+          Format.fprintf ppf "@[<hov>Type@ %a@ is@ coming@ from:@]"
+            (format_typ ctx) t1),
+       t1_pos;
+       (fun ppf ->
+          Format.fprintf ppf "@[<hov>Type@ %a@ is@ coming@ from:@]"
+            (format_typ ctx) t2),
+       t2_pos;
+
+     ]
+  in
+  Message.raise_multispanned_error_full
+    (List.map (fun (a, b) -> Some a, b) pos_msgs)
     "@[<v>Error during typechecking, incompatible types:@,\
      @[<v>@{<bold;blue>@<3>%s@} @[<hov>%a@]@,\
      @{<bold;blue>@<3>%s@} @[<hov>%a@]@]@]" "┌─⯈" (format_typ ctx) t1 "└─⯈"

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -230,8 +230,10 @@ let handle_type_error ctx (A.AnyExpr e) t1 t2 =
     [
       ( Some
           (fun ppf ->
-            Format.pp_print_string ppf
-              "Error coming from typechecking the following expression:"),
+            Format.fprintf ppf
+              "@[<hv 2>Error coming from typechecking the following expression:";
+            if Cli.globals.debug then Format.fprintf ppf "@ %a@]" Expr.format e
+            else Format.pp_close_box ppf ()),
         Expr.pos e );
       ( Some
           (fun ppf ->

--- a/compiler/shared_ast/typing.mli
+++ b/compiler/shared_ast/typing.mli
@@ -27,7 +27,8 @@ module Env : sig
   val add_var : 'e Var.t -> typ -> 'e t -> 'e t
   val add_toplevel_var : TopdefName.t -> typ -> 'e t -> 'e t
   val add_scope_var : ScopeVar.t -> typ -> 'e t -> 'e t
-  val add_scope : ScopeName.t -> vars:typ ScopeVar.Map.t -> 'e t -> 'e t
+  val add_scope :
+    ScopeName.t -> vars:typ ScopeVar.Map.t -> in_vars:typ ScopeVar.Map.t -> 'e t -> 'e t
   val add_module : ModuleName.t -> module_env:'e t -> 'e t -> 'e t
   val module_env : Uid.Path.t -> 'e t -> 'e t
   val open_scope : ScopeName.t -> 'e t -> 'e t

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -142,12 +142,7 @@ let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed expr) :
         (Print.expr ()) e)
   | EErrorOnEmpty d ->
     d (* input subscope variables and non-input scope variable *)
-  | _ ->
-    Message.raise_spanned_error (Expr.pos e)
-      "Internal error: this expression does not have the structure expected by \
-       the VC generator:\n\
-       %a"
-      (Print.expr ()) e
+  | _ -> e
 
 (** {1 Verification conditions generator}*)
 

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -206,6 +206,8 @@ let rec print_z3model_expr (ctx : context) (ty : typ) (e : Expr.expr) : string =
   | TAny -> failwith "[Z3 model]: Pretty-printing of Any not supported"
   | TClosureEnv ->
     failwith "[Z3 model]: Pretty-printing of closure_env not supported"
+  | TDefault _ ->
+    failwith "[Z3 model]: Pretty-printing of default terms not supported"
 
 (** [print_model] pretty prints a Z3 model, used to exhibit counter examples
     where verification conditions are not satisfied. The context [ctx] is useful
@@ -273,6 +275,7 @@ let rec translate_typ (ctx : context) (t : naked_typ) : context * Sort.sort =
   | TTuple _ -> failwith "[Z3 encoding] TTuple type not supported"
   | TEnum e -> find_or_create_enum ctx e
   | TOption _ -> failwith "[Z3 encoding] TOption type not supported"
+  | TDefault _ -> failwith "[Z3 encoding] TDefault type not supported"
   | TArrow _ -> failwith "[Z3 encoding] TArrow type not supported"
   | TArray _ ->
     (* For now, we are only encoding the (symbolic) length of an array.

--- a/tests/test_array/good/aggregation_3.catala_en
+++ b/tests/test_array/good/aggregation_3.catala_en
@@ -34,7 +34,7 @@ scope S:
 ```catala-test-inline
 $ catala scopelang -s S
 let scope S (x: integer|internal|output) =
-  let x : integer = ⟨true ⊢ 0⟩;
+  let x : integer = error_empty ⟨ ⟨true ⊢ 0⟩ | false ⊢ error_empty ∅ ⟩;
   assert (map (λ (i: integer) → i + 2) [ 1; 2; 3 ]) = [ 3; 4; 5 ];
   assert (filter (λ (i: integer) → i >= 2) [ 1; 2; 3 ]) = [ 2; 3 ];
   assert (map (λ (i: integer) → i + 2)

--- a/tests/test_bool/bad/bad_assert.catala_en
+++ b/tests/test_bool/bad/bad_assert.catala_en
@@ -17,21 +17,21 @@ Error during typechecking, incompatible types:
 ┌─⯈ integer
 └─⯈ bool
 
-Error coming from typechecking the following expression:
+While typechecking the following expression:
 ┌─⯈ tests/test_bool/bad/bad_assert.catala_en:9.13-9.14:
 └─┐
 9 │   assertion x
   │             ‾
   └─ Test
 
-Type integer coming from expression:
+Type integer is coming from:
 ┌─⯈ tests/test_bool/bad/bad_assert.catala_en:5.20-5.27:
 └─┐
 5 │   output x content integer
   │                    ‾‾‾‾‾‾‾
   └─ Test
 
-Type bool coming from expression:
+Type bool is coming from:
 ┌─⯈ tests/test_bool/bad/bad_assert.catala_en:9.13-9.14:
 └─┐
 9 │   assertion x

--- a/tests/test_bool/bad/test_xor_with_int.catala_en
+++ b/tests/test_bool/bad/test_xor_with_int.catala_en
@@ -15,21 +15,14 @@ Error during typechecking, incompatible types:
 ┌─⯈ integer
 └─⯈ bool
 
-Error coming from typechecking the following expression:
+This expression has type integer:
 ┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:8.30-8.32:
 └─┐
 8 │   definition test_var equals 10 xor 20
   │                              ‾‾
   └─ 'xor' should be a boolean operator
 
-Type integer coming from expression:
-┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:8.30-8.32:
-└─┐
-8 │   definition test_var equals 10 xor 20
-  │                              ‾‾
-  └─ 'xor' should be a boolean operator
-
-Type bool coming from expression:
+Expected type bool coming from expression:
 ┌─⯈ tests/test_bool/bad/test_xor_with_int.catala_en:8.33-8.36:
 └─┐
 8 │   definition test_var equals 10 xor 20

--- a/tests/test_bool/good/test_bool.catala_en
+++ b/tests/test_bool/good/test_bool.catala_en
@@ -15,14 +15,20 @@ scope TestBool:
 $ catala Dcalc 
 let TestBool : TestBool_in → TestBool =
   λ (TestBool_in: TestBool_in) →
-  let foo : unit → bool = TestBool_in.foo_in in
-  let bar : unit → integer = TestBool_in.bar_in in
-  let bar1 : integer = error_empty ⟨ bar () | true ⊢ ⟨true ⊢ 1⟩ ⟩ in
+  let foo : unit → ⟨bool⟩ = TestBool_in.foo_in in
+  let bar : unit → ⟨integer⟩ = TestBool_in.bar_in in
+  let bar1 : integer =
+    error_empty
+      ⟨ bar ()
+      | true ⊢ error_empty ⟨ ⟨true ⊢ 1⟩ | false ⊢ error_empty ∅ ⟩ ⟩
+  in
   let foo1 : bool =
     error_empty
       ⟨ foo ()
       | true
-        ⊢ ⟨true ⊢ ⟨ ⟨bar1 >= 0 ⊢ true⟩, ⟨bar1 < 0 ⊢ false⟩ | false ⊢ ∅ ⟩⟩ ⟩
+        ⊢ error_empty
+            ⟨ ⟨bar1 >= 0 ⊢ true⟩, ⟨bar1 < 0 ⊢ false⟩
+            | false ⊢ error_empty ∅ ⟩ ⟩
   in
   { TestBool foo = foo1; bar = bar1; }
 in
@@ -43,10 +49,13 @@ struct TestBool = {
   bar: integer
 }
 
-let scope TestBool (foo: bool|context|output) (bar: integer|context|output) =
-  let bar : integer = reentrant or by default ⟨true ⊢ 1⟩;
+let scope TestBool (foo: ⟨bool⟩|context|output) (bar: ⟨integer⟩|context|
+  output) =
+  let bar : integer = reentrant or by default
+    error_empty ⟨ ⟨true ⊢ 1⟩ | false ⊢ error_empty ∅ ⟩;
   let foo : bool = reentrant or by default
-    ⟨true ⊢ ⟨ ⟨bar >= 0 ⊢ true⟩, ⟨bar < 0 ⊢ false⟩ | false ⊢ ∅ ⟩⟩
+    error_empty
+      ⟨ ⟨bar >= 0 ⊢ true⟩, ⟨bar < 0 ⊢ false⟩ | false ⊢ error_empty ∅ ⟩
 ```
 ```catala-test-inline
 $ catala Interpret_Lcalc -s TestBool --avoid_exceptions --optimize

--- a/tests/test_enum/bad/quick_pattern_2.catala_en
+++ b/tests/test_enum/bad/quick_pattern_2.catala_en
@@ -35,21 +35,21 @@ Error during typechecking, incompatible types:
 ┌─⯈ E
 └─⯈ F
 
-Error coming from typechecking the following expression:
+While typechecking the following expression:
 ┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:28.23-28.24:
 └──┐
 28 │   definition y equals x with pattern Case3
    │                       ‾
    └─ Article
 
-Type E coming from expression:
+Type E is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:17.21-17.22:
 └──┐
 17 │   context x content E
    │                     ‾
    └─ Article
 
-Type F coming from expression:
+Type F is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_2.catala_en:28.23-28.43:
 └──┐
 28 │   definition y equals x with pattern Case3

--- a/tests/test_enum/bad/quick_pattern_3.catala_en
+++ b/tests/test_enum/bad/quick_pattern_3.catala_en
@@ -25,21 +25,21 @@ Error during typechecking, incompatible types:
 ┌─⯈ E
 └─⯈ F
 
-Error coming from typechecking the following expression:
+While typechecking the following expression:
 ┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:18.21-18.22:
 └──┐
 18 │ definition y equals x with pattern Case3
    │                     ‾
    └─ Article
 
-Type E coming from expression:
+Type E is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:13.19-13.20:
 └──┐
 13 │ context x content E
    │                   ‾
    └─ Article
 
-Type F coming from expression:
+Type F is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_3.catala_en:18.21-18.41:
 └──┐
 18 │ definition y equals x with pattern Case3

--- a/tests/test_enum/bad/quick_pattern_4.catala_en
+++ b/tests/test_enum/bad/quick_pattern_4.catala_en
@@ -24,21 +24,21 @@ Error during typechecking, incompatible types:
 ┌─⯈ E
 └─⯈ F
 
-Error coming from typechecking the following expression:
+While typechecking the following expression:
 ┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:17.21-17.22:
 └──┐
 17 │ definition y equals x with pattern Case3
    │                     ‾
    └─ Test
 
-Type E coming from expression:
+Type E is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:12.19-12.20:
 └──┐
 12 │ context x content E
    │                   ‾
    └─ Test
 
-Type F coming from expression:
+Type F is coming from:
 ┌─⯈ tests/test_enum/bad/quick_pattern_4.catala_en:17.21-17.41:
 └──┐
 17 │ definition y equals x with pattern Case3

--- a/tests/test_exception/good/double_definition.catala_en
+++ b/tests/test_exception/good/double_definition.catala_en
@@ -26,7 +26,8 @@ $ catala Scopelang -s Foo
   │   ‾‾‾‾‾‾‾‾‾‾‾‾
   └─ Foo
 let scope Foo (x: integer|internal|output) =
-  let x : integer = ⟨true ⊢ ⟨ ⟨true ⊢ 1⟩, ⟨true ⊢ 1⟩ | false ⊢ ∅ ⟩⟩
+  let x : integer =
+    error_empty ⟨ ⟨true ⊢ 1⟩, ⟨true ⊢ 1⟩ | false ⊢ error_empty ∅ ⟩
 ```
 
 In Scopelang we have what looks like conflicting exceptions. But after
@@ -52,7 +53,7 @@ $ catala Dcalc -s Foo
   └─ Foo
 let scope Foo (Foo_in: Foo_in): Foo {x: integer} =
   let set x : integer =
-    error_empty ⟨true ⊢ ⟨ ⟨ ⟨true ⊢ 1⟩ | true ⊢ 1 ⟩ | false ⊢ ∅ ⟩⟩
+    error_empty ⟨ ⟨ ⟨true ⊢ 1⟩ | true ⊢ 1 ⟩ | false ⊢ error_empty ∅ ⟩
   in
   return { Foo x = x; }
 ```

--- a/tests/test_exception/good/groups_of_exceptions.catala_en
+++ b/tests/test_exception/good/groups_of_exceptions.catala_en
@@ -39,9 +39,13 @@ struct Foo = {
 
 let scope Foo (y: integer|input) (x: integer|internal|output) =
   let x : integer =
-    ⟨ ⟨ ⟨true ⊢ ⟨ ⟨y = 4 ⊢ 4⟩, ⟨y = 5 ⊢ 5⟩ | false ⊢ ∅ ⟩⟩
-      | true ⊢ ⟨ ⟨y = 2 ⊢ 2⟩, ⟨y = 3 ⊢ 3⟩ | false ⊢ ∅ ⟩ ⟩
-    | true ⊢ ⟨ ⟨y = 0 ⊢ 0⟩, ⟨y = 1 ⊢ 1⟩ | false ⊢ ∅ ⟩ ⟩
+    error_empty
+      ⟨ ⟨ ⟨ ⟨y = 4 ⊢ 4⟩, ⟨y = 5 ⊢ 5⟩ | false ⊢ error_empty ∅ ⟩
+        | true
+          ⊢ error_empty
+              ⟨ ⟨y = 2 ⊢ 2⟩, ⟨y = 3 ⊢ 3⟩ | false ⊢ error_empty ∅ ⟩ ⟩
+      | true
+        ⊢ error_empty ⟨ ⟨y = 0 ⊢ 0⟩, ⟨y = 1 ⊢ 1⟩ | false ⊢ error_empty ∅ ⟩ ⟩
 ```
 
 ```catala-test-inline

--- a/tests/test_func/good/closure_conversion.catala_en
+++ b/tests/test_func/good/closure_conversion.catala_en
@@ -19,7 +19,7 @@ type S_in = { x_in: eoption bool; }
 
 type S = { z: eoption integer; }
  
-let topval closure_f : (closure_env, integer) → eoption integer =
+let topval closure_f : (closure_env, integer) → eoption any =
   λ (env: closure_env) (y: integer) →
   ESome
     match
@@ -35,8 +35,8 @@ let topval closure_f : (closure_env, integer) → eoption integer =
     | ESome f → f 
 let scope S (S_in: S_in {x_in: eoption bool}): S {z: eoption integer} =
   let get x : eoption bool = S_in.x_in in
-  let set f :
-      eoption ((closure_env, integer) → eoption integer * closure_env) =
+  let set f : eoption ((closure_env, integer) → eoption any * closure_env)
+      =
     ESome (closure_f, to_closure_env (x))
   in
   let set z : eoption integer =
@@ -50,8 +50,7 @@ let scope S (S_in: S_in {x_in: eoption bool}): S {z: eoption integer} =
             | ENone _1 → ENone _1
             | ESome f →
               let code_and_env :
-                  ((closure_env, integer) → eoption integer * closure_env)
-                  =
+                  ((closure_env, integer) → eoption any * closure_env) =
                 f
               in
               code_and_env.0 code_and_env.1 -1))

--- a/tests/test_func/good/closure_conversion.catala_en
+++ b/tests/test_func/good/closure_conversion.catala_en
@@ -23,9 +23,13 @@ let topval closure_f : (closure_env, integer) → eoption integer =
   λ (env: closure_env) (y: integer) →
   ESome
     match
-      (match (from_closure_env env).0 with
-       | ENone _ → ENone _
-       | ESome x → if x then ESome y else ESome - y)
+      (handle_default_opt
+         [  ]
+         (λ (_: unit) → ESome true)
+         (λ (_: unit) →
+          match (from_closure_env env).0 with
+          | ENone _1 → ENone _1
+          | ESome x → if x then ESome y else ESome - y))
       with
     | ENone _ → raise NoValueProvided
     | ESome f → f 
@@ -38,14 +42,19 @@ let scope S (S_in: S_in {x_in: eoption bool}): S {z: eoption integer} =
   let set z : eoption integer =
     ESome
       match
-        (match f with
-         | ENone _ → ENone _
-         | ESome f →
-           let code_and_env :
-               ((closure_env, integer) → eoption integer * closure_env) =
-             f
-           in
-           code_and_env.0 code_and_env.1 -1)
+        (handle_default_opt
+           [  ]
+           (λ (_: unit) → ESome true)
+           (λ (_: unit) →
+            match f with
+            | ENone _1 → ENone _1
+            | ESome f →
+              let code_and_env :
+                  ((closure_env, integer) → eoption integer * closure_env)
+                  =
+                f
+              in
+              code_and_env.0 code_and_env.1 -1))
         with
       | ENone _ → raise NoValueProvided
       | ESome z → z

--- a/tests/test_func/good/closure_conversion_reduce.catala_en
+++ b/tests/test_func/good/closure_conversion_reduce.catala_en
@@ -21,24 +21,28 @@ let scope S
   let set y : eoption integer =
     ESome
       match
-        (match x with
-         | ENone _ → ENone _
-         | ESome y_2 →
-           reduce
-             (λ (f: eoption integer) (init: eoption integer) →
-              match init with
-              | ENone _ → ENone _
-              | ESome y_3 →
-                match f with
-                | ENone _ → ENone _
-                | ESome y_0 →
-                  let potential_max_1 : integer = y_0 in
-                  let potential_max_2 : integer = y_3 in
-                  if potential_max_1 < potential_max_2 then
-                    ESome potential_max_1
-                  else ESome potential_max_2)
-             ESome -1
-             y_2)
+        (handle_default_opt
+           [  ]
+           (λ (_: unit) → ESome true)
+           (λ (_: unit) →
+            match x with
+            | ENone _1 → ENone _1
+            | ESome y_2 →
+              reduce
+                (λ (f: eoption integer) (init: eoption integer) →
+                 match init with
+                 | ENone _1 → ENone _1
+                 | ESome y_3 →
+                   match f with
+                   | ENone _1 → ENone _1
+                   | ESome y_0 →
+                     let potential_max_1 : integer = y_0 in
+                     let potential_max_2 : integer = y_3 in
+                     if potential_max_1 < potential_max_2 then
+                       ESome potential_max_1
+                     else ESome potential_max_2)
+                ESome -1
+                y_2))
         with
       | ENone _ → raise NoValueProvided
       | ESome y → y
@@ -67,27 +71,30 @@ let scope S
     ESome
       match
         (handle_default_opt
-           [  ]
-           (λ (_: unit) → ESome true)
-           (λ (_: unit) →
-            match x with
-            | ENone _1 → ENone _1
-            | ESome y_2 →
-              reduce
-                (λ (f: eoption integer) (init: eoption integer) →
-                 match init with
-                 | ENone _1 → ENone _1
-                 | ESome y_3 →
-                   match f with
-                   | ENone _1 → ENone _1
-                   | ESome y_0 →
-                     let potential_max_1 : integer = y_0 in
-                     let potential_max_2 : integer = y_3 in
-                     if potential_max_1 < potential_max_2 then
-                       ESome potential_max_1
-                     else ESome potential_max_2)
-                ESome -1
-                y_2))
+           [ handle_default_opt
+               [  ]
+               (λ (_: unit) → ESome true)
+               (λ (_: unit) →
+                match x with
+                | ENone _1 → ENone _1
+                | ESome y_2 →
+                  reduce
+                    (λ (f: eoption integer) (init: eoption integer) →
+                     match init with
+                     | ENone _1 → ENone _1
+                     | ESome y_3 →
+                       match f with
+                       | ENone _1 → ENone _1
+                       | ESome y_0 →
+                         let potential_max_1 : integer = y_0 in
+                         let potential_max_2 : integer = y_3 in
+                         if potential_max_1 < potential_max_2 then
+                           ESome potential_max_1
+                         else ESome potential_max_2)
+                    ESome -1
+                    y_2) ]
+           (λ (_: unit) → ESome false)
+           (λ (_: unit) → ESome raise NoValueProvided))
         with
       | ENone _ → raise NoValueProvided
       | ESome y → y

--- a/tests/test_func/good/closure_return.catala_en
+++ b/tests/test_func/good/closure_return.catala_en
@@ -15,11 +15,9 @@ type eoption =  | ENone of unit  | ESome of any
 
 type S_in = { x_in: eoption bool; }
 
-type S = {
-  f: eoption ((closure_env, integer) → eoption integer * closure_env);
-  }
+type S = { f: eoption ((closure_env, integer) → eoption any * closure_env); }
  
-let topval closure_f : (closure_env, integer) → eoption integer =
+let topval closure_f : (closure_env, integer) → eoption any =
   λ (env: closure_env) (y: integer) →
   ESome
     match
@@ -35,11 +33,11 @@ let topval closure_f : (closure_env, integer) → eoption integer =
     | ESome f → f 
 let scope S
   (S_in: S_in {x_in: eoption bool})
-  : S {f: eoption ((closure_env, integer) → eoption integer * closure_env)}
+  : S {f: eoption ((closure_env, integer) → eoption any * closure_env)}
   =
   let get x : eoption bool = S_in.x_in in
-  let set f :
-      eoption ((closure_env, integer) → eoption integer * closure_env) =
+  let set f : eoption ((closure_env, integer) → eoption any * closure_env)
+      =
     ESome (closure_f, to_closure_env (x))
   in
   return { S f = f; } 

--- a/tests/test_func/good/closure_return.catala_en
+++ b/tests/test_func/good/closure_return.catala_en
@@ -23,9 +23,13 @@ let topval closure_f : (closure_env, integer) → eoption integer =
   λ (env: closure_env) (y: integer) →
   ESome
     match
-      (match (from_closure_env env).0 with
-       | ENone _ → ENone _
-       | ESome x → if x then ESome y else ESome - y)
+      (handle_default_opt
+         [  ]
+         (λ (_: unit) → ESome true)
+         (λ (_: unit) →
+          match (from_closure_env env).0 with
+          | ENone _1 → ENone _1
+          | ESome x → if x then ESome y else ESome - y))
       with
     | ENone _ → raise NoValueProvided
     | ESome f → f 

--- a/tests/test_func/good/closure_through_scope.catala_en
+++ b/tests/test_func/good/closure_through_scope.catala_en
@@ -32,15 +32,12 @@ let scope T (T_in: T_in): T {y: eoption integer} =
   in
   let call result :
       eoption
-        S {
-          f:
-            eoption
-              ((closure_env, integer) → eoption integer * closure_env)
-        } =
+        S {f: eoption ((closure_env, integer) → eoption any * closure_env)}
+      =
     ESome S { S_in x_in = ESome s.x; }
   in
   let sub_get s.f :
-      eoption ((closure_env, integer) → eoption integer * closure_env) =
+      eoption ((closure_env, integer) → eoption any * closure_env) =
     match result with
     | ENone _ → ENone _
     | ESome result → result.f
@@ -56,8 +53,7 @@ let scope T (T_in: T_in): T {y: eoption integer} =
             | ENone _1 → ENone _1
             | ESome s.f →
               let code_and_env :
-                  ((closure_env, integer) → eoption integer * closure_env)
-                  =
+                  ((closure_env, integer) → eoption any * closure_env) =
                 s.f
               in
               code_and_env.0 code_and_env.1 2))

--- a/tests/test_func/good/closure_through_scope.catala_en
+++ b/tests/test_func/good/closure_through_scope.catala_en
@@ -20,7 +20,16 @@ scope T:
 ```catala-test-inline
 $ catala Lcalc -s T --avoid_exceptions -O --closure_conversion
 let scope T (T_in: T_in): T {y: eoption integer} =
-  let sub_set s.x : bool = false in
+  let sub_set s.x : bool =
+    match
+      (handle_default_opt
+         [  ]
+         (λ (_: unit) → ESome true)
+         (λ (_: unit) → ESome false))
+      with
+    | ENone _ → raise NoValueProvided
+    | ESome T_in → T_in
+  in
   let call result :
       eoption
         S {
@@ -39,14 +48,19 @@ let scope T (T_in: T_in): T {y: eoption integer} =
   let set y : eoption integer =
     ESome
       match
-        (match s.f with
-         | ENone _ → ENone _
-         | ESome s.f →
-           let code_and_env :
-               ((closure_env, integer) → eoption integer * closure_env) =
-             s.f
-           in
-           code_and_env.0 code_and_env.1 2)
+        (handle_default_opt
+           [  ]
+           (λ (_: unit) → ESome true)
+           (λ (_: unit) →
+            match s.f with
+            | ENone _1 → ENone _1
+            | ESome s.f →
+              let code_and_env :
+                  ((closure_env, integer) → eoption integer * closure_env)
+                  =
+                s.f
+              in
+              code_and_env.0 code_and_env.1 2))
         with
       | ENone _ → raise NoValueProvided
       | ESome y → y

--- a/tests/test_func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/test_func/good/scope_call_func_struct_closure.catala_en
@@ -45,7 +45,7 @@ $ catala Lcalc --avoid_exceptions -O --closure_conversion
 type eoption =  | ENone of unit  | ESome of any 
 
 type Result = {
-  r: eoption ((closure_env, integer) → eoption integer * closure_env);
+  r: eoption ((closure_env, integer) → eoption any * closure_env);
   q: eoption integer;
   }
 
@@ -53,27 +53,31 @@ type SubFoo1_in = { x_in: eoption integer; }
 
 type SubFoo1 = {
   x: eoption integer;
-  y: eoption ((closure_env, integer) → eoption integer * closure_env);
+  y: eoption ((closure_env, integer) → eoption any * closure_env);
   }
 
 type SubFoo2_in = { x1_in: eoption integer; x2_in: eoption integer; }
 
 type SubFoo2 = {
   x1: eoption integer;
-  y: eoption ((closure_env, integer) → eoption integer * closure_env);
+  y: eoption ((closure_env, integer) → eoption any * closure_env);
   }
 
-type Foo_in = { b_in: eoption bool; }
+type Foo_in = { b_in: eoption ⟨bool⟩; }
 
 type Foo = { z: eoption integer; }
  
-let topval closure_y : (closure_env, integer) → eoption integer =
+let topval closure_y : (closure_env, integer) → eoption any =
   λ (env: closure_env) (z: integer) →
   ESome
     match
-      (match (from_closure_env env).0 with
-       | ENone _ → ENone _
-       | ESome x_0 → ESome (x_0 + z))
+      (handle_default_opt
+         [  ]
+         (λ (_: unit) → ESome true)
+         (λ (_: unit) →
+          match (from_closure_env env).0 with
+          | ENone _1 → ENone _1
+          | ESome x_0 → ESome (x_0 + z)))
       with
     | ENone _ → raise NoValueProvided
     | ESome y → y 
@@ -81,30 +85,34 @@ let scope SubFoo1
   (SubFoo1_in: SubFoo1_in {x_in: eoption integer})
   : SubFoo1 {
       x: eoption integer;
-      y: eoption ((closure_env, integer) → eoption integer * closure_env)
+      y: eoption ((closure_env, integer) → eoption any * closure_env)
     }
   =
   let get x : eoption integer = SubFoo1_in.x_in in
-  let set y :
-      eoption ((closure_env, integer) → eoption integer * closure_env) =
+  let set y : eoption ((closure_env, integer) → eoption any * closure_env)
+      =
     ESome (closure_y, to_closure_env (x))
   in
   return { SubFoo1 x = x; y = y; } 
-let topval closure_y : (closure_env, integer) → eoption integer =
+let topval closure_y : (closure_env, integer) → eoption any =
   λ (env: closure_env) (z: integer) →
   let env1 : (eoption integer * eoption integer) = from_closure_env env in
   ESome
     match
-      (match
-         (match env1.0 with
-          | ENone _ → ENone _
-          | ESome x1_1 →
-            match env1.1 with
-            | ENone _ → ENone _
-            | ESome x1_0 → ESome (x1_0 + x1_1))
-         with
-       | ENone _ → ENone _
-       | ESome y_0 → ESome (y_0 + z))
+      (handle_default_opt
+         [  ]
+         (λ (_: unit) → ESome true)
+         (λ (_: unit) →
+          match
+            (match env1.0 with
+             | ENone _1 → ENone _1
+             | ESome x1_1 →
+               match env1.1 with
+               | ENone _1 → ENone _1
+               | ESome x1_0 → ESome (x1_0 + x1_1))
+            with
+          | ENone _1 → ENone _1
+          | ESome y_0 → ESome (y_0 + z)))
       with
     | ENone _ → raise NoValueProvided
     | ESome y → y 
@@ -112,48 +120,57 @@ let scope SubFoo2
   (SubFoo2_in: SubFoo2_in {x1_in: eoption integer; x2_in: eoption integer})
   : SubFoo2 {
       x1: eoption integer;
-      y: eoption ((closure_env, integer) → eoption integer * closure_env)
+      y: eoption ((closure_env, integer) → eoption any * closure_env)
     }
   =
   let get x1 : eoption integer = SubFoo2_in.x1_in in
   let get x2 : eoption integer = SubFoo2_in.x2_in in
-  let set y :
-      eoption ((closure_env, integer) → eoption integer * closure_env) =
+  let set y : eoption ((closure_env, integer) → eoption any * closure_env)
+      =
     ESome (closure_y, to_closure_env (x2, x1))
   in
   return { SubFoo2 x1 = x1; y = y; } 
-let topval closure_r : (closure_env, integer) → eoption integer =
+let topval closure_r : (closure_env, integer) → eoption any =
   λ (env: closure_env) (param0: integer) →
   match (SubFoo2 { SubFoo2_in x1_in = ESome 10; x2_in = ESome 10; }).y with
   | ENone _ → ENone _
   | ESome result →
-    let code_and_env :
-        ((closure_env, integer) → eoption integer * closure_env) =
+    let code_and_env : ((closure_env, integer) → eoption any * closure_env)
+        =
       result
     in
     code_and_env.0 code_and_env.1 param0 
-let topval closure_r : (closure_env, integer) → eoption integer =
+let topval closure_r : (closure_env, integer) → eoption any =
   λ (env: closure_env) (param0: integer) →
   match (SubFoo1 { SubFoo1_in x_in = ESome 10; }).y with
   | ENone _ → ENone _
   | ESome result →
-    let code_and_env :
-        ((closure_env, integer) → eoption integer * closure_env) =
+    let code_and_env : ((closure_env, integer) → eoption any * closure_env)
+        =
       result
     in
     code_and_env.0 code_and_env.1 param0 
 let scope Foo
-  (Foo_in: Foo_in {b_in: eoption bool})
+  (Foo_in: Foo_in {b_in: eoption ⟨bool⟩})
   : Foo {z: eoption integer}
   =
-  let get b : eoption bool = Foo_in.b_in in
+  let get b : eoption ⟨bool⟩ = Foo_in.b_in in
   let set b : eoption bool =
     ESome
       match
         (handle_default_opt
            [ b ]
            (λ (_: unit) → ESome true)
-           (λ (_: unit) → ESome true))
+           (λ (_: unit) →
+            ESome
+              match
+                (handle_default_opt
+                   [  ]
+                   (λ (_1: unit) → ESome true)
+                   (λ (_1: unit) → ESome true))
+                with
+              | ENone _1 → raise NoValueProvided
+              | ESome b → b))
         with
       | ENone _ → raise NoValueProvided
       | ESome b → b
@@ -161,57 +178,62 @@ let scope Foo
   let set r :
       eoption
         Result {
-          r:
-            eoption
-              ((closure_env, integer) → eoption integer * closure_env);
+          r: eoption ((closure_env, integer) → eoption any * closure_env);
           q: eoption integer
         } =
     ESome
       match
-        (match b with
-         | ENone _ → ENone _
-         | ESome b →
-           if b then
-             match
-               (match (SubFoo1 { SubFoo1_in x_in = ESome 10; }).x with
-                | ENone _ → ENone _
-                | ESome result_0 →
-                  ESome
-                    { SubFoo1
-                      x = ESome result_0;
-                      y = ESome (closure_r, to_closure_env ());
-                    })
-               with
-             | ENone _ → ENone _
-             | ESome f →
-               match f.x with
-               | ENone _ → ENone _
-               | ESome f_1 →
-                 match f.y with
-                 | ENone _ → ENone _
-                 | ESome f_0 → ESome { Result r = ESome f_0; q = ESome f_1; }
-           else
-             match
-               (match
-                  (SubFoo2 { SubFoo2_in x1_in = ESome 10; x2_in = ESome 10; }).
-                    x1
+        (handle_default_opt
+           [  ]
+           (λ (_: unit) → ESome true)
+           (λ (_: unit) →
+            match b with
+            | ENone _1 → ENone _1
+            | ESome b →
+              if b then
+                match
+                  (match (SubFoo1 { SubFoo1_in x_in = ESome 10; }).x with
+                   | ENone _1 → ENone _1
+                   | ESome result_0 →
+                     ESome
+                       { SubFoo1
+                         x = ESome result_0;
+                         y = ESome (closure_r, to_closure_env ());
+                       })
                   with
-                | ENone _ → ENone _
-                | ESome result_0 →
-                  ESome
-                    { SubFoo2
-                      x1 = ESome result_0;
-                      y = ESome (closure_r, to_closure_env ());
-                    })
-               with
-             | ENone _ → ENone _
-             | ESome f →
-               match f.x1 with
-               | ENone _ → ENone _
-               | ESome f_1 →
-                 match f.y with
-                 | ENone _ → ENone _
-                 | ESome f_0 → ESome { Result r = ESome f_0; q = ESome f_1; })
+                | ENone _1 → ENone _1
+                | ESome f →
+                  match f.x with
+                  | ENone _1 → ENone _1
+                  | ESome f_1 →
+                    match f.y with
+                    | ENone _1 → ENone _1
+                    | ESome f_0 →
+                      ESome { Result r = ESome f_0; q = ESome f_1; }
+              else
+                match
+                  (match
+                     (SubFoo2
+                        { SubFoo2_in x1_in = ESome 10; x2_in = ESome 10; }).
+                       x1
+                     with
+                   | ENone _1 → ENone _1
+                   | ESome result_0 →
+                     ESome
+                       { SubFoo2
+                         x1 = ESome result_0;
+                         y = ESome (closure_r, to_closure_env ());
+                       })
+                  with
+                | ENone _1 → ENone _1
+                | ESome f →
+                  match f.x1 with
+                  | ENone _1 → ENone _1
+                  | ESome f_1 →
+                    match f.y with
+                    | ENone _1 → ENone _1
+                    | ESome f_0 →
+                      ESome { Result r = ESome f_0; q = ESome f_1; }))
         with
       | ENone _ → raise NoValueProvided
       | ESome r → r
@@ -219,16 +241,20 @@ let scope Foo
   let set z : eoption integer =
     ESome
       match
-        (match (match r with
-                | ENone _ → ENone _
-                | ESome r → r.r) with
-         | ENone _ → ENone _
-         | ESome r →
-           let code_and_env :
-               ((closure_env, integer) → eoption integer * closure_env) =
-             r
-           in
-           code_and_env.0 code_and_env.1 1)
+        (handle_default_opt
+           [  ]
+           (λ (_: unit) → ESome true)
+           (λ (_: unit) →
+            match (match r with
+                   | ENone _1 → ENone _1
+                   | ESome r → r.r) with
+            | ENone _1 → ENone _1
+            | ESome r →
+              let code_and_env :
+                  ((closure_env, integer) → eoption any * closure_env) =
+                r
+              in
+              code_and_env.0 code_and_env.1 1))
         with
       | ENone _ → raise NoValueProvided
       | ESome z → z

--- a/tests/test_io/good/all_io.catala_en
+++ b/tests/test_io/good/all_io.catala_en
@@ -24,21 +24,32 @@ let scope A
      A_in {
        c_in: integer;
        d_in: integer;
-       e_in: unit → integer;
-       f_in: unit → integer
+       e_in: unit → ⟨integer⟩;
+       f_in: unit → ⟨integer⟩
      })
   : A {b: integer; d: integer; f: integer}
   =
   let get c : integer = A_in.c_in in
   let get d : integer = A_in.d_in in
-  let get e : unit → integer = A_in.e_in in
-  let get f : unit → integer = A_in.f_in in
-  let set a : integer = error_empty ⟨true ⊢ 0⟩ in
-  let set b : integer = error_empty ⟨true ⊢ a + 1⟩ in
-  let set e : integer =
-    error_empty ⟨ e () | true ⊢ ⟨true ⊢ b + c + d + 1⟩ ⟩
+  let get e : unit → ⟨integer⟩ = A_in.e_in in
+  let get f : unit → ⟨integer⟩ = A_in.f_in in
+  let set a : integer =
+    error_empty ⟨ ⟨true ⊢ 0⟩ | false ⊢ error_empty ∅ ⟩
   in
-  let set f : integer = error_empty ⟨ f () | true ⊢ ⟨true ⊢ e + 1⟩ ⟩ in
+  let set b : integer =
+    error_empty ⟨ ⟨true ⊢ a + 1⟩ | false ⊢ error_empty ∅ ⟩
+  in
+  let set e : integer =
+    error_empty
+      ⟨ e ()
+      | true
+        ⊢ error_empty ⟨ ⟨true ⊢ b + c + d + 1⟩ | false ⊢ error_empty ∅ ⟩ ⟩
+  in
+  let set f : integer =
+    error_empty
+      ⟨ f ()
+      | true ⊢ error_empty ⟨ ⟨true ⊢ e + 1⟩ | false ⊢ error_empty ∅ ⟩ ⟩
+  in
   return { A b = b; d = d; f = f; }
 ```
 

--- a/tests/test_io/good/condition_only_input.catala_en
+++ b/tests/test_io/good/condition_only_input.catala_en
@@ -17,10 +17,12 @@ scope B:
 ```catala-test-inline
 $ catala Dcalc -s B
 let scope B (B_in: B_in): B =
-  let sub_set a.x : bool = error_empty ⟨true ⊢ false⟩ in
+  let sub_set a.x : bool =
+    error_empty ⟨ ⟨true ⊢ false⟩ | false ⊢ error_empty ∅ ⟩
+  in
   let call result : A {y: integer} = A { A_in x_in = a.x; } in
   let sub_get a.y : integer = result.y in
-  let assert _ : unit = assert (error_empty (a.y = 1)) in
+  let assert _ : unit = assert ((a.y = 1)) in
   return {B}
 ```
 

--- a/tests/test_io/good/subscope.catala_en
+++ b/tests/test_io/good/subscope.catala_en
@@ -23,11 +23,13 @@ scope B:
 ```catala-test-inline
 $ catala Dcalc -s B
 let scope B (B_in: B_in): B =
-  let sub_set a.a : unit → integer = λ (_: unit) → ∅ in
-  let sub_set a.b : integer = error_empty ⟨true ⊢ 2⟩ in
+  let sub_set a.a : unit → ⟨integer⟩ = λ (_: unit) → ∅ in
+  let sub_set a.b : integer =
+    error_empty ⟨ ⟨true ⊢ 2⟩ | false ⊢ error_empty ∅ ⟩
+  in
   let call result : A {c: integer} = A { A_in a_in = a.a; b_in = a.b; } in
   let sub_get a.c : integer = result.c in
-  let assert _ : unit = assert (error_empty (a.c = 1)) in
+  let assert _ : unit = assert ((a.c = 1)) in
   return {B}
 ```
 

--- a/tests/test_modules/good/output/mod_def.ml
+++ b/tests/test_modules/good/output/mod_def.ml
@@ -31,9 +31,19 @@ let s (s_in: S_in.t) : S.t =
     try
       (handle_default
          {filename = ""; start_line=0; start_column=1;
-           end_line=0; end_column=1; law_headings=[]} ([||])
-         (fun (_: unit) -> true)
-         (fun (_: unit) -> money_of_cents_string "100000"))
+           end_line=0; end_column=1; law_headings=[]}
+         ([|(fun (_: unit) ->
+               handle_default
+                 {filename = ""; start_line=0; start_column=1;
+                   end_line=0; end_column=1; law_headings=[]} ([||])
+                 (fun (_: unit) -> true)
+                 (fun (_: unit) -> money_of_cents_string "100000"))|])
+         (fun (_: unit) -> false)
+         (fun (_: unit) -> try (raise EmptyError) with
+            EmptyError -> (raise (NoValueProvided
+              {filename = "tests/test_modules/good/mod_def.catala_en";
+                start_line=16; start_column=10; end_line=16; end_column=12;
+                law_headings=["Test modules + inclusions 1"]}))))
     with
     EmptyError -> (raise (NoValueProvided
       {filename = "tests/test_modules/good/mod_def.catala_en"; start_line=16;
@@ -43,8 +53,18 @@ let s (s_in: S_in.t) : S.t =
     try
       (handle_default
          {filename = ""; start_line=0; start_column=1;
-           end_line=0; end_column=1; law_headings=[]} ([||])
-         (fun (_: unit) -> true) (fun (_: unit) -> Enum1.Maybe ()))
+           end_line=0; end_column=1; law_headings=[]}
+         ([|(fun (_: unit) ->
+               handle_default
+                 {filename = ""; start_line=0; start_column=1;
+                   end_line=0; end_column=1; law_headings=[]} ([||])
+                 (fun (_: unit) -> true) (fun (_: unit) -> Enum1.Maybe ()))|])
+         (fun (_: unit) -> false)
+         (fun (_: unit) -> try (raise EmptyError) with
+            EmptyError -> (raise (NoValueProvided
+              {filename = "tests/test_modules/good/mod_def.catala_en";
+                start_line=17; start_column=10; end_line=17; end_column=12;
+                law_headings=["Test modules + inclusions 1"]}))))
     with
     EmptyError -> (raise (NoValueProvided
       {filename = "tests/test_modules/good/mod_def.catala_en"; start_line=17;

--- a/tests/test_name_resolution/good/let_in2.catala_en
+++ b/tests/test_name_resolution/good/let_in2.catala_en
@@ -51,15 +51,30 @@ let s (s_in: S_in.t) : S.t =
          {filename = ""; start_line=0; start_column=1;
            end_line=0; end_column=1; law_headings=[]}
          ([|(fun (_: unit) -> a_ ())|]) (fun (_: unit) -> true)
-         (fun (_: unit) ->
-            handle_default
-              {filename = ""; start_line=0; start_column=1;
-                end_line=0; end_column=1; law_headings=[]} ([||])
-              (fun (_: unit) -> true)
-              (fun (_: unit) -> (let a_ : bool = false
-                 in
-                 (let a_ : bool = (o_or a_ true) in
-                 a_)))))
+         (fun (_: unit) -> 
+            try
+              (handle_default
+                 {filename = ""; start_line=0; start_column=1;
+                   end_line=0; end_column=1; law_headings=[]}
+                 ([|(fun (_: unit) ->
+                       handle_default
+                         {filename = ""; start_line=0; start_column=1;
+                           end_line=0; end_column=1; law_headings=[]} (
+                         [||]) (fun (_: unit) -> true)
+                         (fun (_: unit) -> (let a_ : bool = false
+                            in
+                            (let a_ : bool = (o_or a_ true) in
+                            a_))))|]) (fun (_: unit) -> false)
+                 (fun (_: unit) -> try (raise EmptyError) with
+                    EmptyError -> (raise (NoValueProvided
+                      {filename = "tests/test_name_resolution/good/let_in2.catala_en";
+                        start_line=5; start_column=18;
+                        end_line=5; end_column=19; law_headings=["Article"]}))))
+            with
+            EmptyError -> (raise (NoValueProvided
+              {filename = "tests/test_name_resolution/good/let_in2.catala_en";
+                start_line=5; start_column=18; end_line=5; end_column=19;
+                law_headings=["Article"]}))))
     with
     EmptyError -> (raise (NoValueProvided
       {filename = "tests/test_name_resolution/good/let_in2.catala_en";

--- a/tests/test_name_resolution/good/toplevel_defs.catala_en
+++ b/tests/test_name_resolution/good/toplevel_defs.catala_en
@@ -112,13 +112,25 @@ let glob2_10 = A {"y": glob1_2 >= 30., "z": 123. * 17.}
 let S2_6 (S2_in_11: S2_in) =
   decl temp_a_13 : any;
   try:
-    decl temp_a_16 : any;
-    let temp_a_16 (__17 : unit) =
-      return glob3_3 ¤44.00 + 100.;
+    decl temp_a_22 : any;
+    let temp_a_22 (__23 : unit) =
+      try:
+        raise EmptyError
+      with EmptyError:
+        raise NoValueProvided;
+    decl temp_a_20 : any;
+    let temp_a_20 (__21 : unit) =
+      return false;
     decl temp_a_14 : any;
     let temp_a_14 (__15 : unit) =
-      return true;
-    temp_a_13 = handle_default [] temp_a_14 temp_a_16
+      decl temp_a_18 : any;
+      let temp_a_18 (__19 : unit) =
+        return glob3_3 ¤44.00 + 100.;
+      decl temp_a_16 : any;
+      let temp_a_16 (__17 : unit) =
+        return true;
+      return handle_default [] temp_a_16 temp_a_18;
+    temp_a_13 = handle_default [temp_a_14] temp_a_20 temp_a_22
   with EmptyError:
     temp_a_13 = dead_value_1;
     raise NoValueProvided;
@@ -126,70 +138,118 @@ let S2_6 (S2_in_11: S2_in) =
   a_12 = temp_a_13;
   return S2 {"a": a_12}
 
-let S3_7 (S3_in_18: S3_in) =
-  decl temp_a_20 : any;
+let S3_7 (S3_in_24: S3_in) =
+  decl temp_a_26 : any;
   try:
-    decl temp_a_23 : any;
-    let temp_a_23 (__24 : unit) =
-      return 50. + glob4_4 ¤44.00 55.;
-    decl temp_a_21 : any;
-    let temp_a_21 (__22 : unit) =
-      return true;
-    temp_a_20 = handle_default [] temp_a_21 temp_a_23
+    decl temp_a_35 : any;
+    let temp_a_35 (__36 : unit) =
+      try:
+        raise EmptyError
+      with EmptyError:
+        raise NoValueProvided;
+    decl temp_a_33 : any;
+    let temp_a_33 (__34 : unit) =
+      return false;
+    decl temp_a_27 : any;
+    let temp_a_27 (__28 : unit) =
+      decl temp_a_31 : any;
+      let temp_a_31 (__32 : unit) =
+        return 50. + glob4_4 ¤44.00 55.;
+      decl temp_a_29 : any;
+      let temp_a_29 (__30 : unit) =
+        return true;
+      return handle_default [] temp_a_29 temp_a_31;
+    temp_a_26 = handle_default [temp_a_27] temp_a_33 temp_a_35
   with EmptyError:
-    temp_a_20 = dead_value_1;
+    temp_a_26 = dead_value_1;
     raise NoValueProvided;
-  decl a_19 : decimal;
-  a_19 = temp_a_20;
-  return S3 {"a": a_19}
+  decl a_25 : decimal;
+  a_25 = temp_a_26;
+  return S3 {"a": a_25}
 
-let S4_8 (S4_in_25: S4_in) =
-  decl temp_a_27 : any;
+let S4_8 (S4_in_37: S4_in) =
+  decl temp_a_39 : any;
   try:
-    decl temp_a_30 : any;
-    let temp_a_30 (__31 : unit) =
-      return glob5_6 + 1.;
-    decl temp_a_28 : any;
-    let temp_a_28 (__29 : unit) =
-      return true;
-    temp_a_27 = handle_default [] temp_a_28 temp_a_30
+    decl temp_a_48 : any;
+    let temp_a_48 (__49 : unit) =
+      try:
+        raise EmptyError
+      with EmptyError:
+        raise NoValueProvided;
+    decl temp_a_46 : any;
+    let temp_a_46 (__47 : unit) =
+      return false;
+    decl temp_a_40 : any;
+    let temp_a_40 (__41 : unit) =
+      decl temp_a_44 : any;
+      let temp_a_44 (__45 : unit) =
+        return glob5_6 + 1.;
+      decl temp_a_42 : any;
+      let temp_a_42 (__43 : unit) =
+        return true;
+      return handle_default [] temp_a_42 temp_a_44;
+    temp_a_39 = handle_default [temp_a_40] temp_a_46 temp_a_48
   with EmptyError:
-    temp_a_27 = dead_value_1;
+    temp_a_39 = dead_value_1;
     raise NoValueProvided;
-  decl a_26 : decimal;
-  a_26 = temp_a_27;
-  return S4 {"a": a_26}
+  decl a_38 : decimal;
+  a_38 = temp_a_39;
+  return S4 {"a": a_38}
 
-let S_9 (S_in_32: S_in) =
-  decl temp_a_40 : any;
+let S_9 (S_in_50: S_in) =
+  decl temp_a_64 : any;
   try:
-    decl temp_a_43 : any;
-    let temp_a_43 (__44 : unit) =
-      return glob1_2 * glob1_2;
-    decl temp_a_41 : any;
-    let temp_a_41 (__42 : unit) =
-      return true;
-    temp_a_40 = handle_default [] temp_a_41 temp_a_43
+    decl temp_a_73 : any;
+    let temp_a_73 (__74 : unit) =
+      try:
+        raise EmptyError
+      with EmptyError:
+        raise NoValueProvided;
+    decl temp_a_71 : any;
+    let temp_a_71 (__72 : unit) =
+      return false;
+    decl temp_a_65 : any;
+    let temp_a_65 (__66 : unit) =
+      decl temp_a_69 : any;
+      let temp_a_69 (__70 : unit) =
+        return glob1_2 * glob1_2;
+      decl temp_a_67 : any;
+      let temp_a_67 (__68 : unit) =
+        return true;
+      return handle_default [] temp_a_67 temp_a_69;
+    temp_a_64 = handle_default [temp_a_65] temp_a_71 temp_a_73
   with EmptyError:
-    temp_a_40 = dead_value_1;
+    temp_a_64 = dead_value_1;
     raise NoValueProvided;
-  decl a_33 : decimal;
-  a_33 = temp_a_40;
-  decl temp_b_35 : any;
+  decl a_51 : decimal;
+  a_51 = temp_a_64;
+  decl temp_b_53 : any;
   try:
-    decl temp_b_38 : any;
-    let temp_b_38 (__39 : unit) =
-      return glob2_10;
-    decl temp_b_36 : any;
-    let temp_b_36 (__37 : unit) =
-      return true;
-    temp_b_35 = handle_default [] temp_b_36 temp_b_38
+    decl temp_b_62 : any;
+    let temp_b_62 (__63 : unit) =
+      try:
+        raise EmptyError
+      with EmptyError:
+        raise NoValueProvided;
+    decl temp_b_60 : any;
+    let temp_b_60 (__61 : unit) =
+      return false;
+    decl temp_b_54 : any;
+    let temp_b_54 (__55 : unit) =
+      decl temp_b_58 : any;
+      let temp_b_58 (__59 : unit) =
+        return glob2_10;
+      decl temp_b_56 : any;
+      let temp_b_56 (__57 : unit) =
+        return true;
+      return handle_default [] temp_b_56 temp_b_58;
+    temp_b_53 = handle_default [temp_b_54] temp_b_60 temp_b_62
   with EmptyError:
-    temp_b_35 = dead_value_1;
+    temp_b_53 = dead_value_1;
     raise NoValueProvided;
-  decl b_34 : A {y: bool; z: decimal};
-  b_34 = temp_b_35;
-  return S {"a": a_33, "b": b_34}
+  decl b_52 : A {y: bool; z: decimal};
+  b_52 = temp_b_53;
+  return S {"a": a_51, "b": b_52}
 ```
 
 ```catala-test-inline
@@ -375,91 +435,176 @@ glob2 = (
 def s2(s2_in:S2In):
     try:
         def temp_a(_:Unit):
-            return (glob3(money_of_cents_string("4400")) +
-                decimal_of_string("100."))
+            try:
+                raise EmptyError
+            except EmptyError:
+                raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
+                                                     start_line=37,
+                                                     start_column=10,
+                                                     end_line=37,
+                                                     end_column=11,
+                                                     law_headings=["Test toplevel function defs"]))
         def temp_a_1(_:Unit):
-            return True
-        temp_a_2 = handle_default(SourcePosition(filename="", start_line=0,
+            return False
+        def temp_a_2(_:Unit):
+            def temp_a_3(_:Unit):
+                return (glob3(money_of_cents_string("4400")) +
+                    decimal_of_string("100."))
+            def temp_a_4(_:Unit):
+                return True
+            return handle_default(SourcePosition(filename="", start_line=0,
                                   start_column=1, end_line=0, end_column=1,
-                                  law_headings=[]), [], temp_a_1, temp_a)
+                                  law_headings=[]), [], temp_a_4, temp_a_3)
+        temp_a_5 = handle_default(SourcePosition(filename="", start_line=0,
+                                  start_column=1, end_line=0, end_column=1,
+                                  law_headings=[]), [temp_a_2], temp_a_1,
+                                  temp_a)
     except EmptyError:
-        temp_a_2 = dead_value
+        temp_a_5 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
                                              start_line=37, start_column=10,
                                              end_line=37, end_column=11,
                                              law_headings=["Test toplevel function defs"]))
-    a = temp_a_2
+    a = temp_a_5
     return S2(a = a)
 
 def s3(s3_in:S3In):
     try:
-        def temp_a_3(_:Unit):
-            return (decimal_of_string("50.") +
-                glob4(money_of_cents_string("4400"),
-                      decimal_of_string("55.")))
-        def temp_a_4(_:Unit):
-            return True
-        temp_a_5 = handle_default(SourcePosition(filename="", start_line=0,
+        def temp_a_6(_:Unit):
+            try:
+                raise EmptyError
+            except EmptyError:
+                raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
+                                                     start_line=57,
+                                                     start_column=10,
+                                                     end_line=57,
+                                                     end_column=11,
+                                                     law_headings=["Test function def with two args"]))
+        def temp_a_7(_:Unit):
+            return False
+        def temp_a_8(_:Unit):
+            def temp_a_9(_:Unit):
+                return (decimal_of_string("50.") +
+                    glob4(money_of_cents_string("4400"),
+                          decimal_of_string("55.")))
+            def temp_a_10(_:Unit):
+                return True
+            return handle_default(SourcePosition(filename="", start_line=0,
                                   start_column=1, end_line=0, end_column=1,
-                                  law_headings=[]), [], temp_a_4, temp_a_3)
+                                  law_headings=[]), [], temp_a_10, temp_a_9)
+        temp_a_11 = handle_default(SourcePosition(filename="", start_line=0,
+                                   start_column=1, end_line=0, end_column=1,
+                                   law_headings=[]), [temp_a_8], temp_a_7,
+                                   temp_a_6)
     except EmptyError:
-        temp_a_5 = dead_value
+        temp_a_11 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
                                              start_line=57, start_column=10,
                                              end_line=57, end_column=11,
                                              law_headings=["Test function def with two args"]))
-    a_1 = temp_a_5
+    a_1 = temp_a_11
     return S3(a = a_1)
 
 def s4(s4_in:S4In):
     try:
-        def temp_a_6(_:Unit):
-            return (glob5_1 + decimal_of_string("1."))
-        def temp_a_7(_:Unit):
-            return True
-        temp_a_8 = handle_default(SourcePosition(filename="", start_line=0,
+        def temp_a_12(_:Unit):
+            try:
+                raise EmptyError
+            except EmptyError:
+                raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
+                                                     start_line=80,
+                                                     start_column=10,
+                                                     end_line=80,
+                                                     end_column=11,
+                                                     law_headings=["Test inline defs in toplevel defs"]))
+        def temp_a_13(_:Unit):
+            return False
+        def temp_a_14(_:Unit):
+            def temp_a_15(_:Unit):
+                return (glob5_1 + decimal_of_string("1."))
+            def temp_a_16(_:Unit):
+                return True
+            return handle_default(SourcePosition(filename="", start_line=0,
                                   start_column=1, end_line=0, end_column=1,
-                                  law_headings=[]), [], temp_a_7, temp_a_6)
+                                  law_headings=[]), [], temp_a_16, temp_a_15)
+        temp_a_17 = handle_default(SourcePosition(filename="", start_line=0,
+                                   start_column=1, end_line=0, end_column=1,
+                                   law_headings=[]), [temp_a_14], temp_a_13,
+                                   temp_a_12)
     except EmptyError:
-        temp_a_8 = dead_value
+        temp_a_17 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
                                              start_line=80, start_column=10,
                                              end_line=80, end_column=11,
                                              law_headings=["Test inline defs in toplevel defs"]))
-    a_2 = temp_a_8
+    a_2 = temp_a_17
     return S4(a = a_2)
 
 def s(s_in:SIn):
     try:
-        def temp_a_9(_:Unit):
-            return (glob1 * glob1)
-        def temp_a_10(_:Unit):
-            return True
-        temp_a_11 = handle_default(SourcePosition(filename="", start_line=0,
+        def temp_a_18(_:Unit):
+            try:
+                raise EmptyError
+            except EmptyError:
+                raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
+                                                     start_line=7,
+                                                     start_column=10,
+                                                     end_line=7,
+                                                     end_column=11,
+                                                     law_headings=["Test basic toplevel values defs"]))
+        def temp_a_19(_:Unit):
+            return False
+        def temp_a_20(_:Unit):
+            def temp_a_21(_:Unit):
+                return (glob1 * glob1)
+            def temp_a_22(_:Unit):
+                return True
+            return handle_default(SourcePosition(filename="", start_line=0,
+                                  start_column=1, end_line=0, end_column=1,
+                                  law_headings=[]), [], temp_a_22, temp_a_21)
+        temp_a_23 = handle_default(SourcePosition(filename="", start_line=0,
                                    start_column=1, end_line=0, end_column=1,
-                                   law_headings=[]), [], temp_a_10, temp_a_9)
+                                   law_headings=[]), [temp_a_20], temp_a_19,
+                                   temp_a_18)
     except EmptyError:
-        temp_a_11 = dead_value
+        temp_a_23 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
                                              start_line=7, start_column=10,
                                              end_line=7, end_column=11,
                                              law_headings=["Test basic toplevel values defs"]))
-    a_3 = temp_a_11
+    a_3 = temp_a_23
     try:
         def temp_b(_:Unit):
-            return glob2
+            try:
+                raise EmptyError
+            except EmptyError:
+                raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
+                                                     start_line=8,
+                                                     start_column=10,
+                                                     end_line=8,
+                                                     end_column=11,
+                                                     law_headings=["Test basic toplevel values defs"]))
         def temp_b_1(_:Unit):
-            return True
-        temp_b_2 = handle_default(SourcePosition(filename="", start_line=0,
+            return False
+        def temp_b_2(_:Unit):
+            def temp_b_3(_:Unit):
+                return glob2
+            def temp_b_4(_:Unit):
+                return True
+            return handle_default(SourcePosition(filename="", start_line=0,
                                   start_column=1, end_line=0, end_column=1,
-                                  law_headings=[]), [], temp_b_1, temp_b)
+                                  law_headings=[]), [], temp_b_4, temp_b_3)
+        temp_b_5 = handle_default(SourcePosition(filename="", start_line=0,
+                                  start_column=1, end_line=0, end_column=1,
+                                  law_headings=[]), [temp_b_2], temp_b_1,
+                                  temp_b)
     except EmptyError:
-        temp_b_2 = dead_value
+        temp_b_5 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
                                              start_line=8, start_column=10,
                                              end_line=8, end_column=11,
                                              law_headings=["Test basic toplevel values defs"]))
-    b = temp_b_2
+    b = temp_b_5
     return S(a = a_3, b = b)
 ```
 ```catala-test-inline

--- a/tests/test_scope/bad/scope_call_extra.catala_en
+++ b/tests/test_scope/bad/scope_call_extra.catala_en
@@ -29,5 +29,9 @@ Scope Toto declared here
 └─┐
 2 │ declaration scope Toto:
   │                   ‾‾‾‾
+
+Maybe you wanted to write : "bar",
+or "baz",
+or "foo"
 #return code 123#
 ```

--- a/tests/test_scope/bad/scope_call_missing.catala_en
+++ b/tests/test_scope/bad/scope_call_missing.catala_en
@@ -11,7 +11,7 @@ scope Toto:
 declaration scope Titi:
   output fizz content Toto
 scope Titi:
-  definition fizz equals output of Toto with {--bar: 1}
+  definition fizz equals output of Toto with {--bar: 1 }
 ```
 
 ```catala-test-inline
@@ -19,10 +19,10 @@ $ catala dcalc -s Titi
 [ERROR]
 Definition of input variable 'baz' missing in this scope call
 
-┌─⯈ tests/test_scope/bad/scope_call_missing.catala_en:14.26-14.56:
+┌─⯈ tests/test_scope/bad/scope_call_missing.catala_en:14.26-14.57:
 └──┐
-14 │   definition fizz equals output of Toto with {--bar: 1}
-   │                          ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+14 │   definition fizz equals output of Toto with {--bar: 1 }
+   │                          ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 
 Declaration of the missing input variable
 ┌─⯈ tests/test_scope/bad/scope_call_missing.catala_en:4.16-4.19:

--- a/tests/test_scope/good/191_fix_record_name_confusion.catala_en
+++ b/tests/test_scope/good/191_fix_record_name_confusion.catala_en
@@ -44,7 +44,13 @@ end
 
 
 let scope_a (scope_a_in: ScopeA_in.t) : ScopeA.t =
-  let a_: bool = try true with
+  let a_: bool = 
+    try
+      (handle_default
+         {filename = ""; start_line=0; start_column=1;
+           end_line=0; end_column=1; law_headings=[]} ([||])
+         (fun (_: unit) -> true) (fun (_: unit) -> true))
+    with
     EmptyError -> (raise (NoValueProvided
       {filename = "tests/test_scope/good/191_fix_record_name_confusion.catala_en";
         start_line=5; start_column=10; end_line=5; end_column=11;
@@ -54,7 +60,13 @@ let scope_a (scope_a_in: ScopeA_in.t) : ScopeA.t =
 let scope_b (scope_b_in: ScopeB_in.t) : ScopeB.t =
   let result_: ScopeA.t = scope_a (()) in
   let scope_a_dot_a_: bool = result_.ScopeA.a in
-  let a_: bool = try scope_a_dot_a_ with
+  let a_: bool = 
+    try
+      (handle_default
+         {filename = ""; start_line=0; start_column=1;
+           end_line=0; end_column=1; law_headings=[]} ([||])
+         (fun (_: unit) -> true) (fun (_: unit) -> scope_a_dot_a_))
+    with
     EmptyError -> (raise (NoValueProvided
       {filename = "tests/test_scope/good/191_fix_record_name_confusion.catala_en";
         start_line=8; start_column=10; end_line=8; end_column=11;

--- a/tests/test_scope/good/scope_call3.catala_en
+++ b/tests/test_scope/good/scope_call3.catala_en
@@ -32,7 +32,7 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
 [DEBUG] Starting interpretation...
-[LOG] ≔  HousingComputation.f: λ (x_90: integer) → error_empty ⟨#{☛ } true ⊢ (let result_91 : RentComputation = (#{→ RentComputation.direct} (λ (RentComputation_in_92: RentComputation_in) → let g_93 : integer → integer = #{≔ RentComputation.g} (λ (x1_94: integer) → error_empty ⟨#{☛ } true ⊢ x1_94 +! 1⟩) in let f_95 : integer → integer = #{≔ RentComputation.f} (λ (x1_96: integer) → error_empty ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} g_93) #{≔ RentComputation.g.input0} (x1_96 +! 1)⟩) in { RentComputation f = f_95; })) #{≔ RentComputation.direct.input} {RentComputation_in} in let result1_97 : RentComputation = { RentComputation f = λ (param0_98: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} result_91.f) #{≔ RentComputation.f.input0} param0_98; } in #{← RentComputation.direct} #{≔ RentComputation.direct.output} if #{☛ RentComputation.direct.output} true then result1_97 else result1_97).f x_90⟩
+[LOG] ≔  HousingComputation.f: λ (x_90: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ (let result_91 : RentComputation = (#{→ RentComputation.direct} (λ (RentComputation_in_92: RentComputation_in) → let g_93 : integer → integer = #{≔ RentComputation.g} (λ (x1_94: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ x1_94 +! 1⟩ | false ⊢ error_empty ∅ ⟩) in let f_95 : integer → integer = #{≔ RentComputation.f} (λ (x1_96: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} g_93) #{≔ RentComputation.g.input0} (x1_96 +! 1)⟩ | false ⊢ error_empty ∅ ⟩) in { RentComputation f = f_95; })) #{≔ RentComputation.direct.input} {RentComputation_in} in let result1_97 : RentComputation = { RentComputation f = λ (param0_98: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} result_91.f) #{≔ RentComputation.f.input0} param0_98; } in #{← RentComputation.direct} #{≔ RentComputation.direct.output} if #{☛ RentComputation.direct.output} true then result1_97 else result1_97).f x_90⟩ | false ⊢ error_empty ∅ ⟩
 [LOG] ☛ Definition applied:
       ┌─⯈ tests/test_scope/good/scope_call3.catala_en:8.14-8.20:
       └─┐
@@ -47,14 +47,14 @@ $ catala Interpret -t -s HousingComputation --debug
           │              ‾
 [LOG]   →  RentComputation.direct
 [LOG]     ≔  RentComputation.direct.input: {RentComputation_in}
-[LOG]     ≔  RentComputation.g: λ (x_99: integer) → error_empty ⟨#{☛ } true ⊢ x_99 +! 1⟩
-[LOG]     ≔  RentComputation.f: λ (x_100: integer) → error_empty ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_101: integer) → error_empty ⟨#{☛ } true ⊢ x1_101 +! 1⟩)) #{≔ RentComputation.g.input0} (x_100 +! 1)⟩
+[LOG]     ≔  RentComputation.g: λ (x_99: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ x_99 +! 1⟩ | false ⊢ error_empty ∅ ⟩
+[LOG]     ≔  RentComputation.f: λ (x_100: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_101: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ x1_101 +! 1⟩ | false ⊢ error_empty ∅ ⟩)) #{≔ RentComputation.g.input0} (x_100 +! 1)⟩ | false ⊢ error_empty ∅ ⟩
 [LOG]     ☛ Definition applied:
           ┌─⯈ tests/test_scope/good/scope_call3.catala_en:7.29-7.54:
           └─┐
           7 │   definition f of x equals (output of RentComputation).f of x
             │                             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-[LOG]     ≔  RentComputation.direct.output: { RentComputation f = λ (param0_102: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} { RentComputation f = λ (x_103: integer) → error_empty ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_104: integer) → error_empty ⟨#{☛ } true ⊢ x1_104 +! 1⟩)) #{≔ RentComputation.g.input0} (x_103 +! 1)⟩; }.f) #{≔ RentComputation.f.input0} param0_102; }
+[LOG]     ≔  RentComputation.direct.output: { RentComputation f = λ (param0_102: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} { RentComputation f = λ (x_103: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ #{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_104: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ x1_104 +! 1⟩ | false ⊢ error_empty ∅ ⟩)) #{≔ RentComputation.g.input0} (x_103 +! 1)⟩ | false ⊢ error_empty ∅ ⟩; }.f) #{≔ RentComputation.f.input0} param0_102; }
 [LOG]   ←  RentComputation.direct
 [LOG]   →  RentComputation.f
 [LOG]     ≔  RentComputation.f.input0: 1
@@ -82,25 +82,26 @@ $ catala Interpret -t -s HousingComputation --debug
 [RESULT]
 f = λ (x: integer) →
   error_empty
-    ⟨true
-     ⊢ (let result : RentComputation =
-          (λ (RentComputation_in: RentComputation_in) →
-           let g : integer → integer =
-             λ (x1: integer) →
-             error_empty ⟨true ⊢ x1 + 1⟩
-           in
-           let f : integer → integer =
-             λ (x1: integer) →
-             error_empty ⟨true ⊢ g (x1 + 1)⟩
-           in
-           { RentComputation f = f; })
-            {RentComputation_in}
-        in
-        let result1 : RentComputation =
-          { RentComputation f = λ (param0: integer) → result.f param0; }
-        in
-        if true then result1 else result1).
-         f
-         x⟩
+    ⟨ ⟨true
+       ⊢ (let result : RentComputation =
+            (λ (RentComputation_in: RentComputation_in) →
+             let g : integer → integer =
+               λ (x1: integer) →
+               error_empty ⟨ ⟨true ⊢ x1 + 1⟩ | false ⊢ error_empty ∅ ⟩
+             in
+             let f : integer → integer =
+               λ (x1: integer) →
+               error_empty ⟨ ⟨true ⊢ g (x1 + 1)⟩ | false ⊢ error_empty ∅ ⟩
+             in
+             { RentComputation f = f; })
+              {RentComputation_in}
+          in
+          let result1 : RentComputation =
+            { RentComputation f = λ (param0: integer) → result.f param0; }
+          in
+          if true then result1 else result1).
+           f
+           x⟩
+    | false ⊢ error_empty ∅ ⟩
 [RESULT] result = 3
 ```

--- a/tests/test_scope/good/scope_call4.catala_en
+++ b/tests/test_scope/good/scope_call4.catala_en
@@ -42,12 +42,18 @@ $ catala Interpret -s RentComputation --debug
 [RESULT] Computation successful! Results:
 [RESULT]
 f1 = λ (x: integer) →
-  error_empty ⟨true ⊢ let x1 : integer = x + 1 in
-                      error_empty ⟨true ⊢ x1 + 1⟩⟩
+  error_empty
+    ⟨ ⟨true
+       ⊢ let x1 : integer = x + 1 in
+         error_empty ⟨ ⟨true ⊢ x1 + 1⟩ | false ⊢ error_empty ∅ ⟩⟩
+    | false ⊢ error_empty ∅ ⟩
 [RESULT]
 f2 = λ (x: integer) →
-  error_empty ⟨true ⊢ let x1 : integer = x + 1 in
-                      error_empty ⟨true ⊢ x1 + 1⟩⟩
+  error_empty
+    ⟨ ⟨true
+       ⊢ let x1 : integer = x + 1 in
+         error_empty ⟨ ⟨true ⊢ x1 + 1⟩ | false ⊢ error_empty ∅ ⟩⟩
+    | false ⊢ error_empty ∅ ⟩
 ```
 
 ```catala-test-inline
@@ -77,9 +83,25 @@ f1 =
     (λ (x: integer) →
      ESome
        match
-         (match (ESome (λ (x1: integer) → ESome (x1 + 1))) with
-          | ENone _ → ENone _
-          | ESome g → g (x + 1))
+         (handle_default_opt
+            [  ]
+            (λ (_: unit) → ESome true)
+            (λ (_: unit) →
+             match
+               (ESome
+                  (λ (x1: integer) →
+                   ESome
+                     match
+                       (handle_default_opt
+                          [  ]
+                          (λ (_1: unit) → ESome true)
+                          (λ (_1: unit) → ESome (x1 + 1)))
+                       with
+                     | ENone _1 → raise NoValueProvided
+                     | ESome g → g))
+               with
+             | ENone _1 → ENone _1
+             | ESome g → g (x + 1)))
          with
        | ENone _ → raise NoValueProvided
        | ESome f1 → f1)
@@ -89,9 +111,25 @@ f2 =
     (λ (x: integer) →
      ESome
        match
-         (match (ESome (λ (x1: integer) → ESome (x1 + 1))) with
-          | ENone _ → ENone _
-          | ESome g → g (x + 1))
+         (handle_default_opt
+            [  ]
+            (λ (_: unit) → ESome true)
+            (λ (_: unit) →
+             match
+               (ESome
+                  (λ (x1: integer) →
+                   ESome
+                     match
+                       (handle_default_opt
+                          [  ]
+                          (λ (_1: unit) → ESome true)
+                          (λ (_1: unit) → ESome (x1 + 1)))
+                       with
+                     | ENone _1 → raise NoValueProvided
+                     | ESome g → g))
+               with
+             | ENone _1 → ENone _1
+             | ESome g → g (x + 1)))
          with
        | ENone _ → raise NoValueProvided
        | ESome f2 → f2)

--- a/tests/test_scope/good/simple.catala_en
+++ b/tests/test_scope/good/simple.catala_en
@@ -12,7 +12,13 @@ scope Foo:
 $ catala Lcalc -s Foo
 let scope Foo (Foo_in: Foo_in): Foo {bar: integer} =
   let set bar : integer =
-    try handle_default [  ] (λ (_: unit) → true) (λ (_: unit) → 0)
+    try
+      handle_default
+        [ λ (_: unit) →
+          handle_default [  ] (λ (_1: unit) → true) (λ (_1: unit) → 0) ]
+        (λ (_: unit) → false)
+        (λ (_: unit) →
+         try raise EmptyError with EmptyError -> raise NoValueProvided)
     with EmptyError -> raise NoValueProvided
   in
   return { Foo bar = bar; }

--- a/tests/test_typing/bad/err1.catala_en
+++ b/tests/test_typing/bad/err1.catala_en
@@ -17,19 +17,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ decimal
 └─⯈ integer
 
-Error coming from typechecking the following expression:
+This expression has type decimal:
 ┌─⯈ tests/test_typing/bad/err1.catala_en:7.23-7.26:
 └─┐
 7 │     Structure { -- i: 4.1 -- e: y };
   │                       ‾‾‾
 
-Type decimal coming from expression:
-┌─⯈ tests/test_typing/bad/err1.catala_en:7.23-7.26:
-└─┐
-7 │     Structure { -- i: 4.1 -- e: y };
-  │                       ‾‾‾
-
-Type integer coming from expression:
+Expected type integer coming from expression:
 ┌─⯈ tests/test_typing/bad/common.catala_en:8.18-8.25:
 └─┐
 8 │   data i content integer

--- a/tests/test_typing/bad/err2.catala_en
+++ b/tests/test_typing/bad/err2.catala_en
@@ -17,19 +17,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ decimal
 └─⯈ collection
 
-Error coming from typechecking the following expression:
+This expression has type decimal:
 ┌─⯈ tests/test_typing/bad/err2.catala_en:10.39-10.42:
 └──┐
 10 │   definition a equals number of (z ++ 1.1) / 2
    │                                       ‾‾‾
 
-Type decimal coming from expression:
-┌─⯈ tests/test_typing/bad/err2.catala_en:10.39-10.42:
-└──┐
-10 │   definition a equals number of (z ++ 1.1) / 2
-   │                                       ‾‾‾
-
-Type collection coming from expression:
+Expected type collection coming from expression:
 ┌─⯈ tests/test_typing/bad/err2.catala_en:10.36-10.38:
 └──┐
 10 │   definition a equals number of (z ++ 1.1) / 2

--- a/tests/test_typing/bad/err3.catala_en
+++ b/tests/test_typing/bad/err3.catala_en
@@ -23,19 +23,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ integer
 └─⯈ decimal
 
-Error coming from typechecking the following expression:
+This expression has type integer:
 ┌─⯈ tests/test_typing/bad/err3.catala_en:10.42-10.43:
 └──┐
 10 │   definition a equals number of (z ++ z) * 2
    │                                          ‾
 
-Type integer coming from expression:
-┌─⯈ tests/test_typing/bad/err3.catala_en:10.42-10.43:
-└──┐
-10 │   definition a equals number of (z ++ z) * 2
-   │                                          ‾
-
-Type decimal coming from expression:
+Expected type decimal coming from expression:
 ┌─⯈ tests/test_typing/bad/common.catala_en:15.20-15.27:
 └──┐
 15 │   output a content decimal
@@ -58,19 +52,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ integer
 └─⯈ decimal
 
-Error coming from typechecking the following expression:
+This expression has type integer:
 ┌─⯈ tests/test_typing/bad/err3.catala_en:10.42-10.43:
 └──┐
 10 │   definition a equals number of (z ++ z) * 2
    │                                          ‾
 
-Type integer coming from expression:
-┌─⯈ tests/test_typing/bad/err3.catala_en:10.42-10.43:
-└──┐
-10 │   definition a equals number of (z ++ z) * 2
-   │                                          ‾
-
-Type decimal coming from expression:
+Expected type decimal coming from expression:
 ┌─⯈ tests/test_typing/bad/common.catala_en:15.20-15.27:
 └──┐
 15 │   output a content decimal

--- a/tests/test_typing/bad/err4.catala_en
+++ b/tests/test_typing/bad/err4.catala_en
@@ -33,19 +33,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ Enum
 └─⯈ Structure
 
-Error coming from typechecking the following expression:
+This expression has type Enum:
 ┌─⯈ tests/test_typing/bad/err4.catala_en:5.25-5.38:
 └─┐
 5 │   definition z equals [ Int content x ]
   │                         ‾‾‾‾‾‾‾‾‾‾‾‾‾
 
-Type Enum coming from expression:
-┌─⯈ tests/test_typing/bad/err4.catala_en:5.25-5.38:
-└─┐
-5 │   definition z equals [ Int content x ]
-  │                         ‾‾‾‾‾‾‾‾‾‾‾‾‾
-
-Type Structure coming from expression:
+Expected type Structure coming from expression:
 ┌─⯈ tests/test_typing/bad/common.catala_en:14.31-14.40:
 └──┐
 14 │   output z content collection Structure

--- a/tests/test_typing/bad/err5.catala_en
+++ b/tests/test_typing/bad/err5.catala_en
@@ -17,19 +17,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ integer
 └─⯈ Structure
 
-Error coming from typechecking the following expression:
+This expression has type integer:
 ┌─⯈ tests/test_typing/bad/err5.catala_en:8.5-8.9:
 └─┐
 8 │     1040
   │     ‾‾‾‾
 
-Type integer coming from expression:
-┌─⯈ tests/test_typing/bad/err5.catala_en:8.5-8.9:
-└─┐
-8 │     1040
-  │     ‾‾‾‾
-
-Type Structure coming from expression:
+Expected type Structure coming from expression:
 ┌─⯈ tests/test_typing/bad/err5.catala_en:6.5-6.46:
 └─┐
 6 │     Structure { -- i: 3 -- e: Int content x };

--- a/tests/test_typing/bad/err6.catala_en
+++ b/tests/test_typing/bad/err6.catala_en
@@ -33,19 +33,13 @@ Error during typechecking, incompatible types:
 ┌─⯈ decimal
 └─⯈ integer
 
-Error coming from typechecking the following expression:
+This expression has type decimal:
 ┌─⯈ tests/test_typing/bad/err6.catala_en:20.27-20.30:
 └──┐
 20 │   definition sub.x equals 44.
    │                           ‾‾‾
 
-Type decimal coming from expression:
-┌─⯈ tests/test_typing/bad/err6.catala_en:20.27-20.30:
-└──┐
-20 │   definition sub.x equals 44.
-   │                           ‾‾‾
-
-Type integer coming from expression:
+Expected type integer coming from expression:
 ┌─⯈ tests/test_typing/bad/common.catala_en:12.19-12.26:
 └──┐
 12 │   input x content integer

--- a/tests/test_variable_state/good/subscope.catala_en
+++ b/tests/test_variable_state/good/subscope.catala_en
@@ -32,11 +32,14 @@ scope B:
 
 ```catala-test-inline
 $ catala Scopelang -s A
-let scope A (foo_bar: integer|context) (foo_baz: integer|internal)
+let scope A (foo_bar: ⟨integer⟩|context) (foo_baz: integer|internal)
   (foo_fizz: integer|internal|output) =
-  let foo_bar : integer = reentrant or by default ⟨true ⊢ 1⟩;
-  let foo_baz : integer = ⟨true ⊢ foo_bar + 1⟩;
-  let foo_fizz : integer = ⟨true ⊢ foo_baz + 1⟩
+  let foo_bar : integer = reentrant or by default
+    error_empty ⟨ ⟨true ⊢ 1⟩ | false ⊢ error_empty ∅ ⟩;
+  let foo_baz : integer =
+    error_empty ⟨ ⟨true ⊢ foo_bar + 1⟩ | false ⊢ error_empty ∅ ⟩;
+  let foo_fizz : integer =
+    error_empty ⟨ ⟨true ⊢ foo_baz + 1⟩ | false ⊢ error_empty ∅ ⟩
 ```
 
 ```catala-test-inline


### PR DESCRIPTION
This reinforces the internal typing discipline by treating the output of default
terms (which could be ∅) differently from raw terms.

Most of the changes are to adjust the actual compiler passes to adhere to the
new type discipline. In particular, as of `scopelang` the input and output types
of a given scope variable may be different (a reentrant variable would require
`'a default` input, but be accessed as `'a`).

In addition to adding more guarantees to the correctness of the compiler
passes (we now have strong assurance that `error_empty` calls are in the right
places, since they do type translation), I expect this to be extremely helpful
in simplifying the with/without exceptions backends.


Note: the git history should be cleaned up before merging.