### PR TITLE
Attempt to improve type annotations on the dcalc->lcalc translations

### DIFF
--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -689,7 +689,7 @@ let translate_rule
       | Runtime.Reentrant, pos -> (
         match Mark.remove tau with
         | TArrow _ -> new_e
-        | _ -> Expr.thunk_term new_e (Expr.with_pos pos (Mark.get new_e)))
+        | _ -> Mark.map_mark (Expr.with_pos pos) (Expr.thunk_term new_e))
     in
     ( (fun next ->
         Bindlib.box_apply2

--- a/compiler/lcalc/closure_conversion.mli
+++ b/compiler/lcalc/closure_conversion.mli
@@ -21,4 +21,4 @@
     After closure conversion, closure hoisting is perform and all closures end
     up as toplevel definitions. *)
 
-val closure_conversion : 'm Ast.program -> 'm Ast.program Bindlib.box
+val closure_conversion : 'm Ast.program -> Shared_ast.untyped Ast.program

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -41,48 +41,61 @@ let rec translate_typ (tau : typ) : typ =
       | TArrow (t1, t2) -> TArrow (List.map translate_typ t1, translate_typ t2)
     end
 
+let translate_mark e = Expr.map_ty translate_typ (Mark.get e)
+
 let rec translate_default
     (exceptions : 'm D.expr list)
     (just : 'm D.expr)
     (cons : 'm D.expr)
     (mark_default : 'm mark) : 'm A.expr boxed =
-  let exceptions =
-    List.map
-      (fun except -> Expr.thunk_term (translate_expr except) (Mark.get except))
-      exceptions
-  in
   let pos = Expr.mark_pos mark_default in
   let exceptions =
-    Expr.eappop ~op:Op.HandleDefault
-      ~tys:[TAny, pos; TAny, pos; TAny, pos]
-      ~args:
-        [
-          Expr.earray exceptions mark_default;
-          Expr.thunk_term (translate_expr just) (Mark.get just);
-          Expr.thunk_term (translate_expr cons) (Mark.get cons);
-        ]
-      mark_default
+    List.map (fun except -> Expr.thunk_term (translate_expr except)) exceptions
   in
-  exceptions
+  Expr.eappop ~op:Op.HandleDefault
+    ~tys:
+      [
+        TArray (TArrow ([TLit TUnit, pos], (TAny, pos)), pos), pos;
+        TArrow ([TLit TUnit, pos], (TLit TBool, pos)), pos;
+        TArrow ([TLit TUnit, pos], (TAny, pos)), pos;
+      ]
+    ~args:
+      [
+        Expr.earray exceptions
+          (Expr.map_ty
+             (fun ty -> TArray (TArrow ([TLit TUnit, pos], ty), pos), pos)
+             mark_default);
+        Expr.thunk_term (translate_expr just);
+        Expr.thunk_term (translate_expr cons);
+      ]
+    mark_default
 
 and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
-  let m = Mark.get e in
+  let m = translate_mark e in
   match Mark.remove e with
   | EEmptyError -> Expr.eraise EmptyError m
   | EErrorOnEmpty arg ->
     Expr.ecatch (translate_expr arg) EmptyError
       (Expr.eraise NoValueProvided m)
       m
-  | EDefault { excepts; just; cons } ->
-    translate_default excepts just cons (Mark.get e)
+  | EDefault { excepts; just; cons } -> translate_default excepts just cons m
   | EPureDefault e -> translate_expr e
+  (* As we need to translate types as well as terms, we cannot simply use
+     [Expr.map] for terms that contains types. *)
+  | EAbs { binder; tys } ->
+    let tys = List.map translate_typ tys in
+    Expr.map ~f:translate_expr (EAbs { binder; tys }, m)
+  | EApp { f; args; tys } ->
+    let tys = List.map translate_typ tys in
+    Expr.map ~f:translate_expr (EApp { f; args; tys }, m)
   | EAppOp { op; args; tys } ->
     Expr.eappop ~op:(Operator.translate op)
       ~args:(List.map translate_expr args)
-      ~tys m
-  | ( ELit _ | EApp _ | EArray _ | EVar _ | EExternal _ | EAbs _ | EIfThenElse _
-    | ETuple _ | ETupleAccess _ | EInj _ | EAssert _ | EStruct _
-    | EStructAccess _ | EMatch _ ) as e ->
+      ~tys:(List.map translate_typ tys)
+      m
+  | ( ELit _ | EArray _ | EVar _ | EExternal _ | EIfThenElse _ | ETuple _
+    | ETupleAccess _ | EInj _ | EAssert _ | EStruct _ | EStructAccess _
+    | EMatch _ ) as e ->
     Expr.map ~f:translate_expr (Mark.add m e)
   | _ -> .
 
@@ -125,24 +138,20 @@ let translate_code_items scopes =
   in
   Scope.map ~f ~varf:Var.translate scopes
 
-let translate_program (prg : typed D.program) : untyped A.program =
-  Program.untype
-  @@ Bindlib.unbox
-  @@ Bindlib.box_apply
-       (fun code_items ->
-         let ctx_enums =
-           EnumName.Map.map
-             (EnumConstructor.Map.map translate_typ)
-             prg.decl_ctx.ctx_enums
-         in
-         let ctx_structs =
-           StructName.Map.map
-             (StructField.Map.map translate_typ)
-             prg.decl_ctx.ctx_structs
-         in
-         {
-           prg with
-           code_items;
-           decl_ctx = { prg.decl_ctx with ctx_enums; ctx_structs };
-         })
-       (translate_code_items prg.code_items)
+let translate_program (prg : 'm D.program) : 'm A.program =
+  let code_items = Bindlib.unbox (translate_code_items prg.code_items) in
+  let ctx_enums =
+    EnumName.Map.map
+      (EnumConstructor.Map.map translate_typ)
+      prg.decl_ctx.ctx_enums
+  in
+  let ctx_structs =
+    StructName.Map.map
+      (StructField.Map.map translate_typ)
+      prg.decl_ctx.ctx_structs
+  in
+  {
+    prg with
+    code_items;
+    decl_ctx = { prg.decl_ctx with ctx_enums; ctx_structs };
+  }

--- a/compiler/lcalc/compile_with_exceptions.mli
+++ b/compiler/lcalc/compile_with_exceptions.mli
@@ -17,5 +17,4 @@
 (** Translation from the default calculus to the lambda calculus. This
     translation uses exceptions to handle empty default terms. *)
 
-val translate_program :
-  Shared_ast.typed Dcalc.Ast.program -> Shared_ast.untyped Ast.program
+val translate_program : 'm Dcalc.Ast.program -> 'm Ast.program

--- a/compiler/lcalc/compile_without_exceptions.mli
+++ b/compiler/lcalc/compile_without_exceptions.mli
@@ -19,6 +19,4 @@
     transformation is one piece to permit to compile toward legacy languages
     that does not contains exceptions. *)
 
-open Shared_ast
-
-val translate_program : typed Dcalc.Ast.program -> untyped Ast.program
+val translate_program : 'm Dcalc.Ast.program -> 'm Ast.program

--- a/compiler/lcalc/from_dcalc.mli
+++ b/compiler/lcalc/from_dcalc.mli
@@ -14,15 +14,12 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-open Shared_ast
-
-val translate_program_with_exceptions :
-  typed Dcalc.Ast.program -> untyped Ast.program
+val translate_program_with_exceptions : 'm Dcalc.Ast.program -> 'm Ast.program
 (** Translation from the default calculus to the lambda calculus. This
     translation uses exceptions to handle empty default terms. *)
 
 val translate_program_without_exceptions :
-  typed Dcalc.Ast.program -> untyped Ast.program
+  'm Dcalc.Ast.program -> 'm Ast.program
 (** Translation from the default calculus to the lambda calculus. This
     translation uses an option monad to handle empty defaults terms. This
     transformation is one piece to permit to compile toward legacy languages

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -933,6 +933,23 @@ let make_tuple el m0 =
     in
     etuple el m
 
+let make_tupleaccess e index size pos =
+  let m =
+    map_mark
+      (fun _ -> pos)
+      (function
+        | TTuple tl, _ -> (
+          try List.nth tl index
+          with Failure _ ->
+            Message.raise_internal_error "Trying to build invalid tuple access")
+        | TAny, pos -> TAny, pos
+        | ty ->
+          Message.raise_internal_error "Unexpected non-tuple type annotation %a"
+            Print.typ_debug ty)
+      (Mark.get e)
+  in
+  etupleaccess ~e ~index ~size m
+
 let make_app f args tys pos =
   let mark =
     fold_marks

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -188,11 +188,6 @@ let mark_pos (type m) (m : m mark) : Pos.t =
   match m with Untyped { pos } | Typed { pos; _ } | Custom { pos; _ } -> pos
 
 let pos (type m) (x : ('a, m) marked) : Pos.t = mark_pos (Mark.get x)
-
-let fun_id ?(var_name : string = "x") mark : ('a any, 'm) boxed_gexpr =
-  let x = Var.make var_name in
-  eabs (bind [| x |] (evar x mark)) [TAny, mark_pos mark] mark
-
 let ty (_, m) : typ = match m with Typed { ty; _ } -> ty
 
 let set_ty (type m) (ty : typ) (x : ('a, m) marked) : ('a, typed) marked =
@@ -985,12 +980,12 @@ let make_erroronempty e =
   in
   eerroronempty e mark
 
-let thunk_term term mark =
+let thunk_term term =
   let silent = Var.make "_" in
-  let pos = mark_pos mark in
+  let pos = mark_pos (Mark.get term) in
   make_abs [| silent |] term [TLit TUnit, pos] pos
 
-let empty_thunked_term mark = thunk_term (Bindlib.box EEmptyError, mark) mark
+let empty_thunked_term mark = thunk_term (Bindlib.box EEmptyError, mark)
 
 let unthunk_term_nobox term mark =
   Mark.add mark
@@ -1012,3 +1007,7 @@ let make_puredefault e =
     map_mark (fun pos -> pos) (fun ty -> TDefault ty, Mark.get ty) (Mark.get e)
   in
   epuredefault e mark
+
+let fun_id ?(var_name : string = "x") mark : ('a any, 'm) boxed_gexpr =
+  let x = Var.make var_name in
+  make_abs [| x |] (evar x mark) [TAny, mark_pos mark] (mark_pos mark)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -174,6 +174,8 @@ val ecustom :
   (< custom : Definitions.yes ; .. >, 'm) boxed_gexpr
 
 val fun_id : ?var_name:string -> 'm mark -> ('a any, 'm) boxed_gexpr
+(** The type of the mark, if typed, is assumed to correspond to the argument
+    type, not the function type *)
 
 (** {2 Manipulation of marks} *)
 
@@ -342,7 +344,7 @@ val make_erroronempty :
 val empty_thunked_term :
   'm mark -> (< defaultTerms : yes ; .. >, 'm) boxed_gexpr
 
-val thunk_term : ('a any, 'b) boxed_gexpr -> 'b mark -> ('a, 'b) boxed_gexpr
+val thunk_term : ('a any, 'b) boxed_gexpr -> ('a, 'b) boxed_gexpr
 val unthunk_term_nobox : ('a any, 'm) gexpr -> 'm mark -> ('a, 'm) gexpr
 
 val make_let_in :

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -366,6 +366,9 @@ val make_tuple :
 (** Builds a tuple; the mark argument is only used as witness and for position
     when building 0-uples *)
 
+val make_tupleaccess :
+  ('a any, 'm) boxed_gexpr -> int -> int -> Pos.t -> ('a, 'm) boxed_gexpr
+
 (** {2 Transformations} *)
 
 val skip_wrappers : ('a, 'm) gexpr -> ('a, 'm) gexpr


### PR DESCRIPTION
This passes all current tests and fixes the examples broken in #532 ; but might break some in-progress invariants of the c backend.

What I attempted to do is ensuring to add correct type annotations when transforming dcalc to lcalc (for both of the with/without exceptions versions) — when the translation is done on a typed AST of course (note that while I computed the correct types in the cases where it wasn't too complex, it's in general fine to use `TAny` there, what should be avoided is to copy annotations, keeping their types where they're not correct anyore)

- in these changes, I removed the need for `compile_without_exceptions` to run on a typed AST and to copy the type annotations into the `EAppOp` parameters. Since we don't need to untype the whole term anymore, I expect the remaining type annotations should make this unnecessary, but I'm not 100% sure it doesn't break anything @denismerigoux has been working on, so this part may need to be reverted.
- I didn't complete the same effort for the `closure_conversion` pass, but expressed the fact that it doesn't preserve types with an explicit `untype` at the end (that should at least be replaced by a removing of type annotations done during the main traversal)