### PR TITLE
Reduce default verbosity of invariant checks

### DIFF
--- a/compiler/dcalc/invariants.ml
+++ b/compiler/dcalc/invariants.ml
@@ -52,7 +52,7 @@ let check_invariant (inv : string * invariant_expr) (p : typed program) : bool =
         e')
   in
   assert (Bindlib.free_vars p' = Bindlib.empty_ctxt);
-  Message.emit_result "Invariant %s checked.@ result: [%d/%d]" name !ok !total;
+  Message.emit_debug "Invariant %s checked.@ result: [%d/%d]" name !ok !total;
   !result
 
 (* Structural invariant: no default can have as type A -> B *)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -206,8 +206,9 @@ module Passes = struct
       Message.emit_debug "Checking invariants...";
       match typed with
       | Typed _ ->
-        let result = Dcalc.Invariants.check_all_invariants prg in
-        if not result then
+        if Dcalc.Invariants.check_all_invariants prg then
+          Message.emit_result "All invariant checks passed"
+        else
           raise
             (Message.raise_internal_error "Some Dcalc invariants are invalid")
       | _ ->
@@ -549,9 +550,10 @@ module Commands = struct
         Shared_ast.Typing.program ~leave_unresolved:false (Program.untype prg)
       in
       Message.emit_debug "Checking invariants...";
-      let result = Dcalc.Invariants.check_all_invariants prg in
-      if not result then
-        raise (Message.raise_internal_error "Some Dcalc invariants are invalid"));
+        if Dcalc.Invariants.check_all_invariants prg then
+          Message.emit_result "All invariant checks passed"
+        else
+          raise (Message.raise_internal_error "Some Dcalc invariants are invalid"));
     Message.emit_result "Typechecking successful!"
 
   let typecheck_cmd =

--- a/tests/test_arithmetic/good/priorities.catala_en
+++ b/tests/test_arithmetic/good/priorities.catala_en
@@ -16,12 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [62/62]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_arithmetic/good/trivial.catala_en
+++ b/tests/test_arithmetic/good/trivial.catala_en
@@ -10,12 +10,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [14/14]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/aggregation.catala_en
+++ b/tests/test_array/good/aggregation.catala_en
@@ -27,12 +27,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [104/104]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [7/7]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/aggregation_2.catala_en
+++ b/tests/test_array/good/aggregation_2.catala_en
@@ -33,12 +33,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [105/105]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [6/6]
-[RESULT] Invariant no_return_a_function checked. result: [7/7]
-[RESULT] Invariant no_partial_evaluation checked. result: [6/6]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/aggregation_3.catala_en
+++ b/tests/test_array/good/aggregation_3.catala_en
@@ -35,12 +35,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [181/181]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [14/14]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/concatenation.catala_en
+++ b/tests/test_array/good/concatenation.catala_en
@@ -14,12 +14,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [36/36]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/filter.catala_en
+++ b/tests/test_array/good/filter.catala_en
@@ -20,12 +20,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [37/37]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/filter_map.catala_en
+++ b/tests/test_array/good/filter_map.catala_en
@@ -21,12 +21,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [51/51]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/fold.catala_en
+++ b/tests/test_array/good/fold.catala_en
@@ -33,12 +33,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [105/105]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [6/6]
-[RESULT] Invariant no_return_a_function checked. result: [7/7]
-[RESULT] Invariant no_partial_evaluation checked. result: [6/6]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/map.catala_en
+++ b/tests/test_array/good/map.catala_en
@@ -14,12 +14,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [26/26]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/simple.catala_en
+++ b/tests/test_array/good/simple.catala_en
@@ -25,12 +25,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [84/84]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/simpler.catala_en
+++ b/tests/test_array/good/simpler.catala_en
@@ -14,12 +14,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [34/34]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_array/good/simplest.catala_en
+++ b/tests/test_array/good/simplest.catala_en
@@ -12,12 +12,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [13/13]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_bool/good/test_bool.catala_en
+++ b/tests/test_bool/good/test_bool.catala_en
@@ -15,12 +15,7 @@ scope TestBool:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [45/45]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_bool/good/test_precedence.catala_en
+++ b/tests/test_bool/good/test_precedence.catala_en
@@ -12,12 +12,7 @@ scope TestBool:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [26/26]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_bool/good/test_xor.catala_en
+++ b/tests/test_bool/good/test_xor.catala_en
@@ -18,12 +18,7 @@ scope TestXor:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [81/81]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_date/good/durations.catala_en
+++ b/tests/test_date/good/durations.catala_en
@@ -27,12 +27,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [78/78]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [14/14]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_date/good/rounding_option_en.catala_en
+++ b/tests/test_date/good/rounding_option_en.catala_en
@@ -26,12 +26,7 @@ scope Test:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [49/49]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_date/good/rounding_option_fr.catala_fr
+++ b/tests/test_date/good/rounding_option_fr.catala_fr
@@ -26,12 +26,7 @@ champ d'application Test:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [49/49]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_date/good/simple.catala_en
+++ b/tests/test_date/good/simple.catala_en
@@ -16,12 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [57/57]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_dec/good/infinite_precision.catala_en
+++ b/tests/test_dec/good/infinite_precision.catala_en
@@ -18,12 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [88/88]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_dec/good/rounding.catala_en
+++ b/tests/test_dec/good/rounding.catala_en
@@ -18,12 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [39/39]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_dec/good/simple.catala_en
+++ b/tests/test_dec/good/simple.catala_en
@@ -18,12 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [68/68]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [11/11]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_dec/good/zero_after_comma.catala_en
+++ b/tests/test_dec/good/zero_after_comma.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [45/45]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_default/good/mutliple_definitions.catala_en
+++ b/tests/test_default/good/mutliple_definitions.catala_en
@@ -24,12 +24,7 @@ $ catala Typecheck --check-invariants
 └─┐
 6 │   definition w equals 3
   │   ‾‾‾‾‾‾‾‾‾‾‾‾
