### PR TITLE
Support for list recombinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,13 +243,6 @@ all: \
 clean:
 	dune clean
 	rm -rf artifacts
-	$(MAKE) -C $(AIDES_LOGEMENT_DIR) clean
-	$(MAKE) -C $(ALLOCATIONS_FAMILIALES_DIR) clean
-	$(MAKE) -C $(US_TAX_CODE_DIR) clean
-	$(MAKE) -C $(TUTORIEL_FR_DIR) clean
-	$(MAKE) -C $(TUTORIAL_EN_DIR) clean
-	$(MAKE) -C $(POLISH_TAXES_DIR) clean
-	$(MAKE) -C $(CODE_GENERAL_IMPOTS_DIR) clean
 
 inspect:
 	gitinspector -f ml,mli,mly,iro,tex,catala,catala_en,catala_pl,catala_fr,md,fst,mld --grading

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -84,6 +84,7 @@ let format_op (fmt : Format.formatter) (op : operator Mark.pos) : unit =
   | Eq_int_int | Eq_rat_rat | Eq_mon_mon | Eq_dat_dat | Eq_dur_dur ->
     Format.pp_print_string fmt "=="
   | Map -> Format.pp_print_string fmt "list_map"
+  | Map2 -> Format.pp_print_string fmt "list_map2"
   | Reduce -> Format.pp_print_string fmt "list_reduce"
   | Filter -> Format.pp_print_string fmt "list_filter"
   | Fold -> Format.pp_print_string fmt "list_fold_left"

--- a/compiler/scalc/to_r.ml
+++ b/compiler/scalc/to_r.ml
@@ -99,6 +99,7 @@ let format_op (fmt : Format.formatter) (op : operator Mark.pos) : unit =
   | Eq_int_int | Eq_rat_rat | Eq_mon_mon | Eq_dat_dat | Eq_dur_dur ->
     Format.pp_print_string fmt "=="
   | Map -> Format.pp_print_string fmt "catala_list_map"
+  | Map2 -> Format.pp_print_string fmt "catala_list_map2"
   | Reduce -> Format.pp_print_string fmt "catala_list_reduce"
   | Filter -> Format.pp_print_string fmt "catala_list_filter"
   | Fold -> Format.pp_print_string fmt "catala_list_fold_left"

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -314,6 +314,7 @@ module Op = struct
     (* * polymorphic *)
     | Eq : < polymorphic ; .. > t
     | Map : < polymorphic ; .. > t
+    | Map2 : < polymorphic ; .. > t
     | Concat : < polymorphic ; .. > t
     | Filter : < polymorphic ; .. > t
     (* * overloaded *)

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -198,6 +198,14 @@ let rec evaluate_operator
              (Mark.copy e'
                 (EApp { f; args = [e']; tys = [Expr.maybe_ty (Mark.get e')] })))
          es)
+  | Map2, [f; (EArray es1, _); (EArray es2, _)] ->
+    EArray
+      (List.map2
+         (fun e1 e2 ->
+           evaluate_expr
+             (Mark.add m
+                (EApp { f; args = [e1; e2]; tys = [Expr.maybe_ty (Mark.get e1); Expr.maybe_ty (Mark.get e2)] })))
+         es1 es2)
   | Reduce, [_; default; (EArray [], _)] -> Mark.remove default
   | Reduce, [f; _; (EArray (x0 :: xn), _)] ->
     Mark.remove
@@ -249,7 +257,7 @@ let rec evaluate_operator
                        ];
                    })))
          init es)
-  | (Length | Log _ | Eq | Map | Concat | Filter | Fold | Reduce), _ -> err ()
+  | (Length | Log _ | Eq | Map | Map2 | Concat | Filter | Fold | Reduce), _ -> err ()
   | Not, [(ELit (LBool b), _)] -> ELit (LBool (o_not b))
   | GetDay, [(ELit (LDate d), _)] -> ELit (LInt (o_getDay d))
   | GetMonth, [(ELit (LDate d), _)] -> ELit (LInt (o_getMonth d))

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -204,7 +204,15 @@ let rec evaluate_operator
          (fun e1 e2 ->
            evaluate_expr
              (Mark.add m
-                (EApp { f; args = [e1; e2]; tys = [Expr.maybe_ty (Mark.get e1); Expr.maybe_ty (Mark.get e2)] })))
+                (EApp
+                   {
+                     f;
+                     args = [e1; e2];
+                     tys =
+                       [
+                         Expr.maybe_ty (Mark.get e1); Expr.maybe_ty (Mark.get e2);
+                       ];
+                   })))
          es1 es2)
   | Reduce, [_; default; (EArray [], _)] -> Mark.remove default
   | Reduce, [f; _; (EArray (x0 :: xn), _)] ->
