### PR TITLE
Improvements around external modules and error handling

### DIFF
--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1142,9 +1142,13 @@ let main () =
           | exception Sys_error _ ->
             Message.debug "Could not read plugin directory %s" d)
       plugins_dirs;
-    Dynlink.allow_only ["Runtime_ocaml__Runtime"];
-    (* We may use dynlink again, but only for runtime modules: no plugin
-       registration after this point *)
+    Dynlink.allow_only
+      (List.filter (( <> ) "Driver__Plugin") (Dynlink.all_units ()));
+    (* From here on, no plugin registration is allowed. However, the interpreter
+       may yet use Dynlink to load external modules. - TODO: This used to allow
+       only "Runtime_ocaml__Runtime", but forbidding external Catala modules to
+       use the OCaml Stdlib was a bit much. We should examine how to re-add some
+       more filtering here without being too restrictive. *)
     Plugin.list ()
   in
   let command = catala_t plugins in

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -270,7 +270,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
   | EmptyError -> Format.fprintf fmt "EmptyError"
-  | Crash -> Format.fprintf fmt "Crash"
+  | Crash s -> Format.fprintf fmt "(Crash %S)" s
   | NoValueProvided ->
     let pos = Mark.get exc in
     Format.fprintf fmt

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -455,7 +455,7 @@ let rec format_statement
       | ConflictError _ -> "catala_conflict"
       | EmptyError -> "catala_empty"
       | NoValueProvided -> "catala_no_value_provided"
-      | Crash -> "catala_crash")
+      | Crash _ -> "catala_crash")
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
       (Pos.get_end_line pos) (Pos.get_end_column pos)
   | SIfThenElse { if_expr = cond; then_block = b1; else_block = b2 } ->

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -259,7 +259,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
   | EmptyError -> Format.fprintf fmt "EmptyError"
-  | Crash -> Format.fprintf fmt "Crash"
+  | Crash _ -> Format.fprintf fmt "Crash"
   | NoValueProvided ->
     Format.fprintf fmt
       "NoValueProvided(@[<hov 0>SourcePosition(@[<hov 0>filename=\"%s\",@ \

--- a/compiler/scalc/to_r.ml
+++ b/compiler/scalc/to_r.ml
@@ -265,7 +265,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
   | EmptyError -> Format.fprintf fmt "catala_empty_error()"
-  | Crash -> Format.fprintf fmt "catala_crash()"
+  | Crash _ -> Format.fprintf fmt "catala_crash()"
   | NoValueProvided ->
     Format.fprintf fmt
       "catala_no_value_provided_error(@[<hov 0>catala_position(@[<hov \
@@ -279,7 +279,7 @@ let format_exception_name (fmt : Format.formatter) (exc : except) : unit =
   match exc with
   | ConflictError _ -> Format.fprintf fmt "catala_conflict_error"
   | EmptyError -> Format.fprintf fmt "catala_empty_error"
-  | Crash -> Format.fprintf fmt "catala_crash"
+  | Crash _ -> Format.fprintf fmt "catala_crash"
   | NoValueProvided -> Format.fprintf fmt "catala_no_value_provided_error"
 
 let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -382,7 +382,7 @@ type except =
   | ConflictError of Pos.t list
   | EmptyError
   | NoValueProvided
-  | Crash
+  | Crash of string
 
 (** {2 Markings} *)
 

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -129,7 +129,7 @@ let rec evaluate_operator
       | _ -> assert false
     in
     try f x y with