-[RESULT] Invariant typing_defaults checked. result: [14/14]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_enum/good/disambiguated_cases.catala_en
+++ b/tests/test_enum/good/disambiguated_cases.catala_en
@@ -25,12 +25,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [62/62]
-[RESULT] Invariant match_inversion checked. result: [1/1]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_enum/good/quick_pattern_check.catala_en
+++ b/tests/test_enum/good/quick_pattern_check.catala_en
@@ -20,12 +20,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [66/66]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_enum/good/simple.catala_en
+++ b/tests/test_enum/good/simple.catala_en
@@ -20,12 +20,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [43/43]
-[RESULT] Invariant match_inversion checked. result: [1/1]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_enum/good/wildcard.catala_en
+++ b/tests/test_enum/good/wildcard.catala_en
@@ -40,12 +40,7 @@ scope Simple_case_2:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [90/90]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [6/6]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/context_with_default.catala_en
+++ b/tests/test_exception/good/context_with_default.catala_en
@@ -19,12 +19,7 @@ scope Bar:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [47/47]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/double_definition.catala_en
+++ b/tests/test_exception/good/double_definition.catala_en
@@ -27,12 +27,7 @@ $ catala Typecheck --check-invariants
 8 │   definition x equals 1
   │   ‾‾‾‾‾‾‾‾‾‾‾‾
   └─ Foo
