### PR TITLE
Add env variables to set flags `-O`, `--avoid-exceptions`, `--trace`

### DIFF
--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -50,7 +50,10 @@ let run_catala_test test_flags catala_exe catala_opts file program args oc =
   let env =
     Unix.environment ()
     |> Array.to_seq
-    |> Seq.filter (fun s -> not (String.starts_with ~prefix:"OCAMLRUNPARAM=" s))
+    |> Seq.filter (fun s ->
+           not
+             (String.starts_with ~prefix:"OCAMLRUNPARAM=" s
+             || String.starts_with ~prefix:"CATALA_" s))
     |> Seq.cons "CATALA_OUT=-"
     (* |> Seq.cons "CATALA_COLOR=never" *)
     |> Seq.cons "CATALA_PLUGINS="

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -146,6 +146,7 @@ module Flags = struct
       value
       & flag
       & info ["trace"; "t"]
+          ~env:(Cmd.Env.info "CATALA_TRACE")
           ~doc:
             "Displays a trace of the interpreter's computation or generates \
              logging instructions in translate programs."
@@ -318,12 +319,17 @@ module Flags = struct
            the chosen backend. Use $(b,-o -) for stdout."
 
   let optimize =
-    value & flag & info ["optimize"; "O"] ~doc:"Run compiler optimizations."
+    value
+    & flag
+    & info ["optimize"; "O"]
+        ~env:(Cmd.Env.info "CATALA_OPTIMIZE")
+        ~doc:"Run compiler optimizations."
 
   let avoid_exceptions =
     value
     & flag
     & info ["avoid-exceptions"]
+        ~env:(Cmd.Env.info "CATALA_AVOID_EXCEPTIONS")
         ~doc:"Compiles the default calculus without exceptions."
 
   let keep_special_ops =


### PR DESCRIPTION
It makes it easier to batch-set them when testing a given repo with different
sets of options. Direct flags should still be preferred in general, of course.