-    | Division_by_zero ->
+    | Runtime.Division_by_zero ->
       Message.error
         ~extra_pos:
           [

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -663,16 +663,21 @@ let rec evaluate_expr :
         Message.error ~pos "wrong function call, expected %d arguments, got %d"
           (Bindlib.mbinder_arity binder)
           (List.length args)
-    | ECustom { obj; targs; tret } ->
+    | ECustom { obj; targs; tret } -> (
       (* Applies the arguments one by one to the curried form *)
-      List.fold_left2
-        (fun fobj targ arg ->
-          (Obj.obj fobj : Obj.t -> Obj.t)
-            (val_to_runtime (fun ctx -> evaluate_expr ctx lang) ctx targ arg))
-        obj targs args
-      |> Obj.obj
-      |> fun o ->
-      runtime_to_val (fun ctx -> evaluate_expr ctx lang) ctx m tret o
+      match
+        List.fold_left2
+          (fun fobj targ arg ->
+            (Obj.obj fobj : Obj.t -> Obj.t)
+              (val_to_runtime (fun ctx -> evaluate_expr ctx lang) ctx targ arg))
+          obj targs args
+      with
+      | exception e ->
+        Format.ksprintf
+          (fun s -> raise (CatalaException (Crash s, pos)))
+          "@[<hv 2>This call to code from a module failed with:@ %s@]"
+          (Printexc.to_string e)
+      | o -> runtime_to_val (fun ctx -> evaluate_expr ctx lang) ctx m tret o)
     | _ ->
       Message.error ~pos "%a" Format.pp_print_text
         "function has not been reduced to a lambda at evaluation (should not \
@@ -927,9 +932,7 @@ let interp_failure_message ~pos = function
       "%a" Format.pp_print_text
       "There is a conflict between multiple valid consequences for assigning \
        the same variable."
-  | Crash ->
-    (* This constructor seems to be never used *)
-    Message.error ~pos ~internal:true "The interpreter crashed"
+  | Crash s -> Message.error ~pos "%s" s
   | EmptyError ->
     Message.error ~pos ~internal:true
       "A variable without valid definition escaped"

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -1090,10 +1090,7 @@ let load_runtime_modules prg =
   let load m =
     let obj_file =
       Dynlink.adapt_filename
-        File.(
-          Pos.get_file (Mark.get (ModuleName.get_info m))
-          /../ ModuleName.to_string m
-          ^ ".cmo")
+        File.(Pos.get_file (Mark.get (ModuleName.get_info m)) -.- "cmo")
     in
     if not (Sys.file_exists obj_file) then
       Message.error

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -350,7 +350,7 @@ let except (fmt : Format.formatter) (exn : except) : unit =
     (match exn with
     | EmptyError -> "EmptyError"
     | ConflictError _ -> "ConflictError"
-    | Crash -> "Crash"
+    | Crash s -> Printf.sprintf "Crash %S" s
     | NoValueProvided -> "NoValueProvided")
 
 let var_debug fmt v =

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -76,6 +76,7 @@ exception UncomparableDurations
 exception IndivisibleDurations
 exception ImpossibleDate
 exception NoValueProvided of source_position
+exception Division_by_zero (* Shadows the stdlib definition *)
 
 (** {1 Value Embedding} *)
 


### PR DESCRIPTION
This allows external modules to access all modules (see first patch), protects
the interpreter for better reporting of exceptions raised from modules (third
patch), and register exception printers in the OCaml runtime.

Quoting here the message from the second patch because it mentions some
important points, that may warrant discussion:

OCaml runtime: register fallback exception printers

This was a pending TODO: now the Catala program compiled into OCaml should
return better messages and a little more information about uncaught
exceptions.

Note that this also concerns, at the moment, compiled modules called from
the Catala interpreter: in this case, it's already better than nothing, but
what we need is proper interoperation between the runtime exceptions and
the interpreter handling (`EmptyError` should already be handled properly
since it is critical to the computation flow, but "error" exceptions are
left uncaught and will kill the interpreter).

This may be part of a bigger task on unifying the output of the runtime and
toplevel, which also concerns computation traces.

Note 2: All runtime exceptions don't have a position available, which is
quite unfortunate when your program hits an error. With `OCAMLRUNPARAM=b`
and if compiled with `-g` (which should normally be the case), you can get
an OCaml backtrace but that's not very friendly. Ideas for improvement:

- The runtime could force-enable backtrace recording (`Printexc.record_backtrace
  true`) to supersede the need for `OCAMLRUNPARAM`. We can also record our own
  handler to print the file position and/or backtrace in the way we see fit

- The printer of OCaml code in Catala could insert line directives so that the
  positions in the backtrace actually trace automatically back to the Catala
  code

- If we don't want to leverage any OCaml machinery in this way, the compiler
  should add position information to any operator that might fail (e.g.
  divisions, date comparisons, etc.).

Note that running in trace mode might already help pinpoint the location of the
error ?