-[RESULT] Invariant typing_defaults checked. result: [14/14]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/duplicate_labels.catala_en
+++ b/tests/test_exception/good/duplicate_labels.catala_en
@@ -22,12 +22,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [56/56]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/exception.catala_en
+++ b/tests/test_exception/good/exception.catala_en
@@ -16,12 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [28/28]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/exceptions_squared.catala_en
+++ b/tests/test_exception/good/exceptions_squared.catala_en
@@ -20,12 +20,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [37/37]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/grouped_exceptions.catala_en
+++ b/tests/test_exception/good/grouped_exceptions.catala_en
@@ -50,12 +50,7 @@ scope Benefit:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [59/59]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/groups_of_exceptions.catala_en
+++ b/tests/test_exception/good/groups_of_exceptions.catala_en
@@ -44,12 +44,7 @@ scope Test:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [78/78]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [15/15]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/same_label_two_variables.catala_en
+++ b/tests/test_exception/good/same_label_two_variables.catala_en
@@ -23,12 +23,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [66/66]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/split_unlabeled_exception.catala_en
+++ b/tests/test_exception/good/split_unlabeled_exception.catala_en
@@ -18,12 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [28/28]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/two_exceptions_same_outcome.catala_en
+++ b/tests/test_exception/good/two_exceptions_same_outcome.catala_en
@@ -24,12 +24,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [43/43]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/two_unlabeled_exceptions.catala_en
+++ b/tests/test_exception/good/two_unlabeled_exceptions.catala_en
@@ -21,12 +21,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [55/55]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/unlabeled_exception.catala_en
+++ b/tests/test_exception/good/unlabeled_exception.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [28/28]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_exception/good/unsorted_unlabeled_exceptions.catala_en
+++ b/tests/test_exception/good/unsorted_unlabeled_exceptions.catala_en
@@ -21,12 +21,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [55/55]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [12/12]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/closure_conversion.catala_en
+++ b/tests/test_func/good/closure_conversion.catala_en
@@ -15,12 +15,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [27/27]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/closure_conversion_reduce.catala_en
+++ b/tests/test_func/good/closure_conversion_reduce.catala_en
@@ -15,12 +15,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [27/27]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/closure_return.catala_en
+++ b/tests/test_func/good/closure_return.catala_en
@@ -13,12 +13,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [17/17]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/closure_through_scope.catala_en
+++ b/tests/test_func/good/closure_through_scope.catala_en
@@ -21,12 +21,7 @@ scope T:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [43/43]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/context_func.catala_en
+++ b/tests/test_func/good/context_func.catala_en
@@ -19,12 +19,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [45/45]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/func.catala_en
+++ b/tests/test_func/good/func.catala_en
@@ -25,12 +25,7 @@ scope R:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [110/110]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [6/6]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [6/6]
-[RESULT] Invariant default_no_arrow checked. result: [15/15]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/param_consistency.catala_en
+++ b/tests/test_func/good/param_consistency.catala_en
@@ -16,12 +16,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [33/33]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/test_func/good/scope_call_func_struct_closure.catala_en
@@ -44,12 +44,7 @@ two closures in Foo.r are different even with optimizations enabled.
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [130/130]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [12/12]
-[RESULT] Invariant no_return_a_function checked. result: [10/10]
-[RESULT] Invariant no_partial_evaluation checked. result: [12/12]
-[RESULT] Invariant default_no_arrow checked. result: [11/11]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_io/good/all_io.catala_en
+++ b/tests/test_io/good/all_io.catala_en
@@ -21,12 +21,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [68/68]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [10/10]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_io/good/condition_only_input.catala_en
+++ b/tests/test_io/good/condition_only_input.catala_en
@@ -18,12 +18,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [34/34]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_io/good/subscope.catala_en
+++ b/tests/test_io/good/subscope.catala_en
@@ -24,12 +24,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [63/63]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_literate/good/test_grave_char_en.catala_en
+++ b/tests/test_literate/good/test_grave_char_en.catala_en
@@ -31,12 +31,7 @@ int main(void) { return 0; }
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [19/19]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_literate/good/test_grave_char_fr.catala_fr
+++ b/tests/test_literate/good/test_grave_char_fr.catala_fr
@@ -31,12 +31,7 @@ int main(void) { return 0; }
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [19/19]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_metadata/good/test_markup_refactoring.catala_en
+++ b/tests/test_metadata/good/test_markup_refactoring.catala_en
@@ -32,12 +32,7 @@ scope S2:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [40/40]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_def.catala_en
+++ b/tests/test_modules/good/mod_def.catala_en
@@ -31,12 +31,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [24/24]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_def_context.catala_en
+++ b/tests/test_modules/good/mod_def_context.catala_en
@@ -60,12 +60,7 @@ scope Stest:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [207/207]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [18/18]
-[RESULT] Invariant no_return_a_function checked. result: [17/17]
-[RESULT] Invariant no_partial_evaluation checked. result: [18/18]
-[RESULT] Invariant default_no_arrow checked. result: [22/22]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_middle.catala_en
+++ b/tests/test_modules/good/mod_middle.catala_en
@@ -21,12 +21,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [65/65]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_use.catala_en
+++ b/tests/test_modules/good/mod_use.catala_en
@@ -27,12 +27,7 @@ scope T2:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [74/74]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_use2.catala_en
+++ b/tests/test_modules/good/mod_use2.catala_en
@@ -19,12 +19,7 @@ scope T:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [49/49]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_use3.catala_en
+++ b/tests/test_modules/good/mod_use3.catala_en
@@ -23,12 +23,7 @@ scope T:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [49/49]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_modules/good/mod_use_context.catala_en
+++ b/tests/test_modules/good/mod_use_context.catala_en
@@ -44,12 +44,7 @@ scope TestCall:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [146/146]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [15/15]
-[RESULT] Invariant no_return_a_function checked. result: [16/16]
-[RESULT] Invariant no_partial_evaluation checked. result: [15/15]
-[RESULT] Invariant default_no_arrow checked. result: [13/13]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_money/good/literal_parsing.catala_en
+++ b/tests/test_money/good/literal_parsing.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [27/27]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_money/good/simple.catala_en
+++ b/tests/test_money/good/simple.catala_en
@@ -16,12 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [61/61]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_name_resolution/good/let_in.catala_en
+++ b/tests/test_name_resolution/good/let_in.catala_en
@@ -29,12 +29,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [62/62]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [5/5]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [5/5]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_name_resolution/good/let_in2.catala_en
+++ b/tests/test_name_resolution/good/let_in2.catala_en
@@ -17,12 +17,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [27/27]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [3/3]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_name_resolution/good/out_of_order.catala_en
+++ b/tests/test_name_resolution/good/out_of_order.catala_en
@@ -22,12 +22,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [41/41]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_name_resolution/good/toplevel_defs.catala_en
+++ b/tests/test_name_resolution/good/toplevel_defs.catala_en
@@ -23,12 +23,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [29/29]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 
@@ -443,20 +438,20 @@ def s2(s2_in:S2In):
             def temp_a_4(_:Unit):
                 return True
             return handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=50, start_column=10,
