### PR TITLE
Improve message formatting throughout

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -145,19 +145,13 @@ module Content = struct
     content @ [Position { pos = position; pos_message = message }]
 
   let of_string (s : string) : t =
-    [
-      MainMessage
-        (fun ppf ->
-          Format.pp_open_hovbox ppf 0;
-          Format.pp_print_text ppf s;
-          Format.pp_close_box ppf ());
-    ]
+    [MainMessage (fun ppf -> Format.pp_print_text ppf s)]
 
   let emit (content : t) (target : level) : unit =
     match Global.options.message_format with
     | Global.Human ->
       let ppf = get_ppf target in
-      Format.pp_open_hvbox ppf 0;
+      Format.pp_open_vbox ppf 0;
       Format.pp_print_list
         ~pp_sep:(fun ppf () -> Format.fprintf ppf "@,@,")
         (fun ppf -> function
@@ -167,14 +161,9 @@ module Content = struct
               pos.pos_message;
             Pos.format_loc_text ppf pos.pos
           | MainMessage msg ->
-            Format.fprintf ppf "%t%t%t" (pp_marker target)
-              (fun ppf ->
-                match target with
-                | Result | Error -> Format.pp_print_space ppf ()
-                | _ -> Format.pp_print_char ppf ' ')
-              msg
+            Format.fprintf ppf "@[<hov 2>%t %t@]" (pp_marker target) msg
           | Outcome msg ->
-            Format.fprintf ppf "@[<hv>%t@ %t@]" (pp_marker target) msg
+            Format.fprintf ppf "@[<hov>%t@ %t@]" (pp_marker target) msg
           | Suggestion suggestions_list ->
             Suggestions.format ppf suggestions_list)
         ppf content;

--- a/compiler/desugared/dependency.ml
+++ b/compiler/desugared/dependency.ml
@@ -142,8 +142,8 @@ let check_for_cycle (scope : Ast.scope) (g : ScopeDependencies.t) : unit =
         (List.tl cycle @ [List.hd cycle])
     in
     Message.error ~extra_pos
-      "@[<hov 2>Cyclic dependency detected between the following variables of \
-       scope %a:@ @[<hv>%a@]@]"
+      "Cyclic dependency detected between the following variables of scope \
+       %a:@ @[<hv>%a@]"
       ScopeName.format scope.scope_uid
       (Format.pp_print_list
          ~pp_sep:(fun ppf () -> Format.fprintf ppf " →@ ")
@@ -197,13 +197,13 @@ let build_scope_dependencies (scope : Ast.scope) : ScopeDependencies.t =
                 match def_key with
                 | _, Ast.ScopeDef.Var _ ->
                   Message.error ~pos:fv_def_pos
-                    "The variable %a is used in one of its definitions, but \
-                     recursion is forbidden in Catala"
+                    "The variable@ %a@ is@ used@ in@ one@ of@ its@ \
+                     definitions@ (Catala doesn't support recursion)"
                     Ast.ScopeDef.format def_key
                 | v, Ast.ScopeDef.SubScopeInput _ ->
                   Message.error ~pos:fv_def_pos
-                    "The subscope %a is used in the definition of its own \
-                     input %a, but recursion is forbidden in Catala"
+                    "The subscope@ %a@ is@ used@ in@ the@ definition@ of@ its@ \
+                     own@ input@ %a@ (Catala doesn't support recursion)"
                     ScopeVar.format (Mark.remove v) Ast.ScopeDef.format def_key
             in
             ScopeDependencies.add_edge_e g
@@ -499,6 +499,7 @@ let check_for_exception_cycle
     in
     let v, _ = RuleName.Map.choose (List.hd scc).rules in
     Message.error ~extra_pos:spans
-      "Exception cycle detected when defining %a: each of these %d exceptions \
-       applies over the previous one, and the first applies over the last"
+      "Exception cycle detected when defining@ %a:@ each of these %d \
+       exceptions applies over the previous one,@ and@ the@ first@ applies@ \
+       over@ the@ last"
       RuleName.format v (List.length scc)

--- a/compiler/desugared/linting.ml
+++ b/compiler/desugared/linting.ml
@@ -39,8 +39,8 @@ let detect_empty_definitions (p : program) : unit =
           then
             Message.warning
               ~pos:(ScopeDef.get_position scope_def_key)
-              "In scope \"%a\", the variable \"%a\" is declared but never \
-               defined; did you forget something?"
+              "In scope \"%a\",@ the@ variable@ \"%a\"@ is@ declared@ but@ \
+               never@ defined;@ did you forget something?"
               ScopeName.format scope_name Ast.ScopeDef.format scope_def_key)
         scope.scope_defs)
     p.program_root.module_scopes
@@ -95,8 +95,8 @@ let detect_identical_rules (p : program) : unit =
             (fun _ pos ->
               if List.length pos > 1 then
                 Message.warning ~extra_pos:pos
-                  "These %s have identical justifications and consequences; is \
-                   it a mistake?"
+                  "These %s have identical justifications@ and@ consequences;@ \
+                   is it a mistake?"
                   (if scope_def.scope_def_is_condition then "rules"
                    else "definitions"))
             rules_seen)
@@ -155,7 +155,7 @@ let detect_unused_struct_fields (p : program) : unit =
         then
           Message.warning
             ~pos:(snd (StructName.get_info s_name))
-            "The structure \"%a\" is never used; maybe it's unnecessary?"
+            "The structure@ \"%a\"@ is@ never@ used;@ maybe it's unnecessary?"
             StructName.format s_name
         else
           StructField.Map.iter
@@ -166,8 +166,8 @@ let detect_unused_struct_fields (p : program) : unit =
               then
                 Message.warning
                   ~pos:(snd (StructField.get_info field))
-                  "The field \"%a\" of struct @{<yellow>\"%a\"@} is never \
-                   used; maybe it's unnecessary?"
+                  "The field@ \"%a\"@ of@ struct@ @{<yellow>\"%a\"@}@ is@ \
+                   never@ used;@ maybe it's unnecessary?"
                   StructField.format field StructName.format s_name)
             fields)
       p.program_ctx.ctx_structs
@@ -213,7 +213,7 @@ let detect_unused_enum_constructors (p : program) : unit =
         then
           Message.warning
             ~pos:(snd (EnumName.get_info e_name))
-            "The enumeration \"%a\" is never used; maybe it's unnecessary?"
+            "The enumeration@ \"%a\"@ is@ never@ used;@ maybe it's unnecessary?"
             EnumName.format e_name
         else
           EnumConstructor.Map.iter
@@ -223,8 +223,8 @@ let detect_unused_enum_constructors (p : program) : unit =
               then
                 Message.warning
                   ~pos:(snd (EnumConstructor.get_info constructor))
-                  "The constructor \"%a\" of enumeration \"%a\" is never used; \
-                   maybe it's unnecessary?"
+                  "The constructor@ \"%a\"@ of@ enumeration@ \"%a\"@ is@ \
+                   never@ used;@ maybe it's unnecessary?"
                   EnumConstructor.format constructor EnumName.format e_name)
             constructors)
       p.program_ctx.ctx_enums
@@ -268,8 +268,8 @@ let detect_dead_code (p : program) : unit =
       let emit_unused_warning vx =
         Message.warning
           ~pos:(Mark.get (Dependency.Vertex.info vx))
-          "Unused varible: %a does not contribute to computing any of scope %a \
-           outputs. Did you forget something?"
+          "Unused varible:@ %a@ does@ not@ contribute@ to@ computing@ any@ of@ \
+           scope@ %a@ outputs.@ Did you forget something?"
           Dependency.Vertex.format vx ScopeName.format scope_name
       in
       Dependency.ScopeDependencies.iter_vertex

--- a/compiler/desugared/name_resolution.ml
+++ b/compiler/desugared/name_resolution.ml
@@ -396,6 +396,7 @@ let process_data_decl
                       (Ident.Map.find state_id_name states_idmap
                       |> StateName.get_info) );
                 ]
+              "%a" Format.pp_print_text
               "There are two states with the same name for the same variable: \
                this is ambiguous. Please change the name of either states.";
           let state_uid = StateName.fresh state_id in
