### PR TITLE
Unify rounding operations in OCaml runtime

### DIFF
--- a/examples/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
+++ b/examples/aides_logement/tests/tests_calcul_apl_accession_propriete.catala_fr
@@ -33,7 +33,7 @@ champ d'application Exemple1:
     calcul.aide_finale_formule
   assertion montant = 181,91 €
   assertion calcul.mensualité_éligible = 533,91 €
-  assertion calcul.mensualité_minimale = 332,75 €
+  assertion calcul.mensualité_minimale = 332,76 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,67
   assertion calcul.aide_finale_formule = 187,35€
 ```
@@ -107,7 +107,7 @@ champ d'application Exemple3:
     calcul.aide_finale_formule
   assertion montant = 181,91 €
   assertion calcul.mensualité_éligible = 533,91 €
-  assertion calcul.mensualité_minimale = 332,75 €
+  assertion calcul.mensualité_minimale = 332,76 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,67
   assertion calcul.aide_finale_formule = 187,57€
 ```
@@ -142,9 +142,9 @@ champ d'application Exemple4:
     calcul.aide_finale_formule
   assertion montant = 118,59 €
   assertion calcul.mensualité_éligible = 399,20 €
-  assertion calcul.mensualité_minimale = 290,20 €
+  assertion calcul.mensualité_minimale = 290,21 €
   assertion calcul.coefficient_prise_en_charge_d832_10 = 0,66
-  assertion calcul.aide_finale_formule = 123,95 €
+  assertion calcul.aide_finale_formule = 123,94 €
 ```
 
 ```catala-test-inline

--- a/examples/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
+++ b/examples/aides_logement/tests/tests_calcul_apl_logement_foyer.catala_fr
@@ -23,7 +23,7 @@ champ d'application CasTest1:
   assertion calcul.n_nombre_parts_d832_25 = 1,8
   assertion calcul.coefficient_prise_en_charge_d832_25 = 0,41
   assertion calcul.plafond_équivalence_loyer_éligible = 450,57 €
-  assertion calcul.équivalence_loyer_minimale = 318,12 €
+  assertion calcul.équivalence_loyer_minimale = 318,13 €
   définition montant égal à calcul.traitement_aide_finale de calcul.aide_finale_formule
   assertion montant = 12,06 €
 
@@ -46,7 +46,7 @@ champ d'application CasTest2:
     PersonnesÂgéesSelon3DeD842_16
   assertion calcul.équivalence_loyer = 320,73 €
   assertion calcul.montant_forfaitaire_charges = 54,22 €
-  assertion calcul.loyer_minimal = 307,96 €
+  assertion calcul.loyer_minimal = 307,97 €
   assertion calcul.coefficient_prise_en_charge = 0,43
   définition montant égal à
     calcul.traitement_aide_finale de

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -239,19 +239,29 @@ val pp_events : ?is_first_call:bool -> Format.formatter -> event list -> unit
 
 (**{1 Constructors and conversions} *)
 
+(**{2 Rounding}*)
+
+val round : Q.t -> Z.t
+(** This helper function rounds a rational to the nearest integer. Tie-breaker
+    is the "half away from zero" rule: [0.5] is rounded to [1.0] and [-0.5] is
+    rounded to [-1.0]. This function shall be used anytime rounding is
+    necessary. *)
+
 (**{2 Money}*)
 
 val money_of_cents_string : string -> money
 val money_of_units_int : int -> money
 
 val money_of_decimal : decimal -> money
-(** Warning: rounds to nearest cent. *)
+(** Warning: rounds to nearest cent, using {!val:round}. *)
 
 val money_of_cents_integer : integer -> money
 val money_to_float : money -> float
 val money_to_string : money -> string
 val money_to_cents : money -> integer
+
 val money_round : money -> money
+(** Rounds to the nearest currency unit using {!val:round}. *)
 
 (** {2 Decimals} *)
 
@@ -260,7 +270,10 @@ val decimal_to_string : max_prec_digits:int -> decimal -> string
 val decimal_of_integer : integer -> decimal
 val decimal_of_float : float -> decimal
 val decimal_to_float : decimal -> float
+
 val decimal_round : decimal -> decimal
+(** Rounds to the nearest integer using {!val:round}. *)
+
 val decimal_of_money : money -> decimal
 
 (**{2 Integers} *)

--- a/tests/test_arithmetic/good/rounding.catala_en
+++ b/tests/test_arithmetic/good/rounding.catala_en
@@ -1,0 +1,64 @@
+```catala
+declaration scope A:
+  output o condition
+
+scope A:
+  assertion (money of -0.015 = -$$0.02)
+  assertion (money of -0.011 = -$$0.01)
+  assertion (money of -0.005 = -$$0.01)
+  assertion (money of -0.001 = $0.00)
+  assertion (money of 0.000 = $0.00)
+  assertion (money of 0.001 = $0.00)
+  assertion (money of 0.005 = $0.01)
+  assertion (money of 0.011 = $0.01)
+  assertion (money of 0.015 = $0.02)
+
+  assertion (-0.015 * $1 = -$$0.02)
+  assertion (-0.011 * $1 = -$$0.01)
+  assertion (-0.005 * $1 = -$$0.01)
+  assertion (-0.001 * $1 = $0.00)
+  assertion (0.000 * $1 = $0.00)
+  assertion (0.001 * $1 = $0.00)
+  assertion (0.005 * $1 = $0.01)
+  assertion (0.011 * $1 = $0.01)
+  assertion (0.015 * $1 = $0.02)
+
+  assertion (round of (-$$1.5) = -$$2)
+  assertion (round of (-$$1.1) = -$$1)
+  assertion (round of (-$$0.5) = -$$1)
+  assertion (round of (-$$0.1) = $0)
+  assertion (round of $0.0 = $0)
+  assertion (round of $0.1 = $0)
+  assertion (round of $0.5 = $1)
+  assertion (round of $1.1 = $1)
+  assertion (round of $1.5 = $2)
+
+  assertion (round of (-1.5) = -2.)
+  assertion (round of (-1.1) = -1.)
+  assertion (round of (-0.5) = -1.)
+  assertion (round of (-0.1) = 0.)
+  assertion (round of 0.0 = 0.)
+  assertion (round of 0.1 = 0.)
+  assertion (round of 0.5 = 1.)
+  assertion (round of 1.1 = 1.)
+  assertion (round of 1.5 = 2.)
+```
+
+```catala-test-inline
+$ catala Interpret -s A
+[RESULT] Computation successful! Results:
+[RESULT] o = false
+```
+
+```catala-test-inline
+$ catala Interpret -s A
+[RESULT] Computation successful! Results:
+[RESULT] o = false
+```
+
+```catala-test-inline
+$ catala Interpret_Lcalc -s A
+[RESULT] Computation successful! Results:
+[RESULT] o = false
+```
+


### PR DESCRIPTION
4 operations in the OCaml runtime implemented different rounding schemes. This PR adds a unique `round` function to round rationals to bigints the way that it was originally intended. `round` rounds rationals to the nearest bigint. On ties, the "half away from zero" rule is used. For example, `0.5` is rounded to `1.0` and `-0.5` is rounded to `-1.0`.

This function is documented, the 4 operations that use rounding are updated to use it, and their documentations explicitly refer to it. Moreover, a new test `tests/test_arithmetic/good/rounding.catala_en` shows the intended behaviour on key examples.

This PR does not change unit tests. However, some assertions in examples (`examples/aides_logement`) break. I have not updated them because as I understand it they come from official guides, so I think they should be checked more carefully before fixing.