-                                  end_line=50, end_column=11,
+                                  start_line=45, start_column=10,
+                                  end_line=45, end_column=11,
                                   law_headings=["Test toplevel function defs"]), [],
                                   temp_a_4, temp_a_3)
         temp_a_5 = handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=50, start_column=10,
-                                  end_line=50, end_column=11,
+                                  start_line=45, start_column=10,
+                                  end_line=45, end_column=11,
                                   law_headings=["Test toplevel function defs"]), [temp_a_2],
                                   temp_a_1, temp_a)
     except EmptyError:
         temp_a_5 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=50, start_column=10,
-                                             end_line=50, end_column=11,
+                                             start_line=45, start_column=10,
+                                             end_line=45, end_column=11,
                                              law_headings=["Test toplevel function defs"]))
     a = temp_a_5
     return S2(a = a)
@@ -475,20 +470,20 @@ def s3(s3_in:S3In):
             def temp_a_10(_:Unit):
                 return True
             return handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=70, start_column=10,
-                                  end_line=70, end_column=11,
+                                  start_line=65, start_column=10,
+                                  end_line=65, end_column=11,
                                   law_headings=["Test function def with two args"]), [],
                                   temp_a_10, temp_a_9)
         temp_a_11 = handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                   start_line=70, start_column=10,
-                                   end_line=70, end_column=11,
+                                   start_line=65, start_column=10,
+                                   end_line=65, end_column=11,
                                    law_headings=["Test function def with two args"]), [temp_a_8],
                                    temp_a_7, temp_a_6)
     except EmptyError:
         temp_a_11 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=70, start_column=10,
-                                             end_line=70, end_column=11,
+                                             start_line=65, start_column=10,
+                                             end_line=65, end_column=11,
                                              law_headings=["Test function def with two args"]))
     a_1 = temp_a_11
     return S3(a = a_1)