@@ -257,7 +265,8 @@ let rec evaluate_operator
                        ];
                    })))
          init es)
-  | (Length | Log _ | Eq | Map | Map2 | Concat | Filter | Fold | Reduce), _ -> err ()
+  | (Length | Log _ | Eq | Map | Map2 | Concat | Filter | Fold | Reduce), _ ->
+    err ()
   | Not, [(ELit (LBool b), _)] -> ELit (LBool (o_not b))
   | GetDay, [(ELit (LDate d), _)] -> ELit (LInt (o_getDay d))
   | GetMonth, [(ELit (LDate d), _)] -> ELit (LInt (o_getMonth d))

--- a/compiler/shared_ast/operator.ml
+++ b/compiler/shared_ast/operator.ml
@@ -45,6 +45,7 @@ let name : type a. a t -> string = function
   | Xor -> "o_xor"
   | Eq -> "o_eq"
   | Map -> "o_map"
+  | Map2 -> "o_map2"
   | Concat -> "o_concat"
   | Filter -> "o_filter"
   | Reduce -> "o_reduce"
@@ -174,6 +175,7 @@ let compare (type a1 a2) (t1 : a1 t) (t2 : a2 t) =
   | Xor, Xor
   | Eq, Eq
   | Map, Map
+  | Map2, Map2
   | Concat, Concat
   | Filter, Filter
   | Reduce, Reduce
@@ -259,6 +261,7 @@ let compare (type a1 a2) (t1 : a1 t) (t2 : a2 t) =
   | Xor, _ -> -1 | _, Xor -> 1
   | Eq, _ -> -1 | _, Eq -> 1
   | Map, _ -> -1 | _, Map -> 1
+  | Map2, _ -> -1 | _, Map2 -> 1
   | Concat, _ -> -1 | _, Concat -> 1
   | Filter, _ -> -1 | _, Filter -> 1
   | Reduce, _ -> -1 | _, Reduce -> 1
@@ -339,7 +342,7 @@ let kind_dispatch :
   | ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth | And
     | Or | Xor ) as op ->
     monomorphic op