@@ -431,8 +432,8 @@ let process_struct_decl (ctxt : context) (sdecl : Surface.Ast.struct_decl) :
   if sdecl.struct_decl_fields = [] then
     Message.error
       ~pos:(Mark.get sdecl.struct_decl_name)
-      "The struct %s does not have any fields; give it some for Catala to be \
-       able to accept it."
+      "The struct@ %s@ does@ not@ have@ any@ fields;@ give it some for Catala \
+       to be able to accept it."
       (Mark.remove sdecl.struct_decl_name);
   List.fold_left
     (fun ctxt (fdecl, _) ->
@@ -476,8 +477,8 @@ let process_enum_decl (ctxt : context) (edecl : Surface.Ast.enum_decl) : context
   if List.length edecl.enum_decl_cases = 0 then
     Message.error
       ~pos:(Mark.get edecl.enum_decl_name)
-      "The enum %s does not have any cases; give it some for Catala to be able \
-       to accept it."
+      "The enum@ %s@ does@ not@ have@ any@ cases;@ give it some for Catala to \
+       be able to accept it."
       (Mark.remove edecl.enum_decl_name);
   List.fold_left
     (fun ctxt (cdecl, cdecl_pos) ->
@@ -777,7 +778,7 @@ let get_def_key
                   "", Mark.get state;
                   "Variable declaration:", Mark.get (ScopeVar.get_info x_uid);
                 ]
-              "This identifier is not a state declared for variable %a."
+              "This identifier is not a state declared for variable@ %a."
               ScopeVar.format x_uid)
         | None ->
           if not (Ident.Map.is_empty var_sig.var_sig_states_idmap) then
@@ -787,8 +788,8 @@ let get_def_key
                   "", Mark.get x;
                   "Variable declaration:", Mark.get (ScopeVar.get_info x_uid);
                 ]
-              "This definition does not indicate which state has to be \
-               considered for variable %a."
+              "This definition does not indicate which state has to@ be@ \
+               considered@ for@ variable@ %a."
               ScopeVar.format x_uid
           else None) )
   | [y; x] ->
@@ -796,17 +797,17 @@ let get_def_key
       match Ident.Map.find_opt (Mark.remove y) scope_ctxt.var_idmap with
       | Some (SubScope (v, u, _)) -> v, u
       | Some _ ->
-        Message.error ~pos "Invalid definition, %a is not a subscope"
+        Message.error ~pos "Invalid definition,@ %a@ is@ not@ a@ subscope"
           Print.lit_style (Mark.remove y)
       | None ->
-        Message.error ~pos "No definition found for subscope %a" Print.lit_style
-          (Mark.remove y)
+        Message.error ~pos "No definition found for subscope@ %a"
+          Print.lit_style (Mark.remove y)
     in
     let var_within_origin_scope = get_var_uid name ctxt x in
     ( (subscope_var, pos),
       Ast.ScopeDef.SubScopeInput { name; var_within_origin_scope } )
   | _ ->
-    Message.error ~pos
+    Message.error ~pos "%a" Format.pp_print_text
       "This line is defining a quantity that is neither a scope variable nor a \
        subscope variable. In particular, it is not possible to define struct \
        fields individually in Catala."

--- a/compiler/scopelang/dependency.ml
+++ b/compiler/scopelang/dependency.ml
@@ -120,8 +120,9 @@ let build_program_dep_graph (prgm : 'm Ast.program) : SDependencies.t =
         if VMap.mem (Topdef glo_name) used_defs then
           Message.error
             ~pos:(Mark.get (TopdefName.get_info glo_name))
-            "The Topdef %a has a definition that refers to itself, which is \
-             forbidden since Catala does not provide recursion"
+            "The toplevel declaration@ %a@ has@ a@ definition@ that@ refers@ \
+             to@ itself,@ which@ is@ not@ supported@ (Catala does not provide \
+             recursion)"
             TopdefName.format glo_name;
         VMap.fold
           (fun def pos g ->
@@ -138,8 +139,8 @@ let build_program_dep_graph (prgm : 'm Ast.program) : SDependencies.t =
           if VMap.mem (Scope scope_name) used_defs then
             Message.error
               ~pos:(Mark.get (ScopeName.get_info scope.Ast.scope_decl_name))
-              "The scope %a is calling into itself as a subscope, which is \
-               forbidden since Catala does not provide recursion"
+              "The scope@ %a@ is@ calling@ into@ itself@ as@ a@ subscope,@ \
+               which@ is@ not@ supported@ (Catala does not provide recursion)"
               ScopeName.format scope.Ast.scope_decl_name;
           VMap.fold
             (fun used_def pos g ->
@@ -192,8 +193,7 @@ let check_for_cycle_in_defs (g : SDependencies.t) : unit =
         (List.tl cycle @ [List.hd cycle])
     in
     Message.error ~extra_pos:spans
-      "@[<hov 2>Cyclic dependency detected between the following scopes:@ \
-       @[<hv>%a@]@]"
+      "Cyclic dependency detected between the following scopes:@ @[<hv>%a@]"
       (Format.pp_print_list
          ~pp_sep:(fun ppf () -> Format.fprintf ppf " →@ ")
          SVertex.format)
@@ -283,8 +283,8 @@ let build_type_graph (structs : struct_ctx) (enums : enum_ctx) : TDependencies.t
               (fun used g ->
                 if TVertex.equal used def then
                   Message.error ~pos:(Mark.get typ)
-                    "The type %a is defined using itself, which is forbidden \
-                     since Catala does not provide recursive types"
+                    "The type@ %a@ is@ defined@ using@ itself,@ which@ is@ \
+                     not@ supported@ (Catala does not allow recursive types)"
                     TVertex.format used
                 else
                   let edge = TDependencies.E.create used (Mark.get typ) def in
@@ -305,8 +305,8 @@ let build_type_graph (structs : struct_ctx) (enums : enum_ctx) : TDependencies.t
               (fun used g ->
                 if TVertex.equal used def then
                   Message.error ~pos:(Mark.get typ)
-                    "The type %a is defined using itself, which is forbidden \
-                     since Catala does not provide recursive types"
+                    "The type@ %a@ is@ defined@ using@ itself,@ which@ is@ \
+                     not@ supported@ (Catala does not allow recursive types)"
                     TVertex.format used
                 else
                   let edge = TDependencies.E.create used (Mark.get typ) def in

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -225,6 +225,7 @@ let rule_to_exception_graph (scope : D.scope) = function
                          ( "Incriminated subscope variable definition:",
                            Mark.get (RuleName.get_info rule) ))
                        (RuleName.Map.keys def))
+                "%a" Format.pp_print_text
                 "Invalid assignment to a subscope variable that is not tagged \
                  as input or context."
             | OnlyInput when RuleName.Map.is_empty def && not is_cond ->
@@ -237,6 +238,7 @@ let rule_to_exception_graph (scope : D.scope) = function
                       Mark.get (ScopeVar.get_info (Mark.remove sscope)) );
                     "Incriminated variable:", Mark.get sscope;
                   ]
+                "%a" Format.pp_print_text
                 "This subscope variable is a mandatory input but no definition \
                  was provided."
             | _ -> ()
@@ -261,8 +263,8 @@ let rule_to_exception_graph (scope : D.scope) = function
                  ( "Incriminated variable definition:",
                    Mark.get (RuleName.get_info rule) ))
                (RuleName.Map.keys var_def))
-        "It is impossible to give a definition to a scope variable tagged as \
-         input."
+        "%a" Format.pp_print_text
+        "There cannot be a definition for a scope variable tagged as input."
     | OnlyInput -> D.ScopeDef.Map.empty
     (* we do not provide any definition for an input-only variable *)
     | _ ->

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -264,9 +264,9 @@ let handle_type_error ctx (A.AnyExpr e) t1 t2 =
       ]
   in
   Message.error ~fmt_pos
-    "@[<v>Error during typechecking, incompatible types:@,\
+    "Error during typechecking, incompatible types:@\n\
      @[<v>@{<bold;blue>@<3>%s@} @[<hov>%a@]@,\
-     @{<bold;blue>@<3>%s@} @[<hov>%a@]@]@]" "┌─⯈" (format_typ ctx) t1 "└─⯈"
+     @{<bold;blue>@<3>%s@} @[<hov>%a@]@]" "┌─⯈" (format_typ ctx) t1 "└─⯈"
     (format_typ ctx) t2
 
 let lit_type (lit : A.lit) : naked_typ =