@@ -505,20 +500,20 @@ def s4(s4_in:S4In):
             def temp_a_16(_:Unit):
                 return True
             return handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=93, start_column=10,
-                                  end_line=93, end_column=11,
+                                  start_line=88, start_column=10,
+                                  end_line=88, end_column=11,
                                   law_headings=["Test inline defs in toplevel defs"]), [],
                                   temp_a_16, temp_a_15)
         temp_a_17 = handle_default(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                   start_line=93, start_column=10,
-                                   end_line=93, end_column=11,
+                                   start_line=88, start_column=10,
+                                   end_line=88, end_column=11,
                                    law_headings=["Test inline defs in toplevel defs"]), [temp_a_14],
                                    temp_a_13, temp_a_12)
     except EmptyError:
         temp_a_17 = dead_value
         raise NoValueProvided(SourcePosition(filename="tests/test_name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=93, start_column=10,
-                                             end_line=93, end_column=11,
+                                             start_line=88, start_column=10,
+                                             end_line=88, end_column=11,
                                              law_headings=["Test inline defs in toplevel defs"]))
     a_2 = temp_a_17
     return S4(a = a_2)

--- a/tests/test_name_resolution/good/toplevel_defs_simple.catala_en
+++ b/tests/test_name_resolution/good/toplevel_defs_simple.catala_en
@@ -14,12 +14,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [13/13]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/array_length.catala_en
+++ b/tests/test_proof/good/array_length.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [30/30]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/assert.catala_en
+++ b/tests/test_proof/good/assert.catala_en
@@ -26,12 +26,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [46/46]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/dates_get_year.catala_en
+++ b/tests/test_proof/good/dates_get_year.catala_en
@@ -17,12 +17,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [52/52]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/dates_simple.catala_en
+++ b/tests/test_proof/good/dates_simple.catala_en
@@ -17,12 +17,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [46/46]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/direct_scope_call.catala_en
+++ b/tests/test_proof/good/direct_scope_call.catala_en
@@ -18,12 +18,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [39/39]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [2/2]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/direct_scope_call_with_context.catala_en
+++ b/tests/test_proof/good/direct_scope_call_with_context.catala_en
@@ -19,12 +19,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [55/55]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/duration.catala_en
+++ b/tests/test_proof/good/duration.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [30/30]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/enums-arith.catala_en
+++ b/tests/test_proof/good/enums-arith.catala_en
@@ -30,12 +30,7 @@ $ catala Typecheck --check-invariants
 5 │    -- C content boolean
   │       ‾
   └─ Test
-[RESULT] Invariant typing_defaults checked. result: [38/38]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/enums-nonbool.catala_en
+++ b/tests/test_proof/good/enums-nonbool.catala_en
@@ -30,12 +30,7 @@ $ catala Typecheck --check-invariants
 5 │    -- C content boolean
   │       ‾
   └─ Test
-[RESULT] Invariant typing_defaults checked. result: [36/36]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/enums.catala_en
+++ b/tests/test_proof/good/enums.catala_en
@@ -29,12 +29,7 @@ $ catala Typecheck --check-invariants
 5 │    -- C content boolean
   │       ‾
   └─ Test