-  | ( Log _ | Length | Eq | Map | Concat | Filter | Reduce | Fold
+  | ( Log _ | Length | Eq | Map | Map2 | Concat | Filter | Reduce | Fold
     | HandleDefault | HandleDefaultOpt | FromClosureEnv | ToClosureEnv ) as op
     ->
     polymorphic op
@@ -371,7 +374,7 @@ type 'a no_overloads =
 let translate (t : 'a no_overloads t) : 'b no_overloads t =
   match t with
   | ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth | And
-    | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq | Map
+    | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq | Map | Map2
     | Concat | Filter | Reduce | Fold | Minus_int | Minus_rat | Minus_mon
     | Minus_dur | ToRat_int | ToRat_mon | ToMoney_rat | Round_rat | Round_mon
     | Add_int_int | Add_rat_rat | Add_mon_mon | Add_dat_dur _ | Add_dur_dur

--- a/compiler/shared_ast/operator.ml
+++ b/compiler/shared_ast/operator.ml
@@ -374,8 +374,8 @@ type 'a no_overloads =
 let translate (t : 'a no_overloads t) : 'b no_overloads t =
   match t with
   | ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth | And
-    | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq | Map | Map2
-    | Concat | Filter | Reduce | Fold | Minus_int | Minus_rat | Minus_mon
+    | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq | Map
+    | Map2 | Concat | Filter | Reduce | Fold | Minus_int | Minus_rat | Minus_mon
     | Minus_dur | ToRat_int | ToRat_mon | ToMoney_rat | Round_rat | Round_mon
     | Add_int_int | Add_rat_rat | Add_mon_mon | Add_dat_dur _ | Add_dur_dur
     | Sub_int_int | Sub_rat_rat | Sub_mon_mon | Sub_dat_dat | Sub_dat_dur

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -222,6 +222,7 @@ let operator_to_string : type a. a Op.t -> string =
   | Xor -> "xor"
   | Eq -> "="
   | Map -> "map"
+  | Map2 -> "map2"
   | Reduce -> "reduce"
   | Concat -> "++"
   | Filter -> "filter"
@@ -306,6 +307,7 @@ let operator_to_shorter_string : type a. a Op.t -> string =
   | Xor -> "xor"
   | Eq_int_int | Eq_rat_rat | Eq_mon_mon | Eq_dur_dur | Eq_dat_dat | Eq -> "="
   | Map -> "map"
+  | Map2 -> "map2"
   | Reduce -> "reduce"
   | Concat -> "++"
   | Filter -> "filter"
@@ -407,7 +409,7 @@ module Precedence = struct
       | Div | Div_int_int | Div_rat_rat | Div_mon_rat | Div_mon_mon
       | Div_dur_dur ->
         Op Div
-      | HandleDefault | HandleDefaultOpt | Map | Concat | Filter | Reduce | Fold
+      | HandleDefault | HandleDefaultOpt | Map | Map2 | Concat | Filter | Reduce | Fold
       | ToClosureEnv | FromClosureEnv ->
         App)
     | EApp _ -> App

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -409,8 +409,8 @@ module Precedence = struct
       | Div | Div_int_int | Div_rat_rat | Div_mon_rat | Div_mon_mon
       | Div_dur_dur ->
         Op Div
-      | HandleDefault | HandleDefaultOpt | Map | Map2 | Concat | Filter | Reduce | Fold
-      | ToClosureEnv | FromClosureEnv ->
+      | HandleDefault | HandleDefaultOpt | Map | Map2 | Concat | Filter | Reduce
+      | Fold | ToClosureEnv | FromClosureEnv ->
         App)
     | EApp _ -> App
     | EArray _ -> Contained
@@ -1090,10 +1090,16 @@ module UserFacing = struct
        ppf e ->
     match Mark.remove e with
     | ELit l -> lit lang ppf l
-    | EArray l | ETuple l ->
+    | EArray l ->
       Format.fprintf ppf "@[<hv 2>[@,@[<hov>%a@]@;<0 -2>]@]"
         (Format.pp_print_list
            ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
+           (value ~fallback lang))
+        l
+    | ETuple l ->
+      Format.fprintf ppf "@[<hv 2>(@,@[<hov>%a@]@;<0 -2>)@]"
+        (Format.pp_print_list
+           ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
            (value ~fallback lang))
         l
     | EStruct { name; fields } ->

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -755,9 +755,9 @@ and typecheck_expr_top_down :
   | A.EAbs { binder; tys = t_args } ->
     if Bindlib.mbinder_arity binder <> List.length t_args then
       Message.raise_spanned_error (Expr.pos e)
-        "function has %d variables but was supplied %d types"
+        "function has %d variables but was supplied %d types\n%a"
         (Bindlib.mbinder_arity binder)
-        (List.length t_args)
+        (List.length t_args) Expr.format e
     else
       let tau_args = List.map ast_to_typ t_args in
       let t_ret = unionfind (TAny (Any.fresh ())) in

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -287,6 +287,7 @@ let polymorphic_op_type (op : Operator.polymorphic A.operator Mark.pos) :
   let pos = Mark.get op in
   let any = lazy (UnionFind.make (TAny (Any.fresh ()), pos)) in
   let any2 = lazy (UnionFind.make (TAny (Any.fresh ()), pos)) in
+  let any3 = lazy (UnionFind.make (TAny (Any.fresh ()), pos)) in
   let bt = lazy (UnionFind.make (TLit TBool, pos)) in
   let ut = lazy (UnionFind.make (TLit TUnit, pos)) in
   let it = lazy (UnionFind.make (TLit TInt, pos)) in
@@ -302,6 +303,7 @@ let polymorphic_op_type (op : Operator.polymorphic A.operator Mark.pos) :
     | Fold -> [[any2; any] @-> any2; any2; array any] @-> any2
     | Eq -> [any; any] @-> bt
     | Map -> [[any] @-> any2; array any] @-> array any2
+    | Map2 -> [[any; any2] @-> any3; array any; array any2] @-> array any3
     | Filter -> [[any] @-> bt; array any] @-> array any
     | Reduce -> [[any; any] @-> any; any; array any] @-> any
     | Concat -> [array any; array any] @-> array any

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -145,10 +145,10 @@ and literal =
   | LDate of literal_date
 
 and collection_op =
-  | Exists of { predicate : lident Mark.pos * expression }
-  | Forall of { predicate : lident Mark.pos * expression }
-  | Map of { f : lident Mark.pos * expression }
-  | Filter of { f : lident Mark.pos * expression }
+  | Exists of { predicate : lident Mark.pos list * expression }
+  | Forall of { predicate : lident Mark.pos list * expression }
+  | Map of { f : lident Mark.pos list * expression }
+  | Filter of { f : lident Mark.pos list * expression }
   | AggregateSum of { typ : primitive_typ }
   (* it would be nice to remove the need for specifying the and here like for
      extremums, but we need an additionl overload for "neutral element for
@@ -157,7 +157,7 @@ and collection_op =
   | AggregateArgExtremum of {
       max : bool;
       default : expression;
-      f : lident Mark.pos * expression;
+      f : lident Mark.pos list * expression;
     }
 
 and explicit_match_case = {

--- a/compiler/surface/parser.mly
+++ b/compiler/surface/parser.mly
@@ -157,6 +157,10 @@ let qlident :=
 }
 | id = lident ; { [], id }
 
+let mbinder ==
+| id = lident ; { [id] }
+| LPAREN ; ids = separated_nonempty_list(COMMA,lident) ; RPAREN ; <>
+
 let expression :=
 | e = addpos(naked_expression) ; <>
 
@@ -216,7 +220,7 @@ let naked_expression ==
   CollectionOp (AggregateSum { typ = Mark.remove typ }, coll)
 } %prec apply
 | f = expression ;
-  FOR ; i = lident ;
+  FOR ; i = mbinder ;
   AMONG ; coll = expression ; {
   CollectionOp (Map {f = i, f}, coll)
 } %prec apply
@@ -234,12 +238,12 @@ let naked_expression ==
   e2 = expression ; {
   Binop (binop, e1, e2)
 }
-| EXISTS ; i = lident ;
+| EXISTS ; i = mbinder ;
   AMONG ; coll = expression ;
   SUCH ; THAT ; predicate = expression ; {
   CollectionOp (Exists {predicate = i, predicate}, coll)
 } %prec let_expr
-| FOR ; ALL ; i = lident ;
+| FOR ; ALL ; i = mbinder ;
   AMONG ; coll = expression ;
   WE_HAVE ; predicate = expression ; {
   CollectionOp (Forall {predicate = i, predicate}, coll)
@@ -254,28 +258,28 @@ let naked_expression ==
   ELSE ; e3 = expression ; {
   IfThenElse (e1, e2, e3)
 } %prec let_expr
-| LET ; ids = separated_nonempty_list(COMMA,lident) ;
+| LET ; ids = mbinder ;
   DEFINED_AS ; e1 = expression ;
   IN ; e2 = expression ; {
   LetIn (ids, e1, e2)
 } %prec let_expr
-| i = lident ;
+| i = lident ; (* FIXME: should be mbinder *)
   AMONG ; coll = expression ;
   SUCH ; THAT ; f = expression ; {
-  CollectionOp (Filter {f = i, f}, coll)
+  CollectionOp (Filter {f = [i], f}, coll)
 } %prec top_expr
 | fmap = expression ;
-  FOR ; i = lident ;
+  FOR ; i = mbinder ;
   AMONG ; coll = expression ;
   SUCH ; THAT ; ffilt = expression ; {
   CollectionOp (Map {f = i, fmap}, (CollectionOp (Filter {f = i, ffilt}, coll), Pos.from_lpos $loc))
 } %prec top_expr
-| i = lident ;
+| i = lident ; (* FIXME: should be mbinder *)
   AMONG ; coll = expression ;
   SUCH ; THAT ; f = expression ;
   IS ; max = minmax ;
   OR ; IF ; LIST_EMPTY ; THEN ; default = expression ; {
-  CollectionOp (AggregateArgExtremum { max; default; f = i, f }, coll)
+  CollectionOp (AggregateArgExtremum { max; default; f = [i], f }, coll)
 } %prec top_expr
 
 

--- a/dune
+++ b/dune
@@ -12,7 +12,7 @@
  ; don't stop building because of warnings
  (dev
   (flags
-   (:standard -warn-error -a -w -67)))
+   (:standard -warn-error -a+8 -w -67)))
  ; for CI runs: must fail on warnings
  (check
   (flags

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -661,7 +661,9 @@ module Oper = struct
   let o_xor : bool -> bool -> bool = ( <> )
   let o_eq = ( = )
   let o_map = Array.map
-  let o_map2 f a b = try Array.map2 f a b with Invalid_argument _ -> raise NotSameLength
+
+  let o_map2 f a b =
+    try Array.map2 f a b with Invalid_argument _ -> raise NotSameLength
 
   let o_reduce f dft a =
     let len = Array.length a in

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -50,6 +50,7 @@ exception UncomparableDurations
 exception IndivisibleDurations
 exception ImpossibleDate
 exception NoValueProvided of source_position
+exception NotSameLength
 
 (* TODO: register exception printers for the above
    (Printexc.register_printer) *)
@@ -660,6 +661,7 @@ module Oper = struct
   let o_xor : bool -> bool -> bool = ( <> )
   let o_eq = ( = )
   let o_map = Array.map
+  let o_map2 f a b = try Array.map2 f a b with Invalid_argument _ -> raise NotSameLength
 
   let o_reduce f dft a =
     let len = Array.length a in

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -353,6 +353,7 @@ module Oper : sig
   val o_xor : bool -> bool -> bool
   val o_eq : 'a -> 'a -> bool
   val o_map : ('a -> 'b) -> 'a array -> 'b array
+  val o_map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
   val o_reduce : ('a -> 'a -> 'a) -> 'a -> 'a array -> 'a
   val o_concat : 'a array -> 'a array -> 'a array
   val o_filter : ('a -> bool) -> 'a array -> 'a array

--- a/runtimes/python/src/catala/runtime.py
+++ b/runtimes/python/src/catala/runtime.py
@@ -571,6 +571,8 @@ def list_filter(f: Callable[[Alpha], bool], l: List[Alpha]) -> List[Alpha]:
 def list_map(f: Callable[[Alpha], Beta], l: List[Alpha]) -> List[Beta]:
     return [f(i) for i in l]
 
+def list_map2(f: Callable[[Alpha, Beta], Gamma], l1: List[Alpha], l2: List[Beta]) -> List[Gamma]:
+    return [f(i, j) for i, j in zip(l1, l2, strict=True)]
 
 def list_reduce(f: Callable[[Alpha, Alpha], Alpha], dft: Alpha, l: List[Alpha]) -> Alpha:
     if l == []:

--- a/runtimes/r/R/runtime.R
+++ b/runtimes/r/R/runtime.R
@@ -285,6 +285,10 @@ catala_list_map <- function(f, l) {
   Map(f, l)
 }
 #' @export
+catala_list_map2 <- function(f, l1, l2) {
+  Map(f, l1, l2)
+}
+#' @export
 catala_list_reduce <- function(f, default, l) {
   if (length(l) == 0) {
     default

--- a/tests/test_array/good/aggregation_3.catala_en
+++ b/tests/test_array/good/aggregation_3.catala_en
@@ -72,18 +72,19 @@ let scope S (x: integer|internal|output) =
             10.
             map (λ (i: integer) → to_rat i) [1; 2; 3])
          = 3.;
-  assert (reduce
-            (λ (i_1: integer) (i_2: integer) →
-             if
-               (let i : integer = i_1 in
-                to_rat ((2 - i) * (2 - i)))
-               < let i : integer = i_2 in
-                 to_rat ((2 - i) * (2 - i))
-             then
-               i_1
-             else i_2)
-            42
-            [1; 2; 3])
+  assert (let weights : list of (integer * decimal) =
+            map (λ (i: integer) →
+                 (i, let i1 : integer = i in
+                     to_rat ((2 - i1) * (2 - i1))))
+              [1; 2; 3]
+          in
+          reduce
+            (λ (x1: (integer * decimal)) (x2: (integer * decimal)) →
+             if x1.1 < x2.1 then x1 else x2)
+            let i : integer = 42 in
+            (i, let i1 : integer = i in
+                to_rat ((2 - i1) * (2 - i1)))
+            weights).0
          = 2
 ```
 

--- a/tests/test_func/good/closure_conversion_reduce.catala_en
+++ b/tests/test_func/good/closure_conversion_reduce.catala_en
@@ -24,12 +24,12 @@ $ catala Lcalc -s S --avoid-exceptions -O --closure-conversion
 let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
   let get x : list of integer = S_in.x_in in
   let set y : integer =
-    reduce
-      (λ (potential_max_1: integer) (potential_max_2: integer) →
-       if potential_max_1 < potential_max_2 then potential_max_1
-       else potential_max_2)
-      -1
-      x
+    (reduce
+       (λ (x1: (integer * integer)) (x2: (integer * integer)) →
+        if x1.1 < x2.1 then x1 else x2)
+       let potential_max : integer = -1 in
+       (potential_max, potential_max)
+       map (λ (potential_max: integer) → (potential_max, potential_max)) x).0
   in
   return { S y = y; }
 ```
@@ -57,18 +57,21 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
              (λ (_: unit) → true)
              (λ (_: unit) →
               ESome
-                (reduce
-                   (λ (potential_max_1: integer) (potential_max_2: integer) →
-                    if
-                      (let potential_max : integer = potential_max_1 in
-                       potential_max)
-                      < let potential_max : integer = potential_max_2 in
-                        potential_max
-                    then
-                      potential_max_1
-                    else potential_max_2)
-                   -1
-                   x))
+                (let weights : list of (integer * integer) =
+                   map (λ (potential_max: integer) →
+                        (potential_max,
+                          let potential_max1 : integer = potential_max in
+                          potential_max1))
+                     x
+                 in
+                 reduce
+                   (λ (x1: (integer * integer)) (x2: (integer * integer)) →
+                    if x1.1 < x2.1 then x1 else x2)
+                   let potential_max : integer = -1 in
+                   (potential_max,
+                     let potential_max1 : integer = potential_max in
+                     potential_max1)
+                   weights).0)
          ]
          (λ (_: unit) → false)
          (λ (_: unit) → ENone ()))

--- a/tests/test_modules/good/prorata_syntax.catala_en
+++ b/tests/test_modules/good/prorata_syntax.catala_en
@@ -1,0 +1,65 @@
+> Using Prorata_external as Ext
+
+
+```catala
+declaration structure HouseholdMember:
+  data birthdate content date
+  data revenue content money
+
+declaration structure HouseholdMemberTaxed:
+  data member content HouseholdMember
+  data tax content money
+
+declaration individual_tax_amount content list of HouseholdMemberTaxed
+  depends on members content list of HouseholdMember,
+             tax_to_distribute content money
+  equals
+  let revenues equals member.revenue for member among members in
+  let distributed_tax equals Ext.prorata of tax_to_distribute, revenues in
+  HouseholdMemberTaxed {
+    -- member: member
+    -- tax: tax_amount
+  }
+  for (member, tax_amount) among (members, distributed_tax)
+
+declaration scope S:
+  output result content list of HouseholdMemberTaxed
+
+scope S:
+  definition result equals
+  individual_tax_amount of
+    [ HouseholdMember { -- birthdate: |2000-01-01| -- revenue: $10000 };
+      HouseholdMember { -- birthdate: |2000-01-02| -- revenue: $1000 };
+      HouseholdMember { -- birthdate: |2000-01-02| -- revenue: $100 } ],
+    $300
+```
+
+```catala-test-inline
+$ catala typecheck --check-invariants
+[RESULT] All invariant checks passed
+[RESULT] Typechecking successful!
+```
+
+```catala-test-inline
+$ catala interpret -s S
+[RESULT] Computation successful! Results:
+[RESULT]
+result =
+  [
+    HouseholdMemberTaxed {
+      -- member:
+        HouseholdMember { -- birthdate: 2000-01-01 -- revenue: $10,000.00 }
+      -- tax: $270.27
+    };
+    HouseholdMemberTaxed {
+      -- member:
+        HouseholdMember { -- birthdate: 2000-01-02 -- revenue: $1,000.00 }
+      -- tax: $27.03
+    };
+    HouseholdMemberTaxed {
+      -- member:
+        HouseholdMember { -- birthdate: 2000-01-02 -- revenue: $100.00 }
+      -- tax: $2.70
+    }
+  ]
+```

--- a/tests/test_tuples/good/tuples.catala_en
+++ b/tests/test_tuples/good/tuples.catala_en
@@ -16,11 +16,11 @@ declaration f2 content decimal
   equals
   match en with pattern
   -- One of str1:
-     let a, w equals str.x1 in
-     let b, w equals str1.x1 in
+     let (a, w) equals str.x1 in
+     let (b, w) equals str1.x1 in
      a / b
   -- Two of z:
-     let z1, z2 equals z in z1 / 2
+     let (z1, z2) equals z in z1 / 2
 
 declaration scope Test:
   output o content (date, decimal)
@@ -40,11 +40,11 @@ $ catala typecheck --check-invariants
 ```catala-test-inline
 $ catala interpret -s Test
 [RESULT] Computation successful! Results:
-[RESULT] o = [2001-01-03; 6.0]
+[RESULT] o = (2001-01-03, 6.0)
 ```
 
 ```catala-test-inline
 $ catala interpret_lcalc -s Test
 [RESULT] Computation successful! Results:
-[RESULT] o = [2001-01-03; 6.0]
+[RESULT] o = (2001-01-03, 6.0)
 ```

--- a/tests/test_tuples/good/tuplists.catala_en
+++ b/tests/test_tuples/good/tuplists.catala_en
@@ -1,0 +1,95 @@
+
+```catala
+
+declaration lis1 content list of decimal equals
+  [ 12.; 13.; 14.; 15.; 16.; 17. ]
+
+declaration lis2 content list of money equals
+  [ $10; $1; $100; $42; $17; $10 ]
+
+declaration lis3 content list of money equals
+  [ $20; $200; $10; $23; $25; $12 ]
+
+declaration tlist content list of (decimal, money, money) equals
+  (a, b, c) for (a, b, c) among (lis1, lis2, lis3)
+
+declaration grok
+  content (money, decimal)
+  depends on dec content decimal,
+             mon1 content money,
+             mon2 content money
+  equals
+  (mon1 * dec, mon1 / mon2)
+
+declaration scope S:
+  output r1 content list of (money, decimal)
+  output r2 content list of (money, decimal)
+  output r3 content list of (money, decimal)
+  output r4 content list of (money, decimal)
+  output r5 content list of (money, decimal)
+  output r6 content list of (money, decimal)
+
+scope S:
+  definition r1 equals (grok of x) for x among tlist
+  definition r2 equals (grok of x) for x among (lis1, lis2, lis3)
+  definition r3 equals (grok of (x, y, z)) for (x, y, z) among (lis1, lis2, lis3)
+  definition r4 equals (x * y, y / z) for (x, y, z) among tlist
+  definition r5 equals (x * y, y / z) for (x, y, z) among (lis1, lis2, lis3)
+  definition r6 equals
+    let lis12 equals (x, y) for (x, y) among (lis1, lis2) in
+    (let (x, y) equals xy in (x * y, y / z))
+      for (xy, z) among (lis12, lis3)
+
+```
+
+```catala-test-inline
+$ catala typecheck
+[RESULT] Typechecking successful!
+```
+
+```catala-test-inline
+$ catala interpret -s S
+[RESULT] Computation successful! Results:
+[RESULT]
+r1 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+[RESULT]
+r2 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+[RESULT]
+r3 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+[RESULT]
+r4 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+[RESULT]
+r5 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+[RESULT]
+r6 =
+  [
+    ($120.00, 0.5); ($13.00, 0.005); ($1,400.00, 10.0);
+    ($630.00, 1.826,086,956,521,739,130,4…); ($272.00, 0.68);
+    ($170.00, 0.833,333,333,333,333,333,33…)
+  ]
+```


### PR DESCRIPTION
The primary use-case for this was to be able to run computations on a list
of structures, then return an updated list with some fields in the
structures modified : that is what we need for distribution of tax amounts
among household members, for example.

This patch has a few components:

- Addition of a test as an example for tax distributions (and tests for various
  cases of the below desugaring)

- Internally added a `Map2` operator that is used as backend for the following

- Added a transformation, performed during desugaring, that -- where lists
  are syntactically expected, i.e. after the `among` keyword -- turns a
  (syntactic) tuple of lists into a list of tuples ("zipping" the lists)

- Arg-extremum transformation was also fixed to use an intermediate list
  instead of computing the predicate twice

- For convenience, allow to bind multiple variables in most* list
  operations (previously only `let in` and functions allowed it)

- Fixed the printer for tuples to differentiate them from lists

*Note: tuples are not yet allowed on the left-hand side of filters and
arg-extremums for annoying syntax conflict reasons.