@@ -607,7 +607,7 @@ and typecheck_expr_top_down :
                   "", Expr.mark_pos context_mark;
                   "Structure definition", Mark.get (A.StructName.get_info name);
                 ]
-              "Field @{<yellow>\"%s\"@} does not belong to structure \
+              "Field@ @{<yellow>\"%s\"@}@ does@ not@ belong@ to@ structure@ \
                @{<yellow>\"%a\"@}."
               field A.StructName.format name
               ~suggestion:(A.Ident.Map.keys ctx.ctx_struct_fields))
@@ -616,8 +616,8 @@ and typecheck_expr_top_down :
       with A.StructName.Map.Not_found _ ->
         Message.error
           ~pos:(Expr.mark_pos context_mark)
-          "@[<hov>Field @{<yellow>\"%s\"@}@ does not belong to@ structure \
-           @{<yellow>\"%a\"@}@ (however, structure %a defines it)@]"
+          "Field@ @{<yellow>\"%s\"@}@ does@ not@ belong@ to@ structure@ \
+           @{<yellow>\"%a\"@}@ (however, structure@ %a@ defines@ it)@]"
           field A.StructName.format name
           (Format.pp_print_list
              ~pp_sep:(fun ppf () -> Format.fprintf ppf "@ or@ ")

--- a/tests/arithmetic/bad/division_by_zero.catala_en
+++ b/tests/arithmetic/bad/division_by_zero.catala_en
@@ -33,8 +33,7 @@ scope Money:
 
 ```catala-test-inline
 $ catala Interpret -s Dec
-[ERROR]
-division by zero at runtime
+[ERROR] division by zero at runtime
 
 The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.23-20.30:
@@ -58,8 +57,7 @@ The null denominator:
 Fixme: the following should give the same result as above, but the optimisation pass propagates the position surrounding the `ErrorOnEmpty` and loses the position of the actual division expression which was in the `cons` of the default term. Unfortunately this is non-trivial due to the bindlib boxing tricks.
 ```catala-test-inline
 $ catala Interpret -O -s Dec
-[ERROR]
-division by zero at runtime
+[ERROR] division by zero at runtime
 
 The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:17.10-17.11:
@@ -81,8 +79,7 @@ The null denominator:
 
 ```catala-test-inline
 $ catala interpret -s Int
-[ERROR]
-division by zero at runtime
+[ERROR] division by zero at runtime
 
 The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.23-10.28:
@@ -104,8 +101,7 @@ The null denominator:
 
 ```catala-test-inline
 $ catala Interpret -s Money
-[ERROR]
-division by zero at runtime
+[ERROR] division by zero at runtime
 
 The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.23-30.35:

--- a/tests/arithmetic/bad/logical_prio.catala_en
+++ b/tests/arithmetic/bad/logical_prio.catala_en
@@ -8,8 +8,8 @@ scope S1:
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Please add parentheses to explicit which of these operators should be applied first
+[ERROR] Please add parentheses to explicit which of these operators should be
+  applied first
 
 ┌─⯈ tests/arithmetic/bad/logical_prio.catala_en:6.28-6.31:
 └─┐

--- a/tests/array/bad/fold_error.catala_en
+++ b/tests/array/bad/fold_error.catala_en
@@ -12,9 +12,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-I don't know how to apply operator >= on types integer and
-money
+[ERROR] I don't know how to apply operator >= on types integer and money
 
 ┌─⯈ tests/array/bad/fold_error.catala_en:10.78-10.85:
 └──┐

--- a/tests/bool/bad/bad_assert.catala_en
+++ b/tests/bool/bad/bad_assert.catala_en
@@ -12,10 +12,9 @@ scope Foo:
 
 ```catala-test-inline
 $ catala test-scope Foo
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ integer
-└─⯈ bool
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ integer
+  └─⯈ bool
 
 While typechecking the following expression:
 ┌─⯈ tests/bool/bad/bad_assert.catala_en:9.13-9.14:

--- a/tests/bool/bad/test_xor_with_int.catala_en
+++ b/tests/bool/bad/test_xor_with_int.catala_en
@@ -10,10 +10,9 @@ scope TestXorWithInt:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ integer
-└─⯈ bool
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ integer
+  └─⯈ bool
 
 This expression has type integer:
 ┌─⯈ tests/bool/bad/test_xor_with_int.catala_en:8.30-8.32:

--- a/tests/date/bad/rounding_option_conflict.catala_en
+++ b/tests/date/bad/rounding_option_conflict.catala_en
@@ -25,8 +25,7 @@ scope Test:
 
 ```catala-test-inline
 $ catala test-scope Test
-[ERROR]
-You cannot set multiple date rounding modes
+[ERROR] You cannot set multiple date rounding modes
 
 ┌─⯈ tests/date/bad/rounding_option_conflict.catala_en:10.14-10.24:
 └──┐

--- a/tests/date/bad/substraction.catala_en
+++ b/tests/date/bad/substraction.catala_en
@@ -8,9 +8,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-I don't know how to apply operator <= on types date and
-duration
+[ERROR] I don't know how to apply operator <= on types date and duration
 
 ┌─⯈ tests/date/bad/substraction.catala_en:6.23-6.52:
 └─┐

--- a/tests/date/bad/uncomparable_duration.catala_en
+++ b/tests/date/bad/uncomparable_duration.catala_en
@@ -42,8 +42,8 @@ scope Ge:
 
 ```catala-test-inline
 $ catala test-scope Ge
-[ERROR]
-Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] Cannot compare together durations that cannot be converted to a
+  precise number of days
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.23-40.30:
 └──┐
@@ -63,8 +63,8 @@ Cannot compare together durations that cannot be converted to a precise number o
 
 ```catala-test-inline
 $ catala test-scope Gt
-[ERROR]
-Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] Cannot compare together durations that cannot be converted to a
+  precise number of days
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.23-30.30:
 └──┐
@@ -84,8 +84,8 @@ Cannot compare together durations that cannot be converted to a precise number o
 
 ```catala-test-inline
 $ catala test-scope Le
-[ERROR]
-Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] Cannot compare together durations that cannot be converted to a
+  precise number of days
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.23-20.30:
 └──┐
@@ -105,8 +105,8 @@ Cannot compare together durations that cannot be converted to a precise number o
 
 ```catala-test-inline
 $ catala test-scope Lt
-[ERROR]
-Cannot compare together durations that cannot be converted to a precise number of days
+[ERROR] Cannot compare together durations that cannot be converted to a
+  precise number of days
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.23-10.30:
 └──┐

--- a/tests/default/bad/empty.catala_en
+++ b/tests/default/bad/empty.catala_en
@@ -11,15 +11,16 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] In scope "A", the variable "y" is declared but never defined; did you forget something?
+[WARNING] In scope "A", the variable "y" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/default/bad/empty.catala_en:6.10-6.11:
 └─┐
 6 │   output y content boolean
   │          ‾
   └─ Article
-[ERROR]
-This variable evaluated to an empty term (no rule that defined it applied in this situation)
+[ERROR] This variable evaluated to an empty term (no rule that defined it
+  applied in this situation)
 
 ┌─⯈ tests/default/bad/empty.catala_en:6.10-6.11:
 └─┐

--- a/tests/default/bad/empty_with_rules.catala_en
+++ b/tests/default/bad/empty_with_rules.catala_en
@@ -14,8 +14,8 @@ scope A:
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR]
-This variable evaluated to an empty term (no rule that defined it applied in this situation)
+[ERROR] This variable evaluated to an empty term (no rule that defined it
+  applied in this situation)
 
 ┌─⯈ tests/default/bad/empty_with_rules.catala_en:5.10-5.11:
 └─┐

--- a/tests/default/bad/typing_or_logical_error.catala_en
+++ b/tests/default/bad/typing_or_logical_error.catala_en
@@ -11,22 +11,13 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Syntax error at token "="
-Message: expected 'under condition' followed by a condition, 'equals' followed by the definition body, or the rest of the variable qualified name
-You could have written : "of",
-or "state",
-or "equals",
-or "under condition",
-or "."
+[ERROR] Syntax error at "="
+  » expected 'under condition' followed by a condition, 'equals' followed by
+    the definition body, or the rest of the variable qualified name
+  Those are valid at this point: "of", "state", "equals", "under condition",
+  "."
 