-[RESULT] Invariant typing_defaults checked. result: [34/34]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/enums_inj.catala_en
+++ b/tests/test_proof/good/enums_inj.catala_en
@@ -19,12 +19,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [29/29]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/enums_unit.catala_en
+++ b/tests/test_proof/good/enums_unit.catala_en
@@ -23,12 +23,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [33/33]
-[RESULT] Invariant match_inversion checked. result: [2/2]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/functions.catala_en
+++ b/tests/test_proof/good/functions.catala_en
@@ -16,12 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [44/44]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [3/3]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [3/3]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/let_in_condition.catala_en
+++ b/tests/test_proof/good/let_in_condition.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [13/13]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/money.catala_en
+++ b/tests/test_proof/good/money.catala_en
@@ -17,12 +17,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [46/46]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [7/7]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/no_vars.catala_en
+++ b/tests/test_proof/good/no_vars.catala_en
@@ -12,12 +12,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [24/24]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/rationals.catala_en
+++ b/tests/test_proof/good/rationals.catala_en
@@ -15,12 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [30/30]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/simple_vars.catala_en
+++ b/tests/test_proof/good/simple_vars.catala_en
@@ -18,12 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [45/45]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_proof/good/structs.catala_en
+++ b/tests/test_proof/good/structs.catala_en
@@ -22,12 +22,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [42/42]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [5/5]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/191_fix_record_name_confusion.catala_en
+++ b/tests/test_scope/good/191_fix_record_name_confusion.catala_en
@@ -19,12 +19,7 @@ scope ScopeB:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [25/25]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [1/1]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [1/1]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/grand_parent_caller.catala_en
+++ b/tests/test_scope/good/grand_parent_caller.catala_en
@@ -33,12 +33,7 @@ scope C:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [126/126]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [7/7]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [7/7]
-[RESULT] Invariant default_no_arrow checked. result: [19/19]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/nothing.catala_en
+++ b/tests/test_scope/good/nothing.catala_en
@@ -16,12 +16,7 @@ $ catala Typecheck --check-invariants
 5 │   output bar content integer
   │          ‾‾‾
   └─ Test
-[RESULT] Invariant typing_defaults checked. result: [6/6]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [1/1]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/scope_call.catala_en
+++ b/tests/test_scope/good/scope_call.catala_en
@@ -24,12 +24,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [85/85]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [7/7]
-[RESULT] Invariant no_return_a_function checked. result: [5/5]
-[RESULT] Invariant no_partial_evaluation checked. result: [7/7]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/scope_call2.catala_en
+++ b/tests/test_scope/good/scope_call2.catala_en
@@ -22,12 +22,7 @@ scope Titi:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [93/93]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [8/8]
-[RESULT] Invariant no_return_a_function checked. result: [7/7]
-[RESULT] Invariant no_partial_evaluation checked. result: [8/8]
-[RESULT] Invariant default_no_arrow checked. result: [11/11]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/scope_call3.catala_en
+++ b/tests/test_scope/good/scope_call3.catala_en
@@ -20,12 +20,7 @@ scope RentComputation:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [67/67]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [7/7]
-[RESULT] Invariant no_return_a_function checked. result: [6/6]
-[RESULT] Invariant no_partial_evaluation checked. result: [7/7]
-[RESULT] Invariant default_no_arrow checked. result: [8/8]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/scope_call4.catala_en
+++ b/tests/test_scope/good/scope_call4.catala_en
@@ -26,12 +26,7 @@ scope RentComputation:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [126/126]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [16/16]
-[RESULT] Invariant no_return_a_function checked. result: [13/13]
-[RESULT] Invariant no_partial_evaluation checked. result: [16/16]
-[RESULT] Invariant default_no_arrow checked. result: [13/13]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/scope_struct.catala_en
+++ b/tests/test_scope/good/scope_struct.catala_en
@@ -25,12 +25,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [65/65]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/simple.catala_en
+++ b/tests/test_scope/good/simple.catala_en
@@ -12,12 +12,7 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [10/10]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/sub_scope.catala_en
+++ b/tests/test_scope/good/sub_scope.catala_en
@@ -27,12 +27,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [138/138]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [7/7]
-[RESULT] Invariant no_return_a_function checked. result: [6/6]
-[RESULT] Invariant no_partial_evaluation checked. result: [7/7]
-[RESULT] Invariant default_no_arrow checked. result: [17/17]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/sub_sub_scope.catala_en
+++ b/tests/test_scope/good/sub_sub_scope.catala_en
@@ -34,12 +34,7 @@ scope C:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [150/150]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [8/8]
-[RESULT] Invariant no_return_a_function checked. result: [7/7]
-[RESULT] Invariant no_partial_evaluation checked. result: [8/8]
-[RESULT] Invariant default_no_arrow checked. result: [19/19]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/subscope_function_arg_not_defined.catala_en
+++ b/tests/test_scope/good/subscope_function_arg_not_defined.catala_en
@@ -21,12 +21,7 @@ scope Caller:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [74/74]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [5/5]
-[RESULT] Invariant no_return_a_function checked. result: [3/3]
-[RESULT] Invariant no_partial_evaluation checked. result: [5/5]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_scope/good/subscope_function_arg_not_defined2.catala_en
+++ b/tests/test_scope/good/subscope_function_arg_not_defined2.catala_en
@@ -23,12 +23,7 @@ scope Caller:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [95/95]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [5/5]
-[RESULT] Invariant no_return_a_function checked. result: [4/4]
-[RESULT] Invariant no_partial_evaluation checked. result: [5/5]
-[RESULT] Invariant default_no_arrow checked. result: [16/16]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_struct/good/ambiguous_fields.catala_en
+++ b/tests/test_struct/good/ambiguous_fields.catala_en
@@ -27,12 +27,7 @@ $ catala Typecheck --check-invariants
 7 │ declaration structure Bar:
   │                       ‾‾‾
   └─ Article