-Error token:
-┌─⯈ tests/default/bad/typing_or_logical_error.catala_en:8.30-8.31:
-└─┐
-8 │  definition wrong_definition = 1
-  │                              ‾
-
-Last good token:
+Last good token
 ┌─⯈ tests/default/bad/typing_or_logical_error.catala_en:8.13-8.29:
 └─┐
 8 │  definition wrong_definition = 1

--- a/tests/default/good/mutliple_definitions.catala_en
+++ b/tests/default/good/mutliple_definitions.catala_en
@@ -13,7 +13,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] These definitions have identical justifications and consequences; is it a mistake?
+[WARNING] These definitions have identical justifications and consequences;
+  is it a mistake?
 
 ┌─⯈ tests/default/good/mutliple_definitions.catala_en:9.3-9.15:
 └─┐
@@ -30,7 +31,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] These definitions have identical justifications and consequences; is it a mistake?
+[WARNING] These definitions have identical justifications and consequences;
+  is it a mistake?
 
 ┌─⯈ tests/default/good/mutliple_definitions.catala_en:9.3-9.15:
 └─┐

--- a/tests/enum/bad/ambiguous_cases.catala_en
+++ b/tests/enum/bad/ambiguous_cases.catala_en
@@ -16,8 +16,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-This constructor name is ambiguous, it can belong to E or F. Desambiguate it by prefixing it with the enum name.
+[ERROR] This constructor name is ambiguous, it can belong to E or F.
+  Disambiguate it by prefixing it with the enum name.
 
 ┌─⯈ tests/enum/bad/ambiguous_cases.catala_en:14.23-14.28:
 └──┐

--- a/tests/enum/bad/ambiguous_wildcard.catala_en
+++ b/tests/enum/bad/ambiguous_wildcard.catala_en
@@ -17,8 +17,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Couldn't infer the enumeration name from lonely wildcard (wildcard cannot be used as single match case)
+[ERROR] Couldn't infer the enumeration name from lonely wildcard (wildcard
+  cannot be used as single match case)
 
 ┌─⯈ tests/enum/bad/ambiguous_wildcard.catala_en:15.5-15.21:
 └──┐

--- a/tests/enum/bad/duplicate_case.catala_en
+++ b/tests/enum/bad/duplicate_case.catala_en
@@ -20,8 +20,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-The constructor Case3 has been matched twice:
+[ERROR] The constructor Case3 has been matched twice:
 
 ┌─⯈ tests/enum/bad/duplicate_case.catala_en:18.16-18.20:
 └──┐

--- a/tests/enum/bad/empty.catala_en
+++ b/tests/enum/bad/empty.catala_en
@@ -9,8 +9,8 @@ declaration scope Bar:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-The enum Foo does not have any cases; give it some for Catala to be able to accept it.
+[ERROR] The enum Foo does not have any cases;
+  give it some for Catala to be able to accept it.
 
 ┌─⯈ tests/enum/bad/empty.catala_en:4.25-4.28:
 └─┐

--- a/tests/enum/bad/missing_case.catala_en
+++ b/tests/enum/bad/missing_case.catala_en
@@ -18,15 +18,15 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] The constructor "Case3" of enumeration "E" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Case3" of enumeration "E" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/enum/bad/missing_case.catala_en:7.6-7.11:
 └─┐
 7 │   -- Case3
   │      ‾‾‾‾‾
   └─ Article
-[ERROR]
-The constructor Case3 of enum E is missing from this pattern matching
+[ERROR] The constructor Case3 of enum E is missing from this pattern matching
 
 ┌─⯈ tests/enum/bad/missing_case.catala_en:14.25-16.22:
 └──┐

--- a/tests/enum/bad/not_ending_wildcard.catala_en
+++ b/tests/enum/bad/not_ending_wildcard.catala_en
@@ -38,8 +38,7 @@ scope Middle_case:
 
 ```catala-test-inline
 $ catala test-scope First_case
-[ERROR]
-Wildcard must be the last match case
+[ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
 ┌─⯈ tests/enum/bad/not_ending_wildcard.catala_en:19.5-19.21:
@@ -61,8 +60,7 @@ Next reachable case:
 
 ```catala-test-inline
 $ catala test-scope Middle_case
-[ERROR]
-Wildcard must be the last match case
+[ERROR] Wildcard must be the last match case
 
 Not ending wildcard:
 ┌─⯈ tests/enum/bad/not_ending_wildcard.catala_en:19.5-19.21:

--- a/tests/enum/bad/quick_pattern_2.catala_en
+++ b/tests/enum/bad/quick_pattern_2.catala_en
@@ -30,10 +30,9 @@ scope B:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ E
-└─⯈ F
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ E
+  └─⯈ F
 
 While typechecking the following expression:
 ┌─⯈ tests/enum/bad/quick_pattern_2.catala_en:28.23-28.24:

--- a/tests/enum/bad/quick_pattern_3.catala_en
+++ b/tests/enum/bad/quick_pattern_3.catala_en
@@ -20,10 +20,9 @@ definition y equals x with pattern Case3
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ E
-└─⯈ F
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ E
+  └─⯈ F
 
 While typechecking the following expression:
 ┌─⯈ tests/enum/bad/quick_pattern_3.catala_en:18.21-18.22:

--- a/tests/enum/bad/quick_pattern_4.catala_en
+++ b/tests/enum/bad/quick_pattern_4.catala_en
@@ -19,10 +19,9 @@ definition y equals x with pattern Case3
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ E
-└─⯈ F
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ E
+  └─⯈ F
 
 While typechecking the following expression:
 ┌─⯈ tests/enum/bad/quick_pattern_4.catala_en:17.21-17.22:

--- a/tests/enum/bad/quick_pattern_fail.catala_en
+++ b/tests/enum/bad/quick_pattern_fail.catala_en
@@ -17,9 +17,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-The name of this constructor has not been defined before
-(it's probably a typographical error).
+[ERROR] The name of this constructor has not been defined before
+  (it's probably a typographical error).
 
 Here is your code :
 ┌─⯈ tests/enum/bad/quick_pattern_fail.catala_en:15.38-15.43:

--- a/tests/enum/bad/too_many_cases.catala_en
+++ b/tests/enum/bad/too_many_cases.catala_en
@@ -23,8 +23,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-This case matches a constructor of enumeration E but previous case were matching constructors of enumeration F
+[ERROR] This case matches a constructor of enumeration E but previous cases
+  were matching constructors of enumeration F
 
 ┌─⯈ tests/enum/bad/too_many_cases.catala_en:21.8-21.13:
 └──┐

--- a/tests/enum/bad/useless_wildcard.catala_en
+++ b/tests/enum/bad/useless_wildcard.catala_en
@@ -19,7 +19,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] Unreachable match case, all constructors of the enumeration E are already specified
+[WARNING] Unreachable match case, all constructors of the enumeration E are
+  already specified
 
 ┌─⯈ tests/enum/bad/useless_wildcard.catala_en:17.5-17.21:
 └──┐

--- a/tests/enum/bad/wrong_cons.catala_en
+++ b/tests/enum/bad/wrong_cons.catala_en
@@ -13,9 +13,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-The name of this constructor has not been defined before
-(it's probably a typographical error).
+[ERROR] The name of this constructor has not been defined before
+  (it's probably a typographical error).
 
 Here is your code :
 ┌─⯈ tests/enum/bad/wrong_cons.catala_en:11.23-11.28:

--- a/tests/exception/bad/ambiguous_unlabeled_exception.catala_en
+++ b/tests/exception/bad/ambiguous_unlabeled_exception.catala_en
@@ -15,8 +15,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-This exception can refer to several definitions. Try using labels to disambiguate
+[ERROR] This exception can refer to several definitions. Try using labels to
+  disambiguate
 
 Ambiguous exception
 ┌─⯈ tests/exception/bad/ambiguous_unlabeled_exception.catala_en:12.3-13.15:

--- a/tests/exception/bad/dangling_exception.catala_en
+++ b/tests/exception/bad/dangling_exception.catala_en
@@ -15,8 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Unknown label for the scope variable x: "base_y"
+[ERROR] Unknown label for the scope variable x: "base_y"
 
 ┌─⯈ tests/exception/bad/dangling_exception.catala_en:12.13-12.19:
 └──┐

--- a/tests/exception/bad/exceptions_cycle.catala_en
+++ b/tests/exception/bad/exceptions_cycle.catala_en
@@ -20,8 +20,9 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Exception cycle detected when defining x: each of these 3 exceptions applies over the previous one, and the first applies over the last
+[ERROR] Exception cycle detected when defining x:
+  each of these 3 exceptions applies over the previous one, and the first
+  applies over the last
 
 ┌─⯈ tests/exception/bad/exceptions_cycle.catala_en:8.3-10.15:
 └──┐

--- a/tests/exception/bad/missing_unlabeled_definition.catala_en
+++ b/tests/exception/bad/missing_unlabeled_definition.catala_en
@@ -11,8 +11,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-This exception does not have a corresponding definition
+[ERROR] This exception does not have a corresponding definition
 
 ┌─⯈ tests/exception/bad/missing_unlabeled_definition.catala_en:8.3-9.15:
 └─┐

--- a/tests/exception/bad/one_ambiguous_exception.catala_en
+++ b/tests/exception/bad/one_ambiguous_exception.catala_en
@@ -21,8 +21,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-This exception can refer to several definitions. Try using labels to disambiguate
+[ERROR] This exception can refer to several definitions. Try using labels to
+  disambiguate
 
 Ambiguous exception
 ┌─⯈ tests/exception/bad/one_ambiguous_exception.catala_en:18.3-19.15:

--- a/tests/exception/bad/self_exception.catala_en
+++ b/tests/exception/bad/self_exception.catala_en
@@ -12,8 +12,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Cannot define rule as an exception to itself
+[ERROR] Cannot define rule as an exception to itself
 
 ┌─⯈ tests/exception/bad/self_exception.catala_en:9.13-9.19:
 └─┐

--- a/tests/exception/bad/two_exceptions.catala_en
+++ b/tests/exception/bad/two_exceptions.catala_en
@@ -19,8 +19,8 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR]
-There is a conflict between multiple valid consequences for assigning the same variable.
+[ERROR] There is a conflict between multiple valid consequences for assigning
+  the same variable.
 
 This consequence has a valid justification:
 ┌─⯈ tests/exception/bad/two_exceptions.catala_en:12.23-12.24:

--- a/tests/exception/good/double_definition.catala_en
+++ b/tests/exception/good/double_definition.catala_en
@@ -14,7 +14,8 @@ scope Foo:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] These definitions have identical justifications and consequences; is it a mistake?
+[WARNING] These definitions have identical justifications and consequences;
+  is it a mistake?
 
 ┌─⯈ tests/exception/good/double_definition.catala_en:9.3-9.15:
 └─┐
@@ -33,7 +34,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Scopelang -s Foo
-[WARNING] These definitions have identical justifications and consequences; is it a mistake?
+[WARNING] These definitions have identical justifications and consequences;
+  is it a mistake?
 
 ┌─⯈ tests/exception/good/double_definition.catala_en:9.3-9.15:
 └─┐
@@ -58,7 +60,8 @@ Dcalc translation below.
 
 ```catala-test-inline
 $ catala Dcalc -s Foo
-[WARNING] These definitions have identical justifications and consequences; is it a mistake?
+[WARNING] These definitions have identical justifications and consequences;
+  is it a mistake?
 
 ┌─⯈ tests/exception/good/double_definition.catala_en:9.3-9.15:
 └─┐

--- a/tests/func/bad/bad_func.catala_en
+++ b/tests/func/bad/bad_func.catala_en
@@ -31,8 +31,8 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s S
-[ERROR]
-There is a conflict between multiple valid consequences for assigning the same variable.
+[ERROR] There is a conflict between multiple valid consequences for assigning
+  the same variable.
 
 This consequence has a valid justification:
 ┌─⯈ tests/func/bad/bad_func.catala_en:14.65-14.70:

--- a/tests/func/bad/param_inconsistency.catala_en
+++ b/tests/func/bad/param_inconsistency.catala_en
@@ -14,8 +14,8 @@ scope S:
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Function argument name mismatch between declaration ('x') and definition ('y')
+[ERROR] Function argument name mismatch between declaration ('x') and
+  definition ('y')
 
 Argument declared here:
 ┌─⯈ tests/func/bad/param_inconsistency.catala_en:4.42-4.43:

--- a/tests/func/bad/param_inconsistency2.catala_en
+++ b/tests/func/bad/param_inconsistency2.catala_en
@@ -13,8 +13,8 @@ scope S:
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Function argument name mismatch between declaration ('x') and definition ('y')
+[ERROR] Function argument name mismatch between declaration ('x') and
+  definition ('y')
 
 Argument declared here:
 ┌─⯈ tests/func/bad/param_inconsistency2.catala_en:4.42-4.43:

--- a/tests/func/bad/param_inconsistency3.catala_en
+++ b/tests/func/bad/param_inconsistency3.catala_en
@@ -13,8 +13,8 @@ scope S:
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Function argument name mismatch between declaration ('x') and definition ('y')
+[ERROR] Function argument name mismatch between declaration ('x') and
+  definition ('y')
 
 Argument declared here:
 ┌─⯈ tests/func/bad/param_inconsistency3.catala_en:4.42-4.43:

--- a/tests/func/bad/recursive.catala_en
+++ b/tests/func/bad/recursive.catala_en
@@ -10,8 +10,8 @@ scope RecursiveFunc:
 
 ```catala-test-inline
 $ catala test-scope RecursiveFunc
-[ERROR]
-The variable f is used in one of its definitions, but recursion is forbidden in Catala
+[ERROR] The variable f is used in one of its definitions
+  (Catala doesn't support recursion)
 
 ┌─⯈ tests/func/bad/recursive.catala_en:8.28-8.29:
 └─┐

--- a/tests/func/good/context_func.catala_en
+++ b/tests/func/good/context_func.catala_en
@@ -19,7 +19,8 @@ scope B:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] Unused varible: a does not contribute to computing any of scope B outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope B
+  outputs. Did you forget something?
 
 ┌─⯈ tests/func/good/context_func.catala_en:9.3-9.4:
 └─┐
@@ -32,7 +33,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Scopelang -s B
-[WARNING] Unused varible: a does not contribute to computing any of scope B outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope B
+  outputs. Did you forget something?
 
 ┌─⯈ tests/func/good/context_func.catala_en:9.3-9.4:
 └─┐
@@ -46,7 +48,8 @@ let scope B (b: bool|input) (a: A {f: integer → integer}|internal) =
 
 ```catala-test-inline
 $ catala Dcalc -s A
-[WARNING] Unused varible: a does not contribute to computing any of scope B outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope B
+  outputs. Did you forget something?
 
 ┌─⯈ tests/func/good/context_func.catala_en:9.3-9.4:
 └─┐
@@ -68,7 +71,8 @@ let scope A
 
 ```catala-test-inline
 $ catala Dcalc -s B
-[WARNING] Unused varible: a does not contribute to computing any of scope B outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope B
+  outputs. Did you forget something?
 
 ┌─⯈ tests/func/good/context_func.catala_en:9.3-9.4:
 └─┐

--- a/tests/io/bad/forgot_input.catala_en
+++ b/tests/io/bad/forgot_input.catala_en
@@ -16,8 +16,8 @@ scope B:
 ```
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-This subscope variable is a mandatory input but no definition was provided.
+[ERROR] This subscope variable is a mandatory input but no definition was
+  provided.
 
 Incriminated subscope:
 ┌─⯈ tests/io/bad/forgot_input.catala_en:9.3-9.4:

--- a/tests/io/bad/inputing_to_not_input.catala_en
+++ b/tests/io/bad/inputing_to_not_input.catala_en
@@ -16,8 +16,8 @@ scope B:
 ```
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-Invalid assignment to a subscope variable that is not tagged as input or context.
+[ERROR] Invalid assignment to a subscope variable that is not tagged as input
+  or context.
 
 Incriminated subscope:
 ┌─⯈ tests/io/bad/inputing_to_not_input.catala_en:8.3-8.4:

--- a/tests/io/bad/redefining_input.catala_en
+++ b/tests/io/bad/redefining_input.catala_en
@@ -9,8 +9,7 @@ scope A:
 ```
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-It is impossible to give a definition to a scope variable tagged as input.
+[ERROR] There cannot be a definition for a scope variable tagged as input.
 
 Incriminated variable:
 ┌─⯈ tests/io/bad/redefining_input.catala_en:5.16-5.17:

--- a/tests/io/bad/using_non_output.catala_en
+++ b/tests/io/bad/using_non_output.catala_en
@@ -15,8 +15,7 @@ scope B:
 ```
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-Variable a is not a declared output of scope A.
+[ERROR] Variable a is not a declared output of scope A.
 
 a is used here as an output
 ┌─⯈ tests/io/bad/using_non_output.catala_en:14.13-14.16:

--- a/tests/modules/bad/mod_bad_include.catala_en
+++ b/tests/modules/bad/mod_bad_include.catala_en
@@ -3,8 +3,9 @@
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-A file that declares a module cannot be used through the raw '> Include' directive. You should use it as a module with '> Use This_is_not_the_file_name' instead.
+[ERROR] A file that declares a module cannot be used through the raw '> Include'
+  directive. You should use it as a module with
+  '> Use This_is_not_the_file_name' instead.
 
 File include
 ┌─⯈ tests/modules/bad/mod_bad_include.catala_en:1.3-1.33:

--- a/tests/modules/bad/mod_badname.catala_en
+++ b/tests/modules/bad/mod_badname.catala_en
@@ -3,11 +3,10 @@
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Module declared as This_is_not_the_file_name, which does not match the file
-name "tests/modules/bad/mod_badname.catala_en". Rename the module to
-Mod_badname or the file to
-"tests/modules/bad/This_is_not_the_file_name.catala_en".
+[ERROR] Module declared as This_is_not_the_file_name, which does not match
+  the file name "tests/modules/bad/mod_badname.catala_en".
+  Rename the module to Mod_badname or the file to
+  "tests/modules/bad/This_is_not_the_file_name.catala_en".
 
 ┌─⯈ tests/modules/bad/mod_badname.catala_en:1.10-1.35:
 └─┐

--- a/tests/money/bad/no_mingle.catala_en
+++ b/tests/money/bad/no_mingle.catala_en
@@ -14,9 +14,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-I don't know how to apply operator * on types money and
-money
+[ERROR] I don't know how to apply operator * on types money and money
 
 ┌─⯈ tests/money/bad/no_mingle.catala_en:12.24-12.29:
 └──┐

--- a/tests/name_resolution/bad/toplevel_defs.catala_en
+++ b/tests/name_resolution/bad/toplevel_defs.catala_en
@@ -13,8 +13,7 @@ declaration glob5 content decimal
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Scope calls are not allowed outside of a scope
+[ERROR] Scope calls are not allowed outside of a scope
 
 ┌─⯈ tests/name_resolution/bad/toplevel_defs.catala_en:11.11-11.23:
 └──┐

--- a/tests/name_resolution/good/let_in.catala_en
+++ b/tests/name_resolution/good/let_in.catala_en
@@ -55,7 +55,8 @@ scope S2:
 
 ```catala-test-inline
 $ catala test-scope S2
-[WARNING] Unused varible: x does not contribute to computing any of scope S2 outputs. Did you forget something?
+[WARNING] Unused varible: x does not contribute to computing any of scope S2
+  outputs. Did you forget something?
 
 ┌─⯈ tests/name_resolution/good/let_in.catala_en:47.4-47.5:
 └──┐

--- a/tests/proof/bad/dates_get_year-empty.catala_en
+++ b/tests/proof/bad/dates_get_year-empty.catala_en
@@ -15,8 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[ERROR]
-It is impossible to give a definition to a scope variable tagged as input.
+[ERROR] There cannot be a definition for a scope variable tagged as input.
 
 Incriminated variable:
 ┌─⯈ tests/proof/bad/dates_get_year-empty.catala_en:5.9-5.10:

--- a/tests/proof/bad/enums-empty.catala_en
+++ b/tests/proof/bad/enums-empty.catala_en
@@ -23,7 +23,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/bad/enums-empty.catala_en:7.7-7.8:
 └─┐

--- a/tests/proof/bad/enums-nonbool-empty.catala_en
+++ b/tests/proof/bad/enums-nonbool-empty.catala_en
@@ -21,7 +21,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/bad/enums-nonbool-empty.catala_en:5.7-5.8:
 └─┐

--- a/tests/proof/bad/enums-nonbool-overlap.catala_en
+++ b/tests/proof/bad/enums-nonbool-overlap.catala_en
@@ -21,7 +21,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/bad/enums-nonbool-overlap.catala_en:5.7-5.8:
 └─┐

--- a/tests/proof/bad/enums-overlap.catala_en
+++ b/tests/proof/bad/enums-overlap.catala_en
@@ -23,7 +23,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/bad/enums-overlap.catala_en:7.7-7.8:
 └─┐

--- a/tests/proof/bad/enums_inj-empty.catala_en
+++ b/tests/proof/bad/enums_inj-empty.catala_en
@@ -16,7 +16,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[WARNING] The constructor "C2" of enumeration "E" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C2" of enumeration "E" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/bad/enums_inj-empty.catala_en:6.6-6.8:
 └─┐

--- a/tests/proof/bad/prolala_motivating_example.catala_en
+++ b/tests/proof/bad/prolala_motivating_example.catala_en
@@ -123,8 +123,8 @@ scope Amount:
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[ERROR]
-Invalid assignment to a subscope variable that is not tagged as input or context.
+[ERROR] Invalid assignment to a subscope variable that is not tagged as input
+  or context.
 
 Incriminated subscope:
 ┌─⯈ tests/proof/bad/prolala_motivating_example.catala_en:56.3-56.14:

--- a/tests/proof/good/enums-arith.catala_en
+++ b/tests/proof/good/enums-arith.catala_en
@@ -23,7 +23,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums-arith.catala_en:5.7-5.8:
 └─┐
@@ -36,7 +37,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums-arith.catala_en:5.7-5.8:
 └─┐

--- a/tests/proof/good/enums-nonbool.catala_en
+++ b/tests/proof/good/enums-nonbool.catala_en
@@ -23,7 +23,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums-nonbool.catala_en:5.7-5.8:
 └─┐
@@ -36,7 +37,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums-nonbool.catala_en:5.7-5.8:
 └─┐

--- a/tests/proof/good/enums.catala_en
+++ b/tests/proof/good/enums.catala_en
@@ -22,7 +22,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums.catala_en:5.7-5.8:
 └─┐
@@ -35,7 +36,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Proof --disable-counterexamples 
-[WARNING] The constructor "C" of enumeration "T" is never used; maybe it's unnecessary?
+[WARNING] The constructor "C" of enumeration "T" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/proof/good/enums.catala_en:5.7-5.8:
 └─┐

--- a/tests/scope/bad/cycle_in_scope.catala_en
+++ b/tests/scope/bad/cycle_in_scope.catala_en
@@ -16,8 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Cyclic dependency detected between the following variables of scope A:
+[ERROR] Cyclic dependency detected between the following variables of scope A:
   z → x → y → z
 
 z is used here in the definition of x:

--- a/tests/scope/bad/cyclic_scope_calls.catala_en
+++ b/tests/scope/bad/cyclic_scope_calls.catala_en
@@ -28,8 +28,7 @@ scope S4:
 
 ```catala-test-inline
 $ catala typecheck
-[ERROR]
-Cyclic dependency detected between the following scopes:
+[ERROR] Cyclic dependency detected between the following scopes:
   S4 → S3 → S2 → S4
 
 S4 is used here in the definition of S3:

--- a/tests/scope/bad/cyclic_scopes.catala_en
+++ b/tests/scope/bad/cyclic_scopes.catala_en
@@ -18,8 +18,8 @@ scope B:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Cyclic dependency detected between the following scopes: B → A → B
+[ERROR] Cyclic dependency detected between the following scopes:
+  B → A → B
 
 B is used here in the definition of A:
 ┌─⯈ tests/scope/bad/cyclic_scopes.catala_en:5.3-5.4:

--- a/tests/scope/bad/scope.catala_en
+++ b/tests/scope/bad/scope.catala_en
@@ -18,8 +18,8 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR]
-There is a conflict between multiple valid consequences for assigning the same variable.
+[ERROR] There is a conflict between multiple valid consequences for assigning
+  the same variable.
 
 This consequence has a valid justification:
 ┌─⯈ tests/scope/bad/scope.catala_en:13.57-13.61:

--- a/tests/scope/bad/scope_call_duplicate.catala_en
+++ b/tests/scope/bad/scope_call_duplicate.catala_en
@@ -16,8 +16,7 @@ scope Titi:
 
 ```catala-test-inline
 $ catala dcalc -s Titi
-[ERROR]
-Duplicate definition of scope input variable 'bar'
+[ERROR] Duplicate definition of scope input variable 'bar'
 
 ┌─⯈ tests/scope/bad/scope_call_duplicate.catala_en:14.70-14.73:
 └──┐

--- a/tests/scope/bad/scope_call_extra.catala_en
+++ b/tests/scope/bad/scope_call_extra.catala_en
@@ -16,8 +16,7 @@ scope Titi:
 
 ```catala-test-inline
 $ catala dcalc -s Titi
-[ERROR]
-Scope Toto has no input variable biz
+[ERROR] Scope Toto has no input variable biz
 
 ┌─⯈ tests/scope/bad/scope_call_extra.catala_en:14.49-14.52:
 └──┐

--- a/tests/scope/bad/scope_call_missing.catala_en
+++ b/tests/scope/bad/scope_call_missing.catala_en
@@ -16,8 +16,7 @@ scope Titi:
 
 ```catala-test-inline
 $ catala dcalc -s Titi
-[ERROR]
-Definition of input variable 'baz' missing in this scope call
+[ERROR] Definition of input variable 'baz' missing in this scope call
 
 ┌─⯈ tests/scope/bad/scope_call_missing.catala_en:14.26-14.57:
 └──┐

--- a/tests/scope/bad/sub_vars_in_sub_var.catala_en
+++ b/tests/scope/bad/sub_vars_in_sub_var.catala_en
@@ -15,8 +15,8 @@ scope B:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-The subscope a is used in the definition of its own input a.y, but recursion is forbidden in Catala
+[ERROR] The subscope a is used in the definition of its own input a.y
+  (Catala doesn't support recursion)
 
 ┌─⯈ tests/scope/bad/sub_vars_in_sub_var.catala_en:13.28-13.29:
 └──┐

--- a/tests/scope/good/local-capture-subscope.catala_en
+++ b/tests/scope/good/local-capture-subscope.catala_en
@@ -20,7 +20,8 @@ scope S:
 
 ```catala-test-inline
 $ catala test-scope S