-[RESULT] Invariant typing_defaults checked. result: [20/20]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [4/4]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_struct/good/nested3.catala_en
+++ b/tests/test_struct/good/nested3.catala_en
@@ -38,12 +38,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [84/84]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [4/4]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [4/4]
-[RESULT] Invariant default_no_arrow checked. result: [9/9]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_struct/good/same_name_fields.catala_en
+++ b/tests/test_struct/good/same_name_fields.catala_en
@@ -27,12 +27,7 @@ $ catala Typecheck --check-invariants
 7 │ declaration structure Bar:
   │                       ‾‾‾
   └─ Article
-[RESULT] Invariant typing_defaults checked. result: [39/39]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_struct/good/simple.catala_en
+++ b/tests/test_struct/good/simple.catala_en
@@ -21,12 +21,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [43/43]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_tuples/good/tuples.catala_en
+++ b/tests/test_tuples/good/tuples.catala_en
@@ -33,12 +33,7 @@ scope Test:
 
 ```catala-test-inline
 $ catala typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [59/59]
-[RESULT] Invariant match_inversion checked. result: [1/1]
-[RESULT] Invariant app_inversion checked. result: [6/6]
-[RESULT] Invariant no_return_a_function checked. result: [8/8]
-[RESULT] Invariant no_partial_evaluation checked. result: [6/6]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_typing/good/common.catala_en
+++ b/tests/test_typing/good/common.catala_en
@@ -49,12 +49,7 @@ $ catala Typecheck --check-invariants
 └─┐
 2 │ declaration enumeration Enum:
   │                         ‾‾‾‾
-[RESULT] Invariant typing_defaults checked. result: [16/16]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [2/2]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_typing/good/overload.catala_en
+++ b/tests/test_typing/good/overload.catala_en
@@ -61,12 +61,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [433/433]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [32/32]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_variable_state/good/simple.catala_en
+++ b/tests/test_variable_state/good/simple.catala_en
@@ -19,12 +19,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [30/30]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [0/0]
-[RESULT] Invariant no_return_a_function checked. result: [0/0]
-[RESULT] Invariant no_partial_evaluation checked. result: [0/0]
-[RESULT] Invariant default_no_arrow checked. result: [6/6]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 

--- a/tests/test_variable_state/good/subscope.catala_en
+++ b/tests/test_variable_state/good/subscope.catala_en
@@ -34,12 +34,7 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[RESULT] Invariant typing_defaults checked. result: [82/82]
-[RESULT] Invariant match_inversion checked. result: [0/0]
-[RESULT] Invariant app_inversion checked. result: [2/2]
-[RESULT] Invariant no_return_a_function checked. result: [1/1]
-[RESULT] Invariant no_partial_evaluation checked. result: [2/2]
-[RESULT] Invariant default_no_arrow checked. result: [15/15]
+[RESULT] All invariant checks passed
 [RESULT] Typechecking successful!
 ```
 


### PR DESCRIPTION
they break the tests too often for no good reason