-[WARNING] Unused varible: a does not contribute to computing any of scope S outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope S
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/local-capture-subscope.catala_en:7.3-7.4:
 └─┐

--- a/tests/scope/good/nothing.catala_en
+++ b/tests/scope/good/nothing.catala_en
@@ -9,7 +9,8 @@ declaration scope Foo2:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] In scope "Foo2", the variable "bar" is declared but never defined; did you forget something?
+[WARNING] In scope "Foo2", the variable "bar" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/scope/good/nothing.catala_en:5.10-5.13:
 └─┐
@@ -22,7 +23,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Scalc -s Foo2 -O -t
-[WARNING] In scope "Foo2", the variable "bar" is declared but never defined; did you forget something?
+[WARNING] In scope "Foo2", the variable "bar" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/scope/good/nothing.catala_en:5.10-5.13:
 └─┐

--- a/tests/scope/good/scope_call2.catala_en
+++ b/tests/scope/good/scope_call2.catala_en
@@ -22,7 +22,8 @@ scope Titi:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] Unused varible: toto does not contribute to computing any of scope Titi outputs. Did you forget something?
+[WARNING] Unused varible: toto does not contribute to computing any of scope
+  Titi outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/scope_call2.catala_en:13.3-13.7:
 └──┐
@@ -34,7 +35,8 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala test-scope Titi
-[WARNING] Unused varible: toto does not contribute to computing any of scope Titi outputs. Did you forget something?
+[WARNING] Unused varible: toto does not contribute to computing any of scope
+  Titi outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/scope_call2.catala_en:13.3-13.7:
 └──┐

--- a/tests/scope/good/sub_sub_scope.catala_en
+++ b/tests/scope/good/sub_sub_scope.catala_en
@@ -34,14 +34,16 @@ scope C:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] Unused varible: a does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 └──┐
 14 │   a scope A
    │   ‾
    └─ Article
-[WARNING] Unused varible: b does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: b does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 └──┐
@@ -54,14 +56,16 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] Unused varible: a does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 └──┐
 14 │   a scope A
    │   ‾
    └─ Article
-[WARNING] Unused varible: b does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: b does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 └──┐
@@ -75,14 +79,16 @@ $ catala test-scope A
 
 ```catala-test-inline
 $ catala test-scope B
-[WARNING] Unused varible: a does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 └──┐
 14 │   a scope A
    │   ‾
    └─ Article
-[WARNING] Unused varible: b does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: b does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 └──┐
@@ -95,14 +101,16 @@ $ catala test-scope B
 
 ```catala-test-inline
 $ catala test-scope C
-[WARNING] Unused varible: a does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: a does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 └──┐
 14 │   a scope A
    │   ‾
    └─ Article
-[WARNING] Unused varible: b does not contribute to computing any of scope C outputs. Did you forget something?
+[WARNING] Unused varible: b does not contribute to computing any of scope C
+  outputs. Did you forget something?
 
 ┌─⯈ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 └──┐

--- a/tests/struct/bad/bug_107.catala_en
+++ b/tests/struct/bad/bug_107.catala_en
@@ -18,8 +18,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-struct name "S" already defined
+[ERROR] struct name "S" already defined
 
 First definition:
 ┌─⯈ tests/struct/bad/bug_107.catala_en:4.23-4.24:

--- a/tests/struct/bad/empty_struct.catala_en
+++ b/tests/struct/bad/empty_struct.catala_en
@@ -9,8 +9,8 @@ declaration scope Bar:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-The struct Foo does not have any fields; give it some for Catala to be able to accept it.
+[ERROR] The struct Foo does not have any fields;
+  give it some for Catala to be able to accept it.
 
 ┌─⯈ tests/struct/bad/empty_struct.catala_en:4.23-4.26:
 └─┐

--- a/tests/struct/bad/nested.catala_en
+++ b/tests/struct/bad/nested.catala_en
@@ -14,15 +14,16 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] The constructor "Rec" of enumeration "E" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Rec" of enumeration "E" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/struct/bad/nested.catala_en:6.6-6.9:
 └─┐
 6 │   -- Rec content E
   │      ‾‾‾
   └─ Article
-[ERROR]
-The type E is defined using itself, which is forbidden since Catala does not provide recursive types
+[ERROR] The type E is defined using itself, which is not supported
+  (Catala does not allow recursive types)
 
 ┌─⯈ tests/struct/bad/nested.catala_en:6.18-6.19:
 └─┐

--- a/tests/struct/bad/nested2.catala_en
+++ b/tests/struct/bad/nested2.catala_en
@@ -15,7 +15,8 @@ declaration scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[WARNING] In scope "A", the variable "x" is declared but never defined; did you forget something?
+[WARNING] In scope "A", the variable "x" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/struct/bad/nested2.catala_en:13.10-13.11:
 └──┐
@@ -36,8 +37,7 @@ $ catala test-scope A
 8 │ declaration enumeration E:
   │                         ‾
   └─ Article
-[ERROR]
-Cyclic dependency detected between types!
+[ERROR] Cyclic dependency detected between types!
 
 Cycle type S, declared:
 ┌─⯈ tests/struct/bad/nested2.catala_en:4.23-4.24:

--- a/tests/struct/bad/nonexisting_struct.catala_en
+++ b/tests/struct/bad/nonexisting_struct.catala_en
@@ -15,8 +15,7 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-No struct named Fo found
+[ERROR] No struct named Fo found
 
 ┌─⯈ tests/struct/bad/nonexisting_struct.catala_en:13.25-13.27:
 └──┐

--- a/tests/struct/bad/wrong_qualified_field.catala_en
+++ b/tests/struct/bad/wrong_qualified_field.catala_en
@@ -19,10 +19,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR]
-Field "g" does not belong to structure "Foo"
-(however, structure "Bar" defines it)
-
+[ERROR] Field "g" does not belong to structure "Foo" (however, structure
+  "Bar" defines it)
 ┌─⯈ tests/struct/bad/wrong_qualified_field.catala_en:17.23-17.30:
 └──┐
 17 │   definition y equals x.Foo.g

--- a/tests/typing/bad/err1.catala_en
+++ b/tests/typing/bad/err1.catala_en
@@ -12,10 +12,9 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ decimal
-└─⯈ integer
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ decimal
+  └─⯈ integer
 
 This expression has type decimal:
 ┌─⯈ tests/typing/bad/err1.catala_en:7.23-7.26:

--- a/tests/typing/bad/err2.catala_en
+++ b/tests/typing/bad/err2.catala_en
@@ -12,10 +12,9 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ decimal
-└─⯈ list
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ decimal
+  └─⯈ list
 
 This expression has type decimal:
 ┌─⯈ tests/typing/bad/err2.catala_en:10.39-10.42:

--- a/tests/typing/bad/err3.catala_en
+++ b/tests/typing/bad/err3.catala_en
@@ -12,16 +12,16 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck
-[WARNING] The constructor "Dec" of enumeration "Enum" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Dec" of enumeration "Enum" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/typing/bad/common.catala_en:4.6-4.9:
 └─┐
 4 │   -- Dec content decimal
   │      ‾‾‾
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ integer
-└─⯈ decimal
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ integer
+  └─⯈ decimal
 
 This expression has type integer:
 ┌─⯈ tests/typing/bad/err3.catala_en:10.23-10.45:
@@ -41,16 +41,16 @@ Re-putting the same check again, to ensure that the `Typecheck` and `ocaml` subc
 
 ```catala-test-inline
 $ catala ocaml
-[WARNING] The constructor "Dec" of enumeration "Enum" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Dec" of enumeration "Enum" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/typing/bad/common.catala_en:4.6-4.9:
 └─┐
 4 │   -- Dec content decimal
   │      ‾‾‾
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ integer
-└─⯈ decimal
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ integer
+  └─⯈ decimal
 
 This expression has type integer:
 ┌─⯈ tests/typing/bad/err3.catala_en:10.23-10.45:

--- a/tests/typing/bad/err4.catala_en
+++ b/tests/typing/bad/err4.catala_en
@@ -16,22 +16,23 @@ $ catala ocaml
 └─┐
 7 │ declaration structure Structure:
   │                       ‾‾‾‾‾‾‾‾‾
-[WARNING] The constructor "Dec" of enumeration "Enum" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Dec" of enumeration "Enum" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/typing/bad/common.catala_en:4.6-4.9:
 └─┐
 4 │   -- Dec content decimal
   │      ‾‾‾
-[WARNING] The constructor "Dat" of enumeration "Enum" is never used; maybe it's unnecessary?
+[WARNING] The constructor "Dat" of enumeration "Enum" is never used;
+  maybe it's unnecessary?
 
 ┌─⯈ tests/typing/bad/common.catala_en:5.6-5.9:
 └─┐
 5 │   -- Dat content date
   │      ‾‾‾
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ Enum
-└─⯈ Structure
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ Enum
+  └─⯈ Structure
 
 This expression has type Enum:
 ┌─⯈ tests/typing/bad/err4.catala_en:5.25-5.38:

--- a/tests/typing/bad/err5.catala_en
+++ b/tests/typing/bad/err5.catala_en
@@ -12,10 +12,9 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ integer
-└─⯈ Structure
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ integer
+  └─⯈ Structure
 
 This expression has type integer:
 ┌─⯈ tests/typing/bad/err5.catala_en:8.5-8.9:

--- a/tests/typing/bad/err6.catala_en
+++ b/tests/typing/bad/err6.catala_en
@@ -28,10 +28,9 @@ Should be "catala Typecheck", see test err3
 
 ```catala-test-inline
 $ catala ocaml
-[ERROR]
-Error during typechecking, incompatible types:
-┌─⯈ decimal
-└─⯈ integer
+[ERROR] Error during typechecking, incompatible types:
+  ┌─⯈ decimal
+  └─⯈ integer
 
 This expression has type decimal:
 ┌─⯈ tests/typing/bad/err6.catala_en:20.27-20.30:

--- a/tests/typing/good/common.catala_en
+++ b/tests/typing/good/common.catala_en
@@ -19,19 +19,22 @@ declaration scope S:
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
-[WARNING] In scope "S", the variable "z" is declared but never defined; did you forget something?
+[WARNING] In scope "S", the variable "z" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/typing/good/common.catala_en:14.10-14.11:
 └──┐
 14 │   output z content list of Structure
    │          ‾
-[WARNING] In scope "S", the variable "a" is declared but never defined; did you forget something?
+[WARNING] In scope "S", the variable "a" is declared but never defined;
+  did you forget something?
 
 ┌─⯈ tests/typing/good/common.catala_en:15.10-15.11:
 └──┐
 15 │   output a content decimal
    │          ‾
-[WARNING] Unused varible: x does not contribute to computing any of scope S outputs. Did you forget something?
+[WARNING] Unused varible: x does not contribute to computing any of scope S
+  outputs. Did you forget something?
 
 ┌─⯈ tests/typing/good/common.catala_en:12.9-12.10:
 └──┐

--- a/tests/variable_state/bad/def_no_state.catala_en
+++ b/tests/variable_state/bad/def_no_state.catala_en
@@ -12,8 +12,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-This definition does not indicate which state has to be considered for variable foo.
+[ERROR] This definition does not indicate which state has to be considered
+  for variable foo.
 
 ┌─⯈ tests/variable_state/bad/def_no_state.catala_en:10.14-10.17:
 └──┐

--- a/tests/variable_state/bad/double_same_state.catala_en
+++ b/tests/variable_state/bad/double_same_state.catala_en
@@ -12,8 +12,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck
-[ERROR]
-There are two states with the same name for the same variable: this is ambiguous. Please change the name of either states.
+[ERROR] There are two states with the same name for the same variable: this
+  is ambiguous. Please change the name of either states.
 
 First instance of state "bar":
 ┌─⯈ tests/variable_state/bad/double_same_state.catala_en:6.11-6.14:

--- a/tests/variable_state/bad/no_cross_exceptions.catala_en
+++ b/tests/variable_state/bad/no_cross_exceptions.catala_en
@@ -16,8 +16,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-Unknown label for the scope variable foo@baz: "thing"
+[ERROR] Unknown label for the scope variable foo@baz: "thing"
 
 ┌─⯈ tests/variable_state/bad/no_cross_exceptions.catala_en:14.13-14.18:
 └──┐

--- a/tests/variable_state/bad/self_reference_first_state.catala_en
+++ b/tests/variable_state/bad/self_reference_first_state.catala_en
@@ -14,8 +14,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-It is impossible to refer to the variable you are defining when defining its first state.
+[ERROR] The definition of the initial state of this variable refers to
+  itself.
 
 ┌─⯈ tests/variable_state/bad/self_reference_first_state.catala_en:10.35-10.38:
 └──┐

--- a/tests/variable_state/bad/state_cycle.catala_en
+++ b/tests/variable_state/bad/state_cycle.catala_en
@@ -21,8 +21,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-Cyclic dependency detected between the following variables of scope A:
+[ERROR] Cyclic dependency detected between the following variables of scope A:
   foofoo@bar → foofoo@baz → foo@bar → foo@baz → foofoo@bar
 
 foofoo@bar is used here in the definition of foofoo@baz:

--- a/tests/variable_state/bad/unknown_state.catala_en
+++ b/tests/variable_state/bad/unknown_state.catala_en
@@ -14,8 +14,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Typecheck 
-[ERROR]
-This identifier is not a state declared for variable foo.
+[ERROR] This identifier is not a state declared for variable foo.
 
 ┌─⯈ tests/variable_state/bad/unknown_state.catala_en:12.24-12.28:
 └──┐


### PR DESCRIPTION
PR #601 changed the interface without impacting the output format. This builds
on top of it to improve message formatting, both in the module `Message`, and in
individual messages to allow word-wrapping where it was not possible.