### PR TITLE
Unify runtime error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ testsuite: unit-tests
 
 #> reset-tests				: Update the expected test results from current run
 reset-tests: .FORCE $(CLERK_BIN)
-	$(CLERK_TEST) tests --reset
+	$(CLERK_TEST) tests doc --reset
 
 tests/%: .FORCE
 	$(CLERK_TEST) test $@

--- a/Makefile
+++ b/Makefile
@@ -194,14 +194,14 @@ syntax:
 # High-level test and benchmarks commands
 ##########################################
 
-CATALA_OPTS ?=
+CATALAOPTS ?=
 CLERK_OPTS ?=
 
 CATALA_BIN=_build/default/$(COMPILER_DIR)/catala.exe
 CLERK_BIN=_build/default/$(BUILD_SYSTEM_DIR)/clerk.exe
 
 CLERK_TEST=$(CLERK_BIN) test --exe $(CATALA_BIN) \
-	$(CLERK_OPTS) $(if $(CATALA_OPTS),--catala-opts=$(CATALA_OPTS),)
+	$(CLERK_OPTS) $(if $(CATALAOPTS),--catala-opts=$(CATALAOPTS),)
 
 
 .FORCE:

--- a/compiler/catala_utils/dune
+++ b/compiler/catala_utils/dune
@@ -3,7 +3,7 @@
  (public_name catala.catala_utils)
  (modules
   (:standard \ get_version))
- (libraries unix cmdliner ubase ocolor re bindlib catala.runtime_ocaml))
+ (libraries unix cmdliner ubase ocolor re))
 
 (executable
  (name get_version)

--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -213,22 +213,21 @@ module Content = struct
                     content
                 | some -> some
               in
-              pos, m
-            | Position { pos_message; pos } ->
-              let message =
-                match pos_message with Some m -> m | None -> fun _ -> ()
-              in
-              Some pos, message
-            | Outcome m -> None, m
-            | Suggestion sl -> None, fun ppf -> Suggestions.format ppf sl
+              pos, Some m
+            | Position { pos_message; pos } -> Some pos, pos_message
+            | Outcome m -> None, Some m
+            | Suggestion sl -> None, Some (fun ppf -> Suggestions.format ppf sl)
           in
           Option.iter
             (fun pos ->
               Format.fprintf ppf "@{<blue>%s@}: " (Pos.to_string_short pos))
             pos;
           pp_marker target ppf;
-          Format.pp_print_char ppf ' ';
-          Format.pp_print_string ppf (unformat message))
+          match message with
+          | Some message ->
+            Format.pp_print_char ppf ' ';
+            Format.pp_print_string ppf (unformat message)
+          | None -> ())
         ppf content;
       Format.pp_print_newline ppf ()
 end

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -71,6 +71,7 @@ val unformat : (Format.formatter -> unit) -> string
     indents *)
 
 val has_color : out_channel -> bool
+val set_terminal_width_function : (unit -> int) -> unit
 
 (* {1 More general color-enabled formatting helpers}*)
 

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -139,7 +139,8 @@ let tag_with_log_entry
   let m = mark_tany (Mark.get e) (Expr.pos e) in
 
   if Global.options.trace then
-    Expr.eappop ~op:(Log (l, markings)) ~tys:[TAny, Expr.pos e] ~args:[e] m
+    let pos = Expr.pos e in
+    Expr.eappop ~op:(Log (l, markings), pos) ~tys:[TAny, pos] ~args:[e] m
   else e
 
 (* In a list of exceptions, it is normally an error if more than a single one
@@ -565,9 +566,9 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm S.expr) : 'm Ast.expr boxed =
       let v, _ = TopdefName.Map.find (Mark.remove name) ctx.toplevel_vars in
       Expr.evar v m
     else Expr.eexternal ~name:(Mark.map (fun n -> External_value n) name) m
-  | EAppOp { op = Add_dat_dur _; args; tys } ->
+  | EAppOp { op = Add_dat_dur _, opos; args; tys } ->
     let args = List.map (translate_expr ctx) args in
-    Expr.eappop ~op:(Add_dat_dur ctx.date_rounding) ~args ~tys m
+    Expr.eappop ~op:(Add_dat_dur ctx.date_rounding, opos) ~args ~tys m
   | ( EVar _ | EAbs _ | ELit _ | EStruct _ | EStructAccess _ | ETuple _
     | ETupleAccess _ | EInj _ | EFatalError _ | EEmpty | EErrorOnEmpty _
     | EArray _ | EIfThenElse _ | EAppOp _ ) as e ->

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -264,7 +264,7 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm S.expr) : 'm Ast.expr boxed =
               ( var_ctx.scope_input_name,
                 Expr.make_abs
                   [| Var.make "_" |]
-                  (Expr.eemptyerror (Expr.with_ty m ty0))
+                  (Expr.eempty (Expr.with_ty m ty0))
                   [TAny, iopos]
                   pos )
           | Some var_ctx, Some e ->
@@ -569,8 +569,8 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm S.expr) : 'm Ast.expr boxed =
     let args = List.map (translate_expr ctx) args in
     Expr.eappop ~op:(Add_dat_dur ctx.date_rounding) ~args ~tys m
   | ( EVar _ | EAbs _ | ELit _ | EStruct _ | EStructAccess _ | ETuple _
-    | ETupleAccess _ | EInj _ | EEmptyError | EErrorOnEmpty _ | EArray _
-    | EIfThenElse _ | EAppOp _ ) as e ->
+    | ETupleAccess _ | EInj _ | EFatalError _ | EEmpty | EErrorOnEmpty _
+    | EArray _ | EIfThenElse _ | EAppOp _ ) as e ->
     Expr.map ~f:(translate_expr ctx) ~op:Operator.translate (e, m)
 
 (** The result of a rule translation is a list of assignments, with variables

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -187,7 +187,7 @@ let empty_rule
     (parameters : (Uid.MarkedString.info * typ) list Mark.pos option) : rule =
   {
     rule_just = Expr.box (ELit (LBool false), Untyped { pos });
-    rule_cons = Expr.box (EEmptyError, Untyped { pos });
+    rule_cons = Expr.box (EEmpty, Untyped { pos });
     rule_parameter =
       Option.map
         (Mark.map (List.map (fun (lbl, typ) -> Mark.map Var.make lbl, typ)))

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -375,7 +375,7 @@ let rec translate_expr
           (try
              Runtime.date_of_numbers date.literal_date_year
                date.literal_date_month date.literal_date_day
-           with Dates_calc.Dates.InvalidDate ->
+           with Failure _ ->
              Message.error ~pos
                "There is an error in this date, it does not correspond to a \
                 correct calendar day")

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -42,7 +42,7 @@ let translate_binop :
     Ast.expr boxed =
  fun (op, op_pos) pos lhs rhs ->
   let op_expr op tys =
-    Expr.eappop ~op
+    Expr.eappop ~op:(op, op_pos)
       ~tys:(List.map (Mark.add op_pos) tys)
       ~args:[lhs; rhs]
       (Untyped { pos })
@@ -114,7 +114,10 @@ let translate_binop :
 
 let translate_unop ((op, op_pos) : S.unop Mark.pos) pos arg : Ast.expr boxed =
   let op_expr op ty =
-    Expr.eappop ~op ~tys:[Mark.add op_pos ty] ~args:[arg] (Untyped { pos })
+    Expr.eappop ~op:(op, op_pos)
+      ~tys:[Mark.add op_pos ty]
+      ~args:[arg]
+      (Untyped { pos })
   in
   match op with
   | S.Not -> op_expr Not (TLit TBool)
@@ -238,12 +241,12 @@ let rec translate_expr
   let rec_helper ?(local_vars = local_vars) e =
     translate_expr scope inside_definition_of ctxt local_vars e
   in
-  let rec detuplify_list names = function
+  let rec detuplify_list opos names = function
     (* Where a list is expected (e.g. after [among]), as syntactic sugar, if a
        tuple is found instead we transpose it into a list of tuples *)
     | S.Tuple ls, pos ->
       let m = Untyped { pos } in
-      let ls = List.map (detuplify_list []) ls in
+      let ls = List.map (detuplify_list opos []) ls in
       let rec zip names = function
         | [] -> assert false
         | [l] -> l
@@ -272,7 +275,7 @@ let rec translate_expr
               (Expr.make_tuple (Expr.evar x1 m :: explode (Expr.evar x2 m)) m)
               tys pos
           in
-          Expr.eappop ~op:Map2 ~args:[f_join; l1; rhs]
+          Expr.eappop ~op:(Map2, opos) ~args:[f_join; l1; rhs]
             ~tys:((TAny, pos) :: List.map (fun ty -> TArray ty, pos) tys)
             m
       in
@@ -286,7 +289,7 @@ let rec translate_expr
   match Mark.remove expr with
   | Paren e -> rec_helper e
   | Binop
-      ( (S.And, _pos_op),
+      ( (S.And, pos_op),
         ( TestMatchCase (e1_sub, ((constructors, Some binding), pos_pattern)),
           _pos_e1 ),
         e2 ) ->
@@ -302,14 +305,14 @@ let rec translate_expr
             let nop_var = Var.make "_" in
             Expr.make_abs [| nop_var |]
               (Expr.elit (LBool false) emark)
-              [tau] pos
+              [tau] pos_op
           else
             let binding_var = Var.make (Mark.remove binding) in
             let local_vars =
               Ident.Map.add (Mark.remove binding) binding_var local_vars
             in
             let e2 = rec_helper ~local_vars e2 in
-            Expr.make_abs [| binding_var |] e2 [tau] pos)
+            Expr.make_abs [| binding_var |] e2 [tau] pos_op)
         (EnumName.Map.find enum_uid ctxt.enums)
     in
     Expr.ematch ~e:(rec_helper e1_sub) ~name:enum_uid ~cases emark
@@ -493,7 +496,7 @@ let rec translate_expr
     in
     Expr.edstructaccess ~e ~field:(Mark.remove x) ~name_opt:(get_str ctxt path)
       emark
-  | FunCall ((Builtin b, _), [arg]) ->
+  | FunCall ((Builtin b, pos), [arg]) ->
     let op, ty =
       match b with
       | S.ToDecimal -> Op.ToRat, TAny
@@ -506,7 +509,7 @@ let rec translate_expr
       | S.FirstDayOfMonth -> Op.FirstDayOfMonth, TLit TDate
       | S.LastDayOfMonth -> Op.LastDayOfMonth, TLit TDate
     in
-    Expr.eappop ~op ~tys:[ty, pos] ~args:[rec_helper arg] emark
+    Expr.eappop ~op:(op, pos) ~tys:[ty, pos] ~args:[rec_helper arg] emark
   | S.Builtin _ ->
     Message.error ~pos "Invalid use of built-in: needs one operand"
   | FunCall (f, args) ->
@@ -723,10 +726,10 @@ let rec translate_expr
   | Tuple es -> Expr.etuple (List.map rec_helper es) emark
   | TupleAccess (e, n) ->
     Expr.etupleaccess ~e:(rec_helper e) ~index:(Mark.remove n - 1) ~size:0 emark
-  | CollectionOp (((S.Filter { f } | S.Map { f }) as op), collection) ->
+  | CollectionOp ((((S.Filter { f } | S.Map { f }), opos) as op), collection) ->
     let param_names, predicate = f in
     let collection =
-      detuplify_list (List.map Mark.remove param_names) collection
+      detuplify_list opos (List.map Mark.remove param_names) collection
     in
     let params = List.map (fun n -> Var.make (Mark.remove n)) param_names in
     let local_vars =
@@ -762,18 +765,19 @@ let rec translate_expr
     Expr.eappop
       ~op:
         (match op with
-        | S.Map _ -> Map
-        | S.Filter _ -> Filter
+        | S.Map _, pos -> Map, pos
+        | S.Filter _, pos -> Filter, pos
         | _ -> assert false)
       ~tys:[TAny, pos; TAny, pos]
       ~args:[f_pred; collection] emark
   | CollectionOp
-      ( S.AggregateArgExtremum { max; default; f = param_names, predicate },
+      ( ( S.AggregateArgExtremum { max; default; f = param_names, predicate },
+          opos ),
         collection ) ->
     let default = rec_helper default in
     let pos_dft = Expr.pos default in
     let collection =
-      detuplify_list (List.map Mark.remove param_names) collection
+      detuplify_list opos (List.map Mark.remove param_names) collection
     in
     let params = List.map (fun n -> Var.make (Mark.remove n)) param_names in
     let local_vars =
@@ -781,7 +785,7 @@ let rec translate_expr
         (fun vars n p -> Ident.Map.add (Mark.remove n) p vars)
         local_vars param_names params
     in
-    let cmp_op = if max then Op.Gt else Op.Lt in
+    let cmp_op = if max then Op.Gt, opos else Op.Lt, opos in
     let f_pred =
       Expr.make_abs (Array.of_list params)
         (rec_helper ~local_vars predicate)
@@ -820,10 +824,10 @@ let rec translate_expr
     let weighted_result =
       Expr.make_let_in weights_var
         (TArray (TTuple [TAny, pos; TAny, pos], pos), pos)
-        (Expr.eappop ~op:Map
+        (Expr.eappop ~op:(Map, opos)
            ~tys:[TAny, pos; TArray (TAny, pos), pos]
            ~args:[add_weight_f; collection] emark)
-        (Expr.eappop ~op:Reduce
+        (Expr.eappop ~op:(Reduce, opos)
            ~tys:[TAny, pos; TAny, pos; TAny, pos]
            ~args:[reduce_f; default; Expr.evar weights_var emark]
            emark)
@@ -831,14 +835,15 @@ let rec translate_expr
     in
     Expr.etupleaccess ~e:weighted_result ~index:0 ~size:2 emark
   | CollectionOp
-      (((Exists { predicate } | Forall { predicate }) as op), collection) ->
+      ((((Exists { predicate } | Forall { predicate }), opos) as op), collection)
+    ->
     let collection =
-      detuplify_list (List.map Mark.remove (fst predicate)) collection
+      detuplify_list opos (List.map Mark.remove (fst predicate)) collection
     in
     let init, op =
       match op with
-      | Exists _ -> false, S.Or
-      | Forall _ -> true, S.And
+      | Exists _, pos -> false, (S.Or, pos)
+      | Forall _, pos -> true, (S.And, pos)
       | _ -> assert false
     in
     let init = Expr.elit (LBool init) emark in
@@ -857,15 +862,14 @@ let rec translate_expr
       Expr.eabs
         (Expr.bind
            (Array.of_list (acc_var :: params))
-           (translate_binop (op, pos) pos acc
-              (rec_helper ~local_vars predicate)))
+           (translate_binop op pos acc (rec_helper ~local_vars predicate)))
         [TAny, pos; TAny, pos]
         emark
     in
-    Expr.eappop ~op:Fold
+    Expr.eappop ~op:(Fold, opos)
       ~tys:[TAny, pos; TAny, pos; TAny, pos]
       ~args:[f; init; collection] emark
-  | CollectionOp (AggregateExtremum { max; default }, collection) ->
+  | CollectionOp ((AggregateExtremum { max; default }, opos), collection) ->
     let collection = rec_helper collection in
     let default = rec_helper default in
     let op = if max then S.Gt KPoly else S.Lt KPoly in
@@ -880,11 +884,11 @@ let rec translate_expr
         [TAny, pos; TAny, pos]
         pos
     in
-    Expr.eappop ~op:Reduce
+    Expr.eappop ~op:(Reduce, opos)
       ~tys:[TAny, pos; TAny, pos; TAny, pos]
       ~args:[op_f; default; collection]
       emark
-  | CollectionOp (AggregateSum { typ }, collection) ->
+  | CollectionOp ((AggregateSum { typ }, opos), collection) ->
     let collection = rec_helper collection in
     let default_lit =
       let i0 = Runtime.integer_of_int 0 in
@@ -894,7 +898,8 @@ let rec translate_expr
       | S.Money -> LMoney (Runtime.money_of_cents_integer i0)
       | S.Duration -> LDuration (Runtime.duration_of_numbers 0 0 0)
       | t ->
-        Message.error ~pos "It is impossible to sum values of type %a together"
+        Message.error ~pos:opos
+          "It is impossible to sum values of type %a together"
           SurfacePrint.format_primitive_typ t
     in
     let op_f =
@@ -905,28 +910,28 @@ let rec translate_expr
       let x1 = Expr.make_var v1 emark in
       let x2 = Expr.make_var v2 emark in
       Expr.make_abs [| v1; v2 |]
-        (translate_binop (S.Add KPoly, pos) pos x1 x2)
+        (translate_binop (S.Add KPoly, opos) pos x1 x2)
         [TAny, pos; TAny, pos]
         pos
     in
-    Expr.eappop ~op:Reduce
+    Expr.eappop ~op:(Reduce, opos)
       ~tys:[TAny, pos; TAny, pos; TAny, pos]
       ~args:[op_f; Expr.elit default_lit emark; collection]
       emark
-  | MemCollection (member, collection) ->
+  | CollectionOp ((Member { element = member }, opos), collection) ->
     let param_var = Var.make "collection_member" in
     let param = Expr.make_var param_var emark in
-    let collection = detuplify_list ["collection_member"] collection in
+    let collection = detuplify_list opos ["collection_member"] collection in
     let init = Expr.elit (LBool false) emark in
     let acc_var = Var.make "acc" in
     let acc = Expr.make_var acc_var emark in
     let f_body =
       let member = rec_helper member in
-      Expr.eappop ~op:Or
+      Expr.eappop ~op:(Or, opos)
         ~tys:[TLit TBool, pos; TLit TBool, pos]
         ~args:
           [
-            Expr.eappop ~op:Eq
+            Expr.eappop ~op:(Eq, opos)
               ~tys:[TAny, pos; TAny, pos]
               ~args:[member; param] emark;
             acc;
@@ -939,7 +944,7 @@ let rec translate_expr
         [TLit TBool, pos; TAny, pos]
         emark
     in
-    Expr.eappop ~op:Fold
+    Expr.eappop ~op:(Fold, opos)
       ~tys:[TAny, pos; TAny, pos; TAny, pos]
       ~args:[f; init; collection] emark
 
@@ -1090,7 +1095,7 @@ let merge_conditions
     (default_pos : Pos.t) : Ast.expr boxed =
   match precond, cond with
   | Some precond, Some cond ->
-    Expr.eappop ~op:And
+    Expr.eappop ~op:(And, default_pos)
       ~tys:[TLit TBool, default_pos; TLit TBool, default_pos]
       ~args:[precond; cond] (Mark.get cond)
   | Some precond, None -> Mark.remove precond, Untyped { pos = default_pos }

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -330,12 +330,18 @@ let rec translate_expr
       match l with
       | LNumber ((Int i, _), None) -> LInt (Runtime.integer_of_string i)
       | LNumber ((Int i, _), Some (Percent, _)) ->
-        LRat Runtime.(Oper.o_div_rat_rat (decimal_of_string i) rat100)
+        LRat
+          Runtime.(
+            Oper.o_div_rat_rat (Expr.pos_to_runtime pos) (decimal_of_string i)
+              rat100)
       | LNumber ((Dec (i, f), _), None) ->
         LRat Runtime.(decimal_of_string (i ^ "." ^ f))
       | LNumber ((Dec (i, f), _), Some (Percent, _)) ->
         LRat
-          Runtime.(Oper.o_div_rat_rat (decimal_of_string (i ^ "." ^ f)) rat100)
+          Runtime.(
+            Oper.o_div_rat_rat (Expr.pos_to_runtime pos)
+              (decimal_of_string (i ^ "." ^ f))
+              rat100)
       | LBool b -> LBool b
       | LMoneyAmount i ->
         LMoney
@@ -366,7 +372,7 @@ let rec translate_expr
           (try
              Runtime.date_of_numbers date.literal_date_year
                date.literal_date_month date.literal_date_day
-           with Runtime.ImpossibleDate ->
+           with Dates_calc.Dates.InvalidDate ->
              Message.error ~pos
                "There is an error in this date, it does not correspond to a \
                 correct calendar day")

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -145,7 +145,8 @@ let rec transform_closures_expr :
     (* let env = from_closure_env env in let arg0 = env.0 in ... *)
     let new_closure_body =
       Expr.make_let_in closure_env_var any_ty
-        (Expr.eappop ~op:Operator.FromClosureEnv
+        (Expr.eappop
+           ~op:(Operator.FromClosureEnv, binder_pos)
            ~tys:[TClosureEnv, binder_pos]
            ~args:[Expr.evar closure_env_arg_var binder_mark]
            binder_mark)
@@ -178,7 +179,8 @@ let rec transform_closures_expr :
         (Expr.make_tuple
            ((Bindlib.box_var code_var, binder_mark)
            :: [
-                Expr.eappop ~op:Operator.ToClosureEnv
+                Expr.eappop
+                  ~op:(Operator.ToClosureEnv, binder_pos)
                   ~tys:[TAny, Expr.pos e]
                   ~args:
                     [
@@ -197,7 +199,7 @@ let rec transform_closures_expr :
         (Expr.pos e) )
   | EAppOp
       {
-        op = (HandleDefaultOpt | Fold | Map | Filter | Reduce) as op;
+        op = ((HandleDefaultOpt | Fold | Map | Filter | Reduce), _) as op;
         tys;
         args;
       } ->
@@ -492,7 +494,7 @@ let rec hoist_closures_expr :
         ~args:new_args ~tys m )
   | EAppOp
       {
-        op = (HandleDefaultOpt | Fold | Map | Filter | Reduce) as op;
+        op = ((HandleDefaultOpt | Fold | Map | Filter | Reduce), _) as op;
         tys;
         args;
       } ->

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -38,7 +38,8 @@ let rec transform_closures_expr :
   let m = Mark.get e in
   match Mark.remove e with
   | EStruct _ | EStructAccess _ | ETuple _ | ETupleAccess _ | EInj _ | EArray _
-  | ELit _ | EExternal _ | EAssert _ | EIfThenElse _ | ERaise _ | ECatch _ ->
+  | ELit _ | EExternal _ | EAssert _ | EFatalError _ | EIfThenElse _
+  | ERaiseEmpty | ECatchEmpty _ ->
     Expr.map_gather ~acc:Var.Set.empty ~join:Var.Set.union
       ~f:(transform_closures_expr ctx)
       e
@@ -538,8 +539,8 @@ let rec hoist_closures_expr :
       ],
       Expr.make_var closure_var m )
   | EApp _ | EStruct _ | EStructAccess _ | ETuple _ | ETupleAccess _ | EInj _
-  | EArray _ | ELit _ | EAssert _ | EAppOp _ | EIfThenElse _ | ERaise _
-  | ECatch _ | EVar _ ->
+  | EArray _ | ELit _ | EAssert _ | EFatalError _ | EAppOp _ | EIfThenElse _
+  | ERaiseEmpty | ECatchEmpty _ | EVar _ ->
     Expr.map_gather ~acc:[] ~join:( @ ) ~f:(hoist_closures_expr name_context) e
   | EExternal _ -> failwith "unimplemented"
   | _ -> .

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -51,7 +51,8 @@ let rec translate_default
   let exceptions =
     List.map (fun except -> Expr.thunk_term (translate_expr except)) exceptions
   in
-  Expr.eappop ~op:Op.HandleDefault
+  Expr.eappop
+    ~op:(Op.HandleDefault, Expr.pos cons)
     ~tys:
       [
         TArray (TArrow ([TLit TUnit, pos], (TAny, pos)), pos), pos;

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -71,10 +71,10 @@ let rec translate_default
 
 and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
   match e with
-  | EEmptyError, m -> Expr.eraise Empty (translate_mark m)
+  | EEmpty, m -> Expr.eraiseempty (translate_mark m)
   | EErrorOnEmpty arg, m ->
     let m = translate_mark m in
-    Expr.ecatch (translate_expr arg) Empty (Expr.eraise NoValueProvided m) m
+    Expr.ecatchempty (translate_expr arg) (Expr.efatalerror Runtime.NoValue m) m
   | EDefault { excepts; just; cons }, m ->
     translate_default excepts just cons (translate_mark m)
   | EPureDefault e, _ -> translate_expr e
@@ -85,7 +85,7 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
       (translate_mark m)
   | ( ( ELit _ | EArray _ | EVar _ | EAbs _ | EApp _ | EExternal _
       | EIfThenElse _ | ETuple _ | ETupleAccess _ | EInj _ | EAssert _
-      | EStruct _ | EStructAccess _ | EMatch _ ),
+      | EFatalError _ | EStruct _ | EStructAccess _ | EMatch _ ),
       _ ) as e ->
     Expr.map ~f:translate_expr ~typ:translate_typ e
   | _ -> .

--- a/compiler/lcalc/compile_with_exceptions.ml
+++ b/compiler/lcalc/compile_with_exceptions.ml
@@ -71,12 +71,10 @@ let rec translate_default
 
 and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
   match e with
-  | EEmptyError, m -> Expr.eraise EmptyError (translate_mark m)
+  | EEmptyError, m -> Expr.eraise Empty (translate_mark m)
   | EErrorOnEmpty arg, m ->
     let m = translate_mark m in
-    Expr.ecatch (translate_expr arg) EmptyError
-      (Expr.eraise NoValueProvided m)
-      m
+    Expr.ecatch (translate_expr arg) Empty (Expr.eraise NoValueProvided m) m
   | EDefault { excepts; just; cons }, m ->
     translate_default excepts just cons (translate_mark m)
   | EPureDefault e, _ -> translate_expr e

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -83,7 +83,7 @@ let rec translate_default
 
 and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
   match e with
-  | EEmptyError, m ->
+  | EEmpty, m ->
     let m = translate_mark m in
     let pos = Expr.mark_pos m in
     Expr.einj
@@ -97,10 +97,8 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
         [
           ( Expr.none_constr,
             let x = Var.make "_" in
-            Expr.make_abs [| x |]
-              (Expr.eraise NoValueProvided m)
-              [TAny, pos]
-              pos );
+            Expr.make_abs [| x |] (Expr.efatalerror NoValue m) [TAny, pos] pos
+          );
           (* | None x -> raise NoValueProvided *)
           Expr.some_constr, Expr.fun_id ~var_name:"arg" m (* | Some x -> x *);
         ]
@@ -118,7 +116,7 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
       (translate_mark m)
   | ( ( ELit _ | EArray _ | EVar _ | EApp _ | EAbs _ | EExternal _
       | EIfThenElse _ | ETuple _ | ETupleAccess _ | EInj _ | EAssert _
-      | EStruct _ | EStructAccess _ | EMatch _ ),
+      | EFatalError _ | EStruct _ | EStructAccess _ | EMatch _ ),
       _ ) as e ->
     Expr.map ~f:translate_expr ~typ:translate_typ e
   | _ -> .

--- a/compiler/lcalc/compile_without_exceptions.ml
+++ b/compiler/lcalc/compile_without_exceptions.ml
@@ -61,7 +61,8 @@ let rec translate_default
   let pos = Expr.mark_pos mark_default in
   let exceptions = List.map translate_expr exceptions in
   let exceptions_and_cons_ty = Expr.maybe_ty mark_default in
-  Expr.eappop ~op:Op.HandleDefaultOpt
+  Expr.eappop
+    ~op:(Op.HandleDefaultOpt, Expr.pos cons)
     ~tys:
       [
         TArray exceptions_and_cons_ty, pos;

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -266,15 +266,6 @@ let needs_parens (e : 'm expr) : bool =
     false
   | _ -> true
 
-let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
-  match Mark.remove exc with
-  | ConflictError _ ->
-    Format.fprintf fmt "(ConflictError@ %a)" format_pos (Mark.get exc)
-  | Empty -> Format.fprintf fmt "Empty"
-  | Crash s -> Format.fprintf fmt "(Crash %S)" s
-  | NoValueProvided ->
-    Format.fprintf fmt "(NoValueProvided@ %a)" format_pos (Mark.get exc)
-
 let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
     unit =
   let format_expr = format_expr ctx in
@@ -458,13 +449,10 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
   | EFatalError er ->
     Format.fprintf fmt "raise@ (Runtime_ocaml.Runtime.Error (%a, %a))"
       Print.runtime_error er format_pos (Expr.pos e)
-  | ERaiseEmpty ->
-    Format.fprintf fmt "raise@ %a" format_exception (Empty, Expr.pos e)
+  | ERaiseEmpty -> Format.fprintf fmt "raise Empty"
   | ECatchEmpty { body; handler } ->
-    Format.fprintf fmt "@[<hv>@[<hov 2>try@ %a@]@ with@]@ @[<hov 2>%a@ ->@ %a@]"
-      format_with_parens body format_exception
-      (Empty, Expr.pos e)
-      format_with_parens handler
+    Format.fprintf fmt "@[<hv>@[<hov 2>try@ %a@]@ with Empty ->@]@ @[%a@]"
+      format_with_parens body format_with_parens handler
   | _ -> .
 
 let format_struct_embedding

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -269,7 +269,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
-  | EmptyError -> Format.fprintf fmt "EmptyError"
+  | Empty -> Format.fprintf fmt "Empty"
   | Crash s -> Format.fprintf fmt "(Crash %S)" s
   | NoValueProvided ->
     let pos = Mark.get exc in

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -374,14 +374,14 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       xs_tau format_expr body
   | EApp
       {
-        f = EAppOp { op = Log (BeginCall, info); args = [f]; _ }, _;
+        f = EAppOp { op = Log (BeginCall, info), _; args = [f]; _ }, _;
         args = [arg];
         _;
       }
     when Global.options.trace ->
     Format.fprintf fmt "(log_begin_call@ %a@ %a)@ %a" format_uid_list info
       format_with_parens f format_with_parens arg
-  | EAppOp { op = Log (VarDef var_def_info, info); args = [arg1]; _ }
+  | EAppOp { op = Log (VarDef var_def_info, info), _; args = [arg1]; _ }
     when Global.options.trace ->
     Format.fprintf fmt
       "(log_variable_definition@ %a@ {io_input=%s;@ io_output=%b}@ (%a)@ %a)"
@@ -393,7 +393,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       var_def_info.log_io_output typ_embedding_name
       (var_def_info.log_typ, Pos.no_pos)
       format_with_parens arg1
-  | EAppOp { op = Log (PosRecordIfTrueBool, _); args = [arg1]; _ }
+  | EAppOp { op = Log (PosRecordIfTrueBool, _), _; args = [arg1]; _ }
     when Global.options.trace ->
     let pos = Expr.pos e in
     Format.fprintf fmt
@@ -402,15 +402,15 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos) format_with_parens arg1
-  | EAppOp { op = Log (EndCall, info); args = [arg1]; _ }
+  | EAppOp { op = Log (EndCall, info), _; args = [arg1]; _ }
     when Global.options.trace ->
     Format.fprintf fmt "(log_end_call@ %a@ %a)" format_uid_list info
       format_with_parens arg1
-  | EAppOp { op = Log _; args = [arg1]; _ } ->
+  | EAppOp { op = Log _, _; args = [arg1]; _ } ->
     Format.fprintf fmt "%a" format_with_parens arg1
   | EAppOp
       {
-        op = (HandleDefault | HandleDefaultOpt) as op;
+        op = ((HandleDefault | HandleDefaultOpt) as op), _;
         args = (EArray excs, _) :: _ as args;
         _;
       } ->
@@ -433,14 +433,14 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
     Format.fprintf fmt
       "@[<hov 2> if@ @[<hov 2>%a@]@ then@ @[<hov 2>%a@]@ else@ @[<hov 2>%a@]@]"
       format_with_parens cond format_with_parens etrue format_with_parens efalse
-  | EAppOp { op; args; _ } ->
+  | EAppOp { op = op, pos; args; _ } ->
     Format.fprintf fmt "@[<hov 2>%s@ %t%a@]" (Operator.name op)
       (fun ppf ->
         match op with
         | Map2 | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat
         | Div_dur_dur | Lt_dur_dur | Lte_dur_dur | Gt_dur_dur | Gte_dur_dur
         | Eq_dur_dur ->
-          Format.fprintf ppf "%a@ " format_pos (Expr.pos e)
+          Format.fprintf ppf "%a@ " format_pos pos
         | _ -> ())
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -437,10 +437,11 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
     Format.fprintf fmt "@[<hov 2>%s@ %t%a@]" (Operator.name op)
       (fun ppf ->
         match op with
-        | Map2 | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat
-        | Div_dur_dur | Lt_dur_dur | Lte_dur_dur | Gt_dur_dur | Gte_dur_dur
+        | Map2 | Lt_dur_dur | Lte_dur_dur | Gt_dur_dur | Gte_dur_dur
         | Eq_dur_dur ->
           Format.fprintf ppf "%a@ " format_pos pos
+        | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat | Div_dur_dur ->
+          Format.fprintf ppf "%a@ " format_pos (Expr.pos (List.nth args 1))
         | _ -> ())
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -142,7 +142,7 @@ let rec lazy_eval :
         log "@]}";
         e, env
       | e, _ -> error e "Invalid apply on %a" Expr.format e)
-  | (EAbs _ | ELit _ | EEmptyError), _ -> e0, env (* these are values *)
+  | (EAbs _ | ELit _ | EEmpty), _ -> e0, env (* these are values *)
   | (EStruct _ | ETuple _ | EInj _ | EArray _), _ ->
     if not llevel.eval_struct then e0, env
     else
@@ -183,7 +183,7 @@ let rec lazy_eval :
       List.filter_map
         (fun e ->
           match eval_to_value env e ~eval_default:false with
-          | (EEmptyError, _), _ -> None
+          | (EEmpty, _), _ -> None
           | e -> Some e)
         excepts
     in
@@ -191,7 +191,7 @@ let rec lazy_eval :
     | [] -> (
       match eval_to_value env just with
       | (ELit (LBool true), _), _ -> lazy_eval ctx env llevel cons
-      | (ELit (LBool false), _), _ -> (EEmptyError, m), env
+      | (ELit (LBool false), _), _ -> (EEmpty, m), env
       | e, _ -> error e "Invalid exception justification %a" Expr.format e)
     | [(e, env)] ->
       log "@[<hov 5>EVAL %a@]" Expr.format e;
@@ -208,7 +208,7 @@ let rec lazy_eval :
     | e, _ -> error e "Invalid condition %a" Expr.format e)
   | EErrorOnEmpty e, _ -> (
     match eval_to_value env e ~eval_default:false with
-    | ((EEmptyError, _) as e'), _ ->
+    | ((EEmpty, _) as e'), _ ->
       (* This does _not_ match the eager semantics ! *)
       error e' "This value is undefined %a" Expr.format e
     | e, env -> lazy_eval ctx env llevel e)
@@ -220,6 +220,8 @@ let rec lazy_eval :
       | (ELit (LBool false), _), _ ->
         error e "Assert failure (%a)" Expr.format e
       | _ -> error e "Invalid assertion condition %a" Expr.format e)
+  | EFatalError err, m ->
+    error e0 "%a" Format.pp_print_text (Runtime.error_message err)
   | EExternal _, _ -> assert false (* todo *)
   | _ -> .
 
@@ -251,7 +253,7 @@ let interpret_program (prg : ('dcalc, 'm) gexpr program) (scope : ScopeName.t) :
              | TArrow (ty_in, ty_out), _ ->
                Expr.make_abs
                  [| Var.make "_" |]
-                 (Bindlib.box EEmptyError, Expr.with_ty m ty_out)
+                 (Bindlib.box EEmpty, Expr.with_ty m ty_out)
                  ty_in (Expr.mark_pos m)
              | ty -> Expr.evar (Var.make "undefined_input") (Expr.with_ty m ty))
            (StructName.Map.find scope_arg_struct ctx.ctx_structs))

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -61,7 +61,7 @@ and naked_expr =
   | EArray of expr list
   | ELit of lit
   | EApp of { f : expr; args : expr list }
-  | EAppOp of { op : operator; args : expr list }
+  | EAppOp of { op : operator Mark.pos; args : expr list }
   | EExternal of { modname : VarName.t Mark.pos; name : string Mark.pos }
 
 type stmt =

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -69,8 +69,9 @@ type stmt =
   | SLocalDecl of { name : VarName.t Mark.pos; typ : typ }
   | SLocalInit of { name : VarName.t Mark.pos; typ : typ; expr : expr }
   | SLocalDef of { name : VarName.t Mark.pos; expr : expr; typ : typ }
-  | STryExcept of { try_block : block; except : except; with_block : block }
-  | SRaise of except
+  | STryWEmpty of { try_block : block; with_block : block }
+  | SRaiseEmpty
+  | SFatalError of Runtime.error
   | SIfThenElse of { if_expr : expr; then_block : block; else_block : block }
   | SSwitch of {
       switch_expr : expr;

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -140,7 +140,7 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) : RevBlock.t * A.expr =
       e1_stmts, (A.ETupleAccess { e1 = new_e1; index }, Expr.pos expr)
     | EAppOp
         {
-          op = Op.HandleDefaultOpt;
+          op = Op.HandleDefaultOpt, _;
           args = [_exceptions; _just; _cons];
           tys = _;
         }
@@ -275,7 +275,7 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
       e_stmts
   | EFatalError err -> [SFatalError err, Expr.pos block_expr]
   | EAppOp
-      { op = Op.HandleDefaultOpt; tys = _; args = [exceptions; just; cons] }
+      { op = Op.HandleDefaultOpt, _; tys = _; args = [exceptions; just; cons] }
     when ctxt.config.keep_special_ops ->
     let exceptions =
       match Mark.remove exceptions with

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -227,7 +227,8 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) : RevBlock.t * A.expr =
           Expr.pos expr )
       in
       RevBlock.empty, (EExternal { modname; name }, Expr.pos expr)
-    | ECatch _ | EAbs _ | EIfThenElse _ | EMatch _ | EAssert _ | ERaise _ ->
+    | ECatchEmpty _ | EAbs _ | EIfThenElse _ | EMatch _ | EAssert _
+    | EFatalError _ | ERaiseEmpty ->
       raise (NotAnExpr { needs_a_local_decl = true })
     | _ -> .
   with NotAnExpr { needs_a_local_decl } ->
@@ -272,6 +273,7 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
     RevBlock.rebuild
       ~tail:[A.SAssert (Mark.remove new_e), Expr.pos block_expr]
       e_stmts
+  | EFatalError err -> [SFatalError err, Expr.pos block_expr]
   | EAppOp
       { op = Op.HandleDefaultOpt; tys = _; args = [exceptions; just; cons] }
     when ctxt.config.keep_special_ops ->
@@ -481,15 +483,14 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
               },
             Expr.pos block_expr );
         ]
-  | ECatch { body; exn; handler } ->
+  | ECatchEmpty { body; handler } ->
     let s_e_try = translate_statements ctxt body in
     let s_e_catch = translate_statements ctxt handler in
     [
-      ( A.STryExcept
-          { try_block = s_e_try; except = exn; with_block = s_e_catch },
+      ( A.STryWEmpty { try_block = s_e_try; with_block = s_e_catch },
         Expr.pos block_expr );
     ]
-  | ERaise except ->
+  | ERaiseEmpty ->
     (* Before raising the exception, we still give a dummy definition to the
        current variable so that tools like mypy don't complain. *)
     (match ctxt.inside_definition_of with
@@ -504,7 +505,7 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
           Expr.pos block_expr );
       ]
     | _ -> [])
-    @ [A.SRaise except, Expr.pos block_expr]
+    @ [A.SRaiseEmpty, Expr.pos block_expr]
   | EInj { e = e1; cons; name } when ctxt.config.no_struct_literals ->
     let e1_stmts, new_e1 = translate_expr ctxt e1 in
     let tmp_struct_var_name =
@@ -572,7 +573,7 @@ and translate_statements (ctxt : 'm ctxt) (block_expr : 'm L.expr) : A.block =
     let e_stmts, new_e = translate_expr ctxt block_expr in
     let tail =
       match (e_stmts :> (A.stmt * Pos.t) list) with
-      | (A.SRaise _, _) :: _ ->
+      | (A.SRaiseEmpty, _) :: _ ->
         (* if the last statement raises an exception, then we don't need to
            return or to define the current variable since this code will be
            unreachable *)

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -74,15 +74,15 @@ let rec format_expr
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" EnumConstructor.format cons
       format_expr e
   | ELit l -> Print.lit fmt l
-  | EAppOp { op = (Map | Filter) as op; args = [arg1; arg2] } ->
+  | EAppOp { op = ((Map | Filter) as op), _; args = [arg1; arg2] } ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" (Print.operator ~debug) op
       format_with_parens arg1 format_with_parens arg2
-  | EAppOp { op; args = [arg1; arg2] } ->
+  | EAppOp { op = op, _; args = [arg1; arg2] } ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@ %a@]" format_with_parens arg1
       (Print.operator ~debug) op format_with_parens arg2
-  | EAppOp { op = Log _; args = [arg1] } when not debug ->
+  | EAppOp { op = Log _, _; args = [arg1] } when not debug ->
     Format.fprintf fmt "%a" format_with_parens arg1
-  | EAppOp { op; args = [arg1] } ->
+  | EAppOp { op = op, _; args = [arg1] } ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" (Print.operator ~debug) op
       format_with_parens arg1
   | EApp { f; args = [] } ->
@@ -93,7 +93,7 @@ let rec format_expr
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
          format_with_parens)
       args
-  | EAppOp { op; args } ->
+  | EAppOp { op = op, _; args } ->
     Format.fprintf fmt "@[<hov 2>%a@ %a@]" (Print.operator ~debug) op
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -141,12 +141,12 @@ let rec format_statement
     Format.fprintf fmt "@[<v 2>%a%a@ %a@]@\n@[<v 2>%a %a%a@ %a@]" Print.keyword
       "try" Print.punctuation ":"
       (format_block decl_ctx ~debug)
-      b_try Print.keyword "with" Print.except Empty Print.punctuation ":"
+      b_try Print.keyword "with" Print.op_style "Empty" Print.punctuation ":"
       (format_block decl_ctx ~debug)
       b_with
   | SRaiseEmpty ->
-    Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "raise" Print.except
-      Empty
+    Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "raise" Print.op_style
+      "Empty"
   | SFatalError err ->
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "fatal"
       Print.runtime_error err

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -137,16 +137,19 @@ let rec format_statement
       Print.punctuation "="
       (format_expr decl_ctx ~debug)
       naked_expr
-  | STryExcept { try_block = b_try; except; with_block = b_with } ->
+  | STryWEmpty { try_block = b_try; with_block = b_with } ->
     Format.fprintf fmt "@[<v 2>%a%a@ %a@]@\n@[<v 2>%a %a%a@ %a@]" Print.keyword
       "try" Print.punctuation ":"
       (format_block decl_ctx ~debug)
-      b_try Print.keyword "with" Print.except except Print.punctuation ":"
+      b_try Print.keyword "with" Print.except Empty Print.punctuation ":"
       (format_block decl_ctx ~debug)
       b_with
-  | SRaise except ->
+  | SRaiseEmpty ->
     Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "raise" Print.except
-      except
+      Empty
+  | SFatalError err ->
+    Format.fprintf fmt "@[<hov 2>%a %a@]" Print.keyword "fatal"
+      Print.runtime_error err
   | SIfThenElse { if_expr = e_if; then_block = b_true; else_block = b_false } ->
     Format.fprintf fmt "@[<v 2>%a @[<hov 2>%a@]%a@ %a@ @]@[<v 2>%a%a@ %a@]"
       Print.keyword "if"

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -453,7 +453,7 @@ let rec format_statement
        longjmp(catala_fatal_error_jump_buffer, 0);"
       (match e with
       | ConflictError _ -> "catala_conflict"
-      | EmptyError -> "catala_empty"
+      | Empty -> "catala_empty"
       | NoValueProvided -> "catala_no_value_provided"
       | Crash _ -> "catala_crash")
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -350,26 +350,23 @@ let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :
     failwith
       "should not happen, array initialization is caught at the statement level"
   | ELit l -> Format.fprintf fmt "%a" format_lit (Mark.copy e l)
-  | EAppOp { op = (Map | Filter) as op; args = [arg1; arg2] } ->
-    Format.fprintf fmt "%a(%a,@ %a)" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1 (format_expression ctx) arg2
+  | EAppOp { op = ((Map | Filter), _) as op; args = [arg1; arg2] } ->
+    Format.fprintf fmt "%a(%a,@ %a)" format_op op (format_expression ctx) arg1
+      (format_expression ctx) arg2
   | EAppOp { op; args = [arg1; arg2] } ->
-    Format.fprintf fmt "(%a %a@ %a)" (format_expression ctx) arg1 format_op
-      (op, Pos.no_pos) (format_expression ctx) arg2
-  | EAppOp { op = Not; args = [arg1] } ->
-    Format.fprintf fmt "%a %a" format_op (Not, Pos.no_pos)
-      (format_expression ctx) arg1
+    Format.fprintf fmt "(%a %a@ %a)" (format_expression ctx) arg1 format_op op
+      (format_expression ctx) arg2
+  | EAppOp { op = (Not, _) as op; args = [arg1] } ->
+    Format.fprintf fmt "%a %a" format_op op (format_expression ctx) arg1
   | EAppOp
       {
-        op = (Minus_int | Minus_rat | Minus_mon | Minus_dur) as op;
+        op = ((Minus_int | Minus_rat | Minus_mon | Minus_dur), _) as op;
         args = [arg1];
       } ->
-    Format.fprintf fmt "%a %a" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1
+    Format.fprintf fmt "%a %a" format_op op (format_expression ctx) arg1
   | EAppOp { op; args = [arg1] } ->
-    Format.fprintf fmt "%a(%a)" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1
-  | EAppOp { op = HandleDefaultOpt | HandleDefault; args = _ } ->
+    Format.fprintf fmt "%a(%a)" format_op op (format_expression ctx) arg1
+  | EAppOp { op = (HandleDefaultOpt | HandleDefault), _; args = _ } ->
     failwith "should not happen because of keep_special_ops"
   | EApp { f; args } ->
     Format.fprintf fmt "%a(@[<hov 0>%a)@]" (format_expression ctx) f
@@ -378,7 +375,7 @@ let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :
          (format_expression ctx))
       args
   | EAppOp { op; args } ->
-    Format.fprintf fmt "%a(@[<hov 0>%a)@]" format_op (op, Pos.no_pos)
+    Format.fprintf fmt "%a(@[<hov 0>%a)@]" format_op op
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
          (format_expression ctx))

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -258,7 +258,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
-  | EmptyError -> Format.fprintf fmt "EmptyError"
+  | Empty -> Format.fprintf fmt "Empty"
   | Crash _ -> Format.fprintf fmt "Crash"
   | NoValueProvided ->
     Format.fprintf fmt

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -247,27 +247,20 @@ let format_func_name (fmt : Format.formatter) (v : FuncName.t) : unit =
   let v_str = Mark.remove (FuncName.get_info v) in
   format_name_cleaned fmt v_str
 
-let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
-  let pos = Mark.get exc in
-  match Mark.remove exc with
-  | ConflictError _ ->
-    Format.fprintf fmt
-      "ConflictError(@[<hov 0>SourcePosition(@[<hov 0>filename=\"%s\",@ \
-       start_line=%d,@ start_column=%d,@ end_line=%d,@ end_column=%d,@ \
-       law_headings=%a)@])@]"
-      (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
-      (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
-      (Pos.get_law_info pos)
-  | Empty -> Format.fprintf fmt "Empty"
-  | Crash _ -> Format.fprintf fmt "Crash"
-  | NoValueProvided ->
-    Format.fprintf fmt
-      "NoValueProvided(@[<hov 0>SourcePosition(@[<hov 0>filename=\"%s\",@ \
-       start_line=%d,@ start_column=%d,@ end_line=%d,@ end_column=%d,@ \
-       law_headings=%a)@])@]"
-      (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
-      (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
-      (Pos.get_law_info pos)
+let format_position ppf pos =
+  Format.fprintf ppf
+    "@[<hov 4>SourcePosition(@,\
+     filename=\"%s\",@ start_line=%d, start_column=%d,@ end_line=%d, \
+     end_column=%d,@ law_headings=%a@;\
+     <0 -4>)@]" (Pos.get_file pos) (Pos.get_start_line pos)
+    (Pos.get_start_column pos) (Pos.get_end_line pos) (Pos.get_end_column pos)
+    format_string_list (Pos.get_law_info pos)
+
+let format_error (ppf : Format.formatter) (err : Runtime.error Mark.pos) : unit
+    =
+  let pos = Mark.get err in
+  let tag = Runtime.error_to_string (Mark.remove err) in
+  Format.fprintf ppf "%s(%a)" tag format_position pos
 
 let rec format_expression ctx (fmt : Format.formatter) (e : expr) : unit =
   match Mark.remove e with
@@ -423,13 +416,12 @@ let rec format_statement ctx (fmt : Format.formatter) (s : stmt Mark.pos) : unit
     ->
     Format.fprintf fmt "@[<hov 4>%a = %a@]" format_var (Mark.remove v)
       (format_expression ctx) e
-  | STryExcept { try_block = try_b; except; with_block = catch_b } ->
-    Format.fprintf fmt "@[<hov 4>try:@\n%a@]@\n@[<hov 4>except %a:@\n%a@]"
-      (format_block ctx) try_b format_exception (except, Pos.no_pos)
-      (format_block ctx) catch_b
-  | SRaise except ->
-    Format.fprintf fmt "@[<hov 4>raise %a@]" format_exception
-      (except, Mark.get s)
+  | STryWEmpty { try_block = try_b; with_block = catch_b } ->
+    Format.fprintf fmt "@[<v 4>try:@,%a@]@\n@[<v 4>except Empty:@,%a@]"
+      (format_block ctx) try_b (format_block ctx) catch_b
+  | SRaiseEmpty -> Format.fprintf fmt "raise Empty"
+  | SFatalError err ->
+    Format.fprintf fmt "@[<hov 4>raise %a@]" format_error (err, Mark.get s)
   | SIfThenElse { if_expr = cond; then_block = b1; else_block = b2 } ->
     Format.fprintf fmt "@[<hov 4>if %a:@\n%a@]@\n@[<hov 4>else:@\n%a@]"
       (format_expression ctx) cond (format_block ctx) b1 (format_block ctx) b2

--- a/compiler/scalc/to_r.ml
+++ b/compiler/scalc/to_r.ml
@@ -305,29 +305,26 @@ let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :
          (fun fmt e -> Format.fprintf fmt "%a" (format_expression ctx) e))
       es
   | ELit l -> Format.fprintf fmt "%a" format_lit (Mark.copy e l)
-  | EAppOp { op = (Map | Filter) as op; args = [arg1; arg2] } ->
-    Format.fprintf fmt "%a(%a,@ %a)" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1 (format_expression ctx) arg2
+  | EAppOp { op = ((Map | Filter), _) as op; args = [arg1; arg2] } ->
+    Format.fprintf fmt "%a(%a,@ %a)" format_op op (format_expression ctx) arg1
+      (format_expression ctx) arg2
   | EAppOp { op; args = [arg1; arg2] } ->
-    Format.fprintf fmt "(%a %a@ %a)" (format_expression ctx) arg1 format_op
-      (op, Pos.no_pos) (format_expression ctx) arg2
-  | EAppOp { op = Not; args = [arg1] } ->
-    Format.fprintf fmt "%a %a" format_op (Not, Pos.no_pos)
-      (format_expression ctx) arg1
+    Format.fprintf fmt "(%a %a@ %a)" (format_expression ctx) arg1 format_op op
+      (format_expression ctx) arg2
+  | EAppOp { op = (Not, _) as op; args = [arg1] } ->
+    Format.fprintf fmt "%a %a" format_op op (format_expression ctx) arg1
   | EAppOp
       {
-        op = (Minus_int | Minus_rat | Minus_mon | Minus_dur) as op;
+        op = ((Minus_int | Minus_rat | Minus_mon | Minus_dur), _) as op;
         args = [arg1];
       } ->
-    Format.fprintf fmt "%a %a" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1
+    Format.fprintf fmt "%a %a" format_op op (format_expression ctx) arg1
   | EAppOp { op; args = [arg1] } ->
-    Format.fprintf fmt "%a(%a)" format_op (op, Pos.no_pos)
-      (format_expression ctx) arg1
-  | EAppOp { op = HandleDefaultOpt; _ } ->
+    Format.fprintf fmt "%a(%a)" format_op op (format_expression ctx) arg1
+  | EAppOp { op = HandleDefaultOpt, _; _ } ->
     Message.error ~internal:true
       "R compilation does not currently support the avoiding of exceptions"
-  | EAppOp { op = HandleDefault as op; args; _ } ->
+  | EAppOp { op = (HandleDefault as op), _; args; _ } ->
     let pos = Mark.get e in
     Format.fprintf fmt
       "%a(@[<hov 0>catala_position(filename=\"%s\",@ start_line=%d,@ \
@@ -359,7 +356,7 @@ let rec format_expression (ctx : decl_ctx) (fmt : Format.formatter) (e : expr) :
          (format_expression ctx))
       args
   | EAppOp { op; args } ->
-    Format.fprintf fmt "%a(@[<hov 0>%a)@]" format_op (op, Pos.no_pos)
+    Format.fprintf fmt "%a(@[<hov 0>%a)@]" format_op op
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
          (format_expression ctx))

--- a/compiler/scalc/to_r.ml
+++ b/compiler/scalc/to_r.ml
@@ -264,7 +264,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos)
-  | EmptyError -> Format.fprintf fmt "catala_empty_error()"
+  | Empty -> Format.fprintf fmt "catala_empty_error()"
   | Crash _ -> Format.fprintf fmt "catala_crash()"
   | NoValueProvided ->
     Format.fprintf fmt
@@ -278,7 +278,7 @@ let format_exception (fmt : Format.formatter) (exc : except Mark.pos) : unit =
 let format_exception_name (fmt : Format.formatter) (exc : except) : unit =
   match exc with
   | ConflictError _ -> Format.fprintf fmt "catala_conflict_error"
-  | EmptyError -> Format.fprintf fmt "catala_empty_error"
+  | Empty -> Format.fprintf fmt "catala_empty"
   | Crash _ -> Format.fprintf fmt "catala_crash"
   | NoValueProvided -> Format.fprintf fmt "catala_no_value_provided_error"
 

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -39,7 +39,7 @@ let tag_with_log_entry
     (markings : Uid.MarkedString.info list) : untyped Ast.expr boxed =
   if Global.options.trace then
     Expr.eappop
-      ~op:(Log (l, markings))
+      ~op:(Log (l, markings), Expr.pos e)
       ~tys:[TAny, Expr.pos e]
       ~args:[e] (Mark.get e)
   else e
@@ -200,9 +200,7 @@ let rec translate_expr (ctx : ctx) (e : D.expr) : untyped Ast.expr boxed =
       ~monomorphic:(fun op -> Expr.eappop ~op ~tys ~args m)
       ~polymorphic:(fun op -> Expr.eappop ~op ~tys ~args m)
       ~overloaded:(fun op ->
-        match
-          Operator.resolve_overload ctx.decl_ctx (Mark.add (Expr.pos e) op) tys
-        with
+        match Operator.resolve_overload ctx.decl_ctx op tys with
         | op, `Straight -> Expr.eappop ~op ~tys ~args m
         | op, `Reversed ->
           Expr.eappop ~op ~tys:(List.rev tys) ~args:(List.rev args) m)

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -448,13 +448,13 @@ let rec rule_tree_to_expr
              match Expr.unbox base_just with
              | ELit (LBool false), _ -> acc
              | _ ->
+               let cons = Expr.make_puredefault base_cons in
                Expr.edefault
                  ~excepts:[]
                    (* Here we insert the logging command that records when a
                       decision is taken for the value of a variable. *)
                  ~just:(tag_with_log_entry base_just PosRecordIfTrueBool [])
-                 ~cons:(Expr.epuredefault base_cons emark)
-                 emark
+                 ~cons (Mark.get cons)
                :: acc)
            (translate_and_unbox_list base_just_list)
            (translate_and_unbox_list base_cons_list)

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -553,6 +553,7 @@ and ('a, 'b, 'm) base_gexpr =
     }
       -> ('a, < explicitScopes : no ; .. >, 't) base_gexpr
   | EAssert : ('a, 'm) gexpr -> ('a, < assertions : yes ; .. >, 'm) base_gexpr
+  | EFatalError : Runtime.error -> ('a, < .. >, 'm) base_gexpr
   (* Default terms *)
   | EDefault : {
       excepts : ('a, 'm) gexpr list;
@@ -564,15 +565,14 @@ and ('a, 'b, 'm) base_gexpr =
       ('a, 'm) gexpr
       -> ('a, < defaultTerms : yes ; .. >, 'm) base_gexpr
       (** "return" of a pure term, so that it can be typed as [default] *)
-  | EEmptyError : ('a, < defaultTerms : yes ; .. >, 'm) base_gexpr
+  | EEmpty : ('a, < defaultTerms : yes ; .. >, 'm) base_gexpr
   | EErrorOnEmpty :
       ('a, 'm) gexpr
       -> ('a, < defaultTerms : yes ; .. >, 'm) base_gexpr
   (* Lambda calculus with exceptions *)
-  | ERaise : except -> ('a, < exceptions : yes ; .. >, 'm) base_gexpr
-  | ECatch : {
+  | ERaiseEmpty : ('a, < exceptions : yes ; .. >, 'm) base_gexpr
+  | ECatchEmpty : {
       body : ('a, 'm) gexpr;
-      exn : except;
       handler : ('a, 'm) gexpr;
     }
       -> ('a, < exceptions : yes ; .. >, 'm) base_gexpr

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -378,12 +378,6 @@ end
 
 type 'a operator = 'a Op.t
 
-type except =
-  | ConflictError of Pos.t list
-  | Empty
-  | NoValueProvided
-  | Crash of string
-
 (** {2 Markings} *)
 
 type untyped = { pos : Pos.t } [@@caml.unboxed]

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -472,7 +472,7 @@ and ('a, 'b, 'm) base_gexpr =
     }
       -> ('a, < .. >, 'm) base_gexpr
   | EAppOp : {
-      op : 'a operator;
+      op : 'a operator Mark.pos;
       args : ('a, 'm) gexpr list;
       tys : typ list;
     }

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -380,7 +380,7 @@ type 'a operator = 'a Op.t
 
 type except =
   | ConflictError of Pos.t list
-  | EmptyError
+  | Empty
   | NoValueProvided
   | Crash of string
 

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -606,8 +606,6 @@ let compare_location
   | _, ToplevelVar _ -> .
 
 let equal_location a b = compare_location a b = 0
-let equal_except ex1 ex2 = ex1 = ex2
-let compare_except ex1 ex2 = Stdlib.compare ex1 ex2
 let equal_error er1 er2 = er1 = er2
 let compare_error er1 er2 = Stdlib.compare er1 er2
 

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -1058,14 +1058,11 @@ let thunk_term term =
 
 let empty_thunked_term mark = thunk_term (Bindlib.box EEmpty, mark)
 
-let unthunk_term_nobox term mark =
-  Mark.add mark
-    (EApp
-       {
-         f = term;
-         args = [ELit LUnit, mark];
-         tys = [TLit TUnit, mark_pos mark];
-       })
+let unthunk_term_nobox = function
+  | EAbs { binder; tys = [(TLit TUnit, _)] }, _ ->
+    let _v, e = Bindlib.unmbind binder in
+    e
+  | _ -> invalid_arg "unthunk_term_nobox"
 
 let make_let_in x tau e1 e2 mpos =
   make_app (make_abs [| x |] e2 [tau] mpos) [e1] [tau] (pos e2)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -361,7 +361,10 @@ val empty_thunked_term :
   'm mark -> (< defaultTerms : yes ; .. >, 'm) boxed_gexpr
 
 val thunk_term : ('a any, 'b) boxed_gexpr -> ('a, 'b) boxed_gexpr
-val unthunk_term_nobox : ('a any, 'm) gexpr -> 'm mark -> ('a, 'm) gexpr
+
+val unthunk_term_nobox : ('a any, 'm) gexpr -> ('a, 'm) gexpr
+(** Remove thunking around an expression (this assumes it's the right form,
+    raises Invalid_argument otherwise) *)
 
 val make_let_in :
   ('a, 'm) gexpr Var.t ->

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -85,7 +85,7 @@ val eassert :
 val efatalerror : Runtime.error -> 'm mark -> (< .. >, 'm) boxed_gexpr
 
 val eappop :
-  op:'a operator ->
+  op:'a operator Mark.pos ->
   args:('a, 'm) boxed_gexpr list ->
   tys:typ list ->
   'm mark ->
@@ -243,7 +243,7 @@ val untype : ('a, 'm) gexpr -> ('a, untyped) boxed_gexpr
 
 val map :
   ?typ:(typ -> typ) ->
-  ?op:('a operator -> 'b operator) ->
+  ?op:('a operator Mark.pos -> 'b operator Mark.pos) ->
   f:(('a, 'm1) gexpr -> ('b, 'm2) boxed_gexpr) ->
   (('a, 'b, 'm1) base_gexpr, 'm2) marked ->
   ('b, 'm2) boxed_gexpr

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -418,8 +418,6 @@ val equal_lit : lit -> lit -> bool
 val compare_lit : lit -> lit -> int
 val equal_location : 'a glocation Mark.pos -> 'a glocation Mark.pos -> bool
 val compare_location : 'a glocation Mark.pos -> 'a glocation Mark.pos -> int
-val equal_except : except -> except -> bool
-val compare_except : except -> except -> int
 
 val equal : ('a, 'm) gexpr -> ('a, 'm) gexpr -> bool
 (** Determines if two expressions are equal, omitting their position information *)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -82,6 +82,8 @@ val eassert :
   'm mark ->
   ((< assertions : yes ; .. > as 'a), 'm) boxed_gexpr
 
+val efatalerror : Runtime.error -> 'm mark -> (< .. >, 'm) boxed_gexpr
+
 val eappop :
   op:'a operator ->
   args:('a, 'm) boxed_gexpr list ->
@@ -108,22 +110,20 @@ val eifthenelse :
   'm mark ->
   ('a any, 'm) boxed_gexpr
 
-val eemptyerror :
-  'm mark -> ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
+val eempty : 'm mark -> ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
 
 val eerroronempty :
   ('a, 'm) boxed_gexpr ->
   'm mark ->
   ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
 
-val ecatch :
+val ecatchempty :
   ('a, 'm) boxed_gexpr ->
-  except ->
   ('a, 'm) boxed_gexpr ->
   'm mark ->
   ((< exceptions : yes ; .. > as 'a), 'm) boxed_gexpr
 
-val eraise : except -> 'm mark -> (< exceptions : yes ; .. >, 'm) boxed_gexpr
+val eraiseempty : 'm mark -> (< exceptions : yes ; .. >, 'm) boxed_gexpr
 val elocation : 'a glocation -> 'm mark -> ((< .. > as 'a), 'm) boxed_gexpr
 
 val estruct :
@@ -229,6 +229,8 @@ val option_enum : EnumName.t
 val none_constr : EnumConstructor.t
 val some_constr : EnumConstructor.t
 val option_enum_config : typ EnumConstructor.Map.t
+val pos_to_runtime : Pos.t -> Runtime.source_position
+val runtime_to_pos : Runtime.source_position -> Pos.t
 
 (** Manipulation of marked expressions *)
 

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -381,7 +381,7 @@ let rec evaluate_operator
       List.filter_map
         (fun e ->
           try Some (evaluate_expr (Expr.unthunk_term_nobox e m))
-          with CatalaException (EmptyError, _) -> None)
+          with CatalaException (Empty, _) -> None)
         excepts
     with
     | [] -> (
@@ -390,7 +390,7 @@ let rec evaluate_operator
       | ELit (LBool true) ->
         Mark.remove
           (evaluate_expr (Expr.unthunk_term_nobox cons (Mark.get cons)))
-      | ELit (LBool false) -> raise (CatalaException (EmptyError, pos))
+      | ELit (LBool false) -> raise (CatalaException (Empty, pos))
       | _ ->
         Message.error ~pos
           "Default justification has not been reduced to a boolean at@ \
@@ -595,7 +595,7 @@ and val_to_runtime :
         let tys = List.map (fun a -> Expr.maybe_ty (Mark.get a)) args in
         val_to_runtime eval_expr ctx tret
           (try eval_expr ctx (EApp { f = v; args; tys }, m)
-           with CatalaException (EmptyError, _) -> raise Runtime.EmptyError)
+           with CatalaException (Empty, _) -> raise Runtime.EmptyError)
       | targ :: targs ->
         Obj.repr (fun x ->
             curry (runtime_to_val eval_expr ctx m targ x :: acc) targs)
@@ -933,7 +933,7 @@ let interp_failure_message ~pos = function
       "There is a conflict between multiple valid consequences for assigning \
        the same variable."
   | Crash s -> Message.error ~pos "%s" s
-  | EmptyError ->
+  | Empty ->
     Message.error ~pos ~internal:true
       "A variable without valid definition escaped"
 
@@ -969,7 +969,7 @@ let interpret_program_lcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
                tell with just this info. *)
             Expr.make_abs
               (Array.of_list @@ List.map (fun _ -> Var.make "_") ty_in)
-              (Expr.eraise EmptyError (Expr.with_ty mark_e ty_out))
+              (Expr.eraise Empty (Expr.with_ty mark_e ty_out))
               ty_in (Expr.mark_pos mark_e)
           | TTuple ((TArrow (ty_in, (TOption _, _)), _) :: _) ->
             (* ... or a closure if closure conversion is enabled *)

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -352,16 +352,15 @@ let rec evaluate_operator
     match
       List.filter_map
         (fun e ->
-          try Some (evaluate_expr (Expr.unthunk_term_nobox e m))
+          try Some (evaluate_expr (Expr.unthunk_term_nobox e))
           with Runtime.Empty -> None)
         excepts
     with
     | [] -> (
-      let just = evaluate_expr (Expr.unthunk_term_nobox just m) in
+      let just = evaluate_expr (Expr.unthunk_term_nobox just) in
       match Mark.remove just with
       | ELit (LBool true) ->
-        Mark.remove
-          (evaluate_expr (Expr.unthunk_term_nobox cons (Mark.get cons)))
+        Mark.remove (evaluate_expr (Expr.unthunk_term_nobox cons))
       | ELit (LBool false) -> raise Runtime.Empty
       | _ ->
         Message.error ~pos
@@ -385,10 +384,10 @@ let rec evaluate_operator
     in
     match valid_exceptions with
     | [] -> (
-      let e = evaluate_expr (Expr.unthunk_term_nobox justification m) in
+      let e = evaluate_expr (Expr.unthunk_term_nobox justification) in
       match Mark.remove e with
       | ELit (LBool true) ->
-        Mark.remove (evaluate_expr (Expr.unthunk_term_nobox conclusion m))
+        Mark.remove (evaluate_expr (Expr.unthunk_term_nobox conclusion))
       | ELit (LBool false) ->
         EInj
           {

--- a/compiler/shared_ast/interpreter.mli
+++ b/compiler/shared_ast/interpreter.mli
@@ -20,8 +20,6 @@
 open Catala_utils
 open Definitions
 
-exception CatalaException of except * Pos.t
-
 val evaluate_operator :
   ((((_, _, _) interpr_kind as 'a), 'm) gexpr -> ('a, 'm) gexpr) ->
   'a operator ->

--- a/compiler/shared_ast/interpreter.mli
+++ b/compiler/shared_ast/interpreter.mli
@@ -22,7 +22,7 @@ open Definitions
 
 val evaluate_operator :
   ((((_, _, _) interpr_kind as 'a), 'm) gexpr -> ('a, 'm) gexpr) ->
-  'a operator ->
+  'a operator Mark.pos ->
   'm mark ->
   Global.backend_lang ->
   ('a, 'm) gexpr list ->

--- a/compiler/shared_ast/operator.ml
+++ b/compiler/shared_ast/operator.ml
@@ -330,36 +330,39 @@ let equal t1 t2 = compare t1 t2 = 0
 
 let kind_dispatch :
     type a.
-    polymorphic:(< polymorphic : yes ; .. > t -> 'b) ->
-    monomorphic:(< monomorphic : yes ; .. > t -> 'b) ->
-    ?overloaded:(< overloaded : yes ; .. > t -> 'b) ->
-    ?resolved:(< resolved : yes ; .. > t -> 'b) ->
-    a t ->
+    polymorphic:(< polymorphic : yes ; .. > t Mark.pos -> 'b) ->
+    monomorphic:(< monomorphic : yes ; .. > t Mark.pos -> 'b) ->
+    ?overloaded:(< overloaded : yes ; .. > t Mark.pos -> 'b) ->
+    ?resolved:(< resolved : yes ; .. > t Mark.pos -> 'b) ->
+    a t Mark.pos ->
     'b =
  fun ~polymorphic ~monomorphic ?(overloaded = fun _ -> assert false)
      ?(resolved = fun _ -> assert false) op ->
   match op with
-  | ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth | And
-    | Or | Xor ) as op ->
+  | ( ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth
+      | And | Or | Xor ),
+      _ ) as op ->
     monomorphic op
-  | ( Log _ | Length | Eq | Map | Map2 | Concat | Filter | Reduce | Fold
-    | HandleDefault | HandleDefaultOpt | FromClosureEnv | ToClosureEnv ) as op
-    ->
+  | ( ( Log _ | Length | Eq | Map | Map2 | Concat | Filter | Reduce | Fold
+      | HandleDefault | HandleDefaultOpt | FromClosureEnv | ToClosureEnv ),
+      _ ) as op ->
     polymorphic op
-  | ( Minus | ToRat | ToMoney | Round | Add | Sub | Mult | Div | Lt | Lte | Gt
-    | Gte ) as op ->
+  | ( ( Minus | ToRat | ToMoney | Round | Add | Sub | Mult | Div | Lt | Lte | Gt
+      | Gte ),
+      _ ) as op ->
     overloaded op
-  | ( Minus_int | Minus_rat | Minus_mon | Minus_dur | ToRat_int | ToRat_mon
-    | ToMoney_rat | Round_rat | Round_mon | Add_int_int | Add_rat_rat
-    | Add_mon_mon | Add_dat_dur _ | Add_dur_dur | Sub_int_int | Sub_rat_rat
-    | Sub_mon_mon | Sub_dat_dat | Sub_dat_dur | Sub_dur_dur | Mult_int_int
-    | Mult_rat_rat | Mult_mon_rat | Mult_dur_int | Div_int_int | Div_rat_rat
-    | Div_mon_mon | Div_mon_rat | Div_dur_dur | Lt_int_int | Lt_rat_rat
-    | Lt_mon_mon | Lt_dat_dat | Lt_dur_dur | Lte_int_int | Lte_rat_rat
-    | Lte_mon_mon | Lte_dat_dat | Lte_dur_dur | Gt_int_int | Gt_rat_rat
-    | Gt_mon_mon | Gt_dat_dat | Gt_dur_dur | Gte_int_int | Gte_rat_rat
-    | Gte_mon_mon | Gte_dat_dat | Gte_dur_dur | Eq_int_int | Eq_rat_rat
-    | Eq_mon_mon | Eq_dat_dat | Eq_dur_dur ) as op ->
+  | ( ( Minus_int | Minus_rat | Minus_mon | Minus_dur | ToRat_int | ToRat_mon
+      | ToMoney_rat | Round_rat | Round_mon | Add_int_int | Add_rat_rat
+      | Add_mon_mon | Add_dat_dur _ | Add_dur_dur | Sub_int_int | Sub_rat_rat
+      | Sub_mon_mon | Sub_dat_dat | Sub_dat_dur | Sub_dur_dur | Mult_int_int
+      | Mult_rat_rat | Mult_mon_rat | Mult_dur_int | Div_int_int | Div_rat_rat
+      | Div_mon_mon | Div_mon_rat | Div_dur_dur | Lt_int_int | Lt_rat_rat
+      | Lt_mon_mon | Lt_dat_dat | Lt_dur_dur | Lte_int_int | Lte_rat_rat
+      | Lte_mon_mon | Lte_dat_dat | Lte_dur_dur | Gt_int_int | Gt_rat_rat
+      | Gt_mon_mon | Gt_dat_dat | Gt_dur_dur | Gte_int_int | Gte_rat_rat
+      | Gte_mon_mon | Gte_dat_dat | Gte_dur_dur | Eq_int_int | Eq_rat_rat
+      | Eq_mon_mon | Eq_dat_dat | Eq_dur_dur ),
+      _ ) as op ->
     resolved op
 
 type 'a no_overloads =
@@ -371,22 +374,23 @@ type 'a no_overloads =
   as
   'a
 
-let translate (t : 'a no_overloads t) : 'b no_overloads t =
+let translate (t : 'a no_overloads t Mark.pos) : 'b no_overloads t Mark.pos =
   match t with
-  | ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth | And
-    | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq | Map
-    | Map2 | Concat | Filter | Reduce | Fold | Minus_int | Minus_rat | Minus_mon
-    | Minus_dur | ToRat_int | ToRat_mon | ToMoney_rat | Round_rat | Round_mon
-    | Add_int_int | Add_rat_rat | Add_mon_mon | Add_dat_dur _ | Add_dur_dur
-    | Sub_int_int | Sub_rat_rat | Sub_mon_mon | Sub_dat_dat | Sub_dat_dur
-    | Sub_dur_dur | Mult_int_int | Mult_rat_rat | Mult_mon_rat | Mult_dur_int
-    | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat | Div_dur_dur
-    | Lt_int_int | Lt_rat_rat | Lt_mon_mon | Lt_dat_dat | Lt_dur_dur
-    | Lte_int_int | Lte_rat_rat | Lte_mon_mon | Lte_dat_dat | Lte_dur_dur
-    | Gt_int_int | Gt_rat_rat | Gt_mon_mon | Gt_dat_dat | Gt_dur_dur
-    | Gte_int_int | Gte_rat_rat | Gte_mon_mon | Gte_dat_dat | Gte_dur_dur
-    | Eq_int_int | Eq_rat_rat | Eq_mon_mon | Eq_dat_dat | Eq_dur_dur
-    | FromClosureEnv | ToClosureEnv ) as op ->
+  | ( ( Not | GetDay | GetMonth | GetYear | FirstDayOfMonth | LastDayOfMonth
+      | And | Or | Xor | HandleDefault | HandleDefaultOpt | Log _ | Length | Eq
+      | Map | Map2 | Concat | Filter | Reduce | Fold | Minus_int | Minus_rat
+      | Minus_mon | Minus_dur | ToRat_int | ToRat_mon | ToMoney_rat | Round_rat
+      | Round_mon | Add_int_int | Add_rat_rat | Add_mon_mon | Add_dat_dur _
+      | Add_dur_dur | Sub_int_int | Sub_rat_rat | Sub_mon_mon | Sub_dat_dat
+      | Sub_dat_dur | Sub_dur_dur | Mult_int_int | Mult_rat_rat | Mult_mon_rat
+      | Mult_dur_int | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat
+      | Div_dur_dur | Lt_int_int | Lt_rat_rat | Lt_mon_mon | Lt_dat_dat
+      | Lt_dur_dur | Lte_int_int | Lte_rat_rat | Lte_mon_mon | Lte_dat_dat
+      | Lte_dur_dur | Gt_int_int | Gt_rat_rat | Gt_mon_mon | Gt_dat_dat
+      | Gt_dur_dur | Gte_int_int | Gte_rat_rat | Gte_mon_mon | Gte_dat_dat
+      | Gte_dur_dur | Eq_int_int | Eq_rat_rat | Eq_mon_mon | Eq_dat_dat
+      | Eq_dur_dur | FromClosureEnv | ToClosureEnv ),
+      _ ) as op ->
     op
 
 let monomorphic_type ((op : monomorphic t), pos) =
@@ -537,8 +541,11 @@ let resolve_overload_aux (op : overloaded t) (operands : typ_lit list) :
       _ ) ->
     raise Not_found
 
-let resolve_overload ctx (op : overloaded t Mark.pos) (operands : typ list) :
-    < resolved : yes ; .. > t * [ `Straight | `Reversed ] =
+let resolve_overload
+    ctx
+    ((op, pos) : overloaded t Mark.pos)
+    (operands : typ list) :
+    < resolved : yes ; .. > t Mark.pos * [ `Straight | `Reversed ] =
   try
     let operands =
       List.map
@@ -546,11 +553,12 @@ let resolve_overload ctx (op : overloaded t Mark.pos) (operands : typ list) :
           match Mark.remove t with TLit tl -> tl | _ -> raise Not_found)
         operands
     in
-    resolve_overload_aux (Mark.remove op) operands
+    let op, direction = resolve_overload_aux op operands in
+    (op, pos), direction
   with Not_found ->
     Message.error
       ~extra_pos:
-        (("", Mark.get op)
+        (("", pos)
         :: List.map
              (fun ty ->
                ( Format.asprintf "Type %a coming from expression:"
@@ -559,7 +567,7 @@ let resolve_overload ctx (op : overloaded t Mark.pos) (operands : typ list) :
              operands)
       "I don't know how to apply operator %a on types %a"
       (Print.operator ~debug:true)
-      (Mark.remove op)
+      op
       (Format.pp_print_list
          ~pp_sep:(fun ppf () -> Format.fprintf ppf " and@ ")
          (Print.typ ctx))
@@ -567,4 +575,4 @@ let resolve_overload ctx (op : overloaded t Mark.pos) (operands : typ list) :
 
 let overload_type ctx (op : overloaded t Mark.pos) (operands : typ list) : typ =
   let rop = fst (resolve_overload ctx op operands) in
-  resolved_type (Mark.copy op rop)
+  resolved_type rop

--- a/compiler/shared_ast/operator.mli
+++ b/compiler/shared_ast/operator.mli
@@ -43,11 +43,11 @@ val name : 'a t -> string
     symbols, e.g. [+$]. *)
 
 val kind_dispatch :
-  polymorphic:(< polymorphic : yes ; .. > t -> 'b) ->
-  monomorphic:(< monomorphic : yes ; .. > t -> 'b) ->
-  ?overloaded:(< overloaded : yes ; .. > t -> 'b) ->
-  ?resolved:(< resolved : yes ; .. > t -> 'b) ->
-  'a t ->
+  polymorphic:(< polymorphic : yes ; .. > t Mark.pos -> 'b) ->
+  monomorphic:(< monomorphic : yes ; .. > t Mark.pos -> 'b) ->
+  ?overloaded:(< overloaded : yes ; .. > t Mark.pos -> 'b) ->
+  ?resolved:(< resolved : yes ; .. > t Mark.pos -> 'b) ->
+  'a t Mark.pos ->
   'b
 (** Calls one of the supplied functions depending on the kind of the operator *)
 
@@ -60,7 +60,7 @@ type 'a no_overloads =
   as
   'a
 
-val translate : 'a no_overloads t -> 'b no_overloads t
+val translate : 'a no_overloads t Mark.pos -> 'b no_overloads t Mark.pos
 (** An identity function that allows translating an operator between different
     passes that don't change operator types *)
 
@@ -84,7 +84,7 @@ val resolve_overload :
   decl_ctx ->
   overloaded t Mark.pos ->
   typ list ->
-  < resolved : yes ; .. > t * [ `Straight | `Reversed ]
+  < resolved : yes ; .. > t Mark.pos * [ `Straight | `Reversed ]
 (** Some overloads are sugar for an operation with reversed operands, e.g.
     [TRat * TMoney] is using [mult_mon_rat]. [`Reversed] is returned to signify
     this case. *)

--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -97,15 +97,15 @@ let rec optimize_expr :
        the matches and the log calls are not preserved, which would be a good
        property *)
     match Mark.remove e with
-    | EAppOp { op = Not; args = [(ELit (LBool b), _)]; _ } ->
+    | EAppOp { op = Not, _; args = [(ELit (LBool b), _)]; _ } ->
       (* reduction of logical not *)
       ELit (LBool (not b))
-    | EAppOp { op = Or; args = [(ELit (LBool b), _); (e, _)]; _ }
-    | EAppOp { op = Or; args = [(e, _); (ELit (LBool b), _)]; _ } ->
+    | EAppOp { op = Or, _; args = [(ELit (LBool b), _); (e, _)]; _ }
+    | EAppOp { op = Or, _; args = [(e, _); (ELit (LBool b), _)]; _ } ->
       (* reduction of logical or *)
       if b then ELit (LBool true) else e
-    | EAppOp { op = And; args = [(ELit (LBool b), _); (e, _)]; _ }
-    | EAppOp { op = And; args = [(e, _); (ELit (LBool b), _)]; _ } ->
+    | EAppOp { op = And, _; args = [(ELit (LBool b), _); (e, _)]; _ }
+    | EAppOp { op = And, _; args = [(e, _); (ELit (LBool b), _)]; _ } ->
       (* reduction of logical and *)
       if b then e else ELit (LBool false)
     | EMatch { e = EInj { e = e'; cons; name = n' }, _; cases; name = n }
@@ -140,15 +140,12 @@ let rec optimize_expr :
               match Mark.remove b1, Mark.remove e2 with
               | EAbs { binder = b1; _ }, EAbs { binder = b2; tys } -> (
                 let v1, e1 = Bindlib.unmbind b1 in
-                let[@warning "-8"] [| v1 |] = v1 in
                 match Mark.remove e1 with
-                | EInj { e = e1; _ } ->
+                | EInj { e = e1, _; _ } ->
                   Some
                     (Expr.unbox
-                       (Expr.make_abs [| v1 |]
-                          (Expr.rebox
-                             (Bindlib.msubst b2
-                                ([e1] |> List.map fst |> Array.of_list)))
+                       (Expr.make_abs v1
+                          (Expr.rebox (Bindlib.msubst b2 [| e1 |]))
                           tys (Expr.pos e2)))
                 | _ -> assert false)
               | _ -> assert false)
@@ -198,13 +195,13 @@ let rec optimize_expr :
           Mark.remove cons
         | ( [],
             ( ( ELit (LBool false)
-              | EAppOp { op = Log _; args = [(ELit (LBool false), _)]; _ } ),
+              | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
               _ ) ) ->
           (* No exceptions and condition false *)
           EEmpty
         | ( [except],
             ( ( ELit (LBool false)
-              | EAppOp { op = Log _; args = [(ELit (LBool false), _)]; _ } ),
+              | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
               _ ) ) ->
           (* Single exception and condition false *)
           Mark.remove except
@@ -213,7 +210,7 @@ let rec optimize_expr :
         {
           cond =
             ( ELit (LBool true), _
-            | EAppOp { op = Log _; args = [(ELit (LBool true), _)]; _ }, _ );
+            | EAppOp { op = Log _, _; args = [(ELit (LBool true), _)]; _ }, _ );
           etrue;
           _;
         } ->
@@ -222,7 +219,7 @@ let rec optimize_expr :
         {
           cond =
             ( ( ELit (LBool false)
-              | EAppOp { op = Log _; args = [(ELit (LBool false), _)]; _ } ),
+              | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
               _ );
           efalse;
           _;
@@ -233,32 +230,37 @@ let rec optimize_expr :
           cond;
           etrue =
             ( ( ELit (LBool btrue)
-              | EAppOp { op = Log _; args = [(ELit (LBool btrue), _)]; _ } ),
+              | EAppOp { op = Log _, _; args = [(ELit (LBool btrue), _)]; _ } ),
               _ );
           efalse =
             ( ( ELit (LBool bfalse)
-              | EAppOp { op = Log _; args = [(ELit (LBool bfalse), _)]; _ } ),
+              | EAppOp { op = Log _, _; args = [(ELit (LBool bfalse), _)]; _ }
+                ),
               _ );
         } ->
       if btrue && not bfalse then Mark.remove cond
       else if (not btrue) && bfalse then
         EAppOp
-          { op = Not; tys = [TLit TBool, Expr.mark_pos mark]; args = [cond] }
+          {
+            op = Not, Expr.mark_pos mark;
+            tys = [TLit TBool, Expr.mark_pos mark];
+            args = [cond];
+          }
         (* note: this last call eliminates the condition & might skip log calls
            as well *)
       else (* btrue = bfalse *) ELit (LBool btrue)
-    | EAppOp { op = Op.Fold; args = [_f; init; (EArray [], _)]; _ } ->
+    | EAppOp { op = Op.Fold, _; args = [_f; init; (EArray [], _)]; _ } ->
       (*reduces a fold with an empty list *)
       Mark.remove init
     | EAppOp
         {
-          op = Map;
+          op = (Map, _) as op;
           args =
             [
               f1;
               ( EAppOp
                   {
-                    op = Map;
+                    op = Map, _;
                     args = [f2; ls];
                     tys = [_; ((TArray xty, _) as lsty)];
                   },
@@ -286,7 +288,7 @@ let rec optimize_expr :
       in
       let fg = optimize_expr ctx (Expr.unbox fg) in
       let mapl =
-        Expr.eappop ~op:Map
+        Expr.eappop ~op
           ~args:[fg; Expr.box ls]
           ~tys:[Expr.maybe_ty (Mark.get fg); lsty]
           mark
@@ -294,13 +296,13 @@ let rec optimize_expr :
       Mark.remove (Expr.unbox mapl)
     | EAppOp
         {
-          op = Map;
+          op = Map, _;
           args =
             [
               f1;
               ( EAppOp
                   {
-                    op = Map2;
+                    op = (Map2, _) as op;
                     args = [f2; ls1; ls2];
                     tys =
                       [
@@ -339,7 +341,7 @@ let rec optimize_expr :
       in
       let fg = optimize_expr ctx (Expr.unbox fg) in
       let mapl =
-        Expr.eappop ~op:Map2
+        Expr.eappop ~op
           ~args:[fg; Expr.box ls1; Expr.box ls2]
           ~tys:[Expr.maybe_ty (Mark.get fg); ls1ty; ls2ty]
           mark
@@ -347,7 +349,7 @@ let rec optimize_expr :
       Mark.remove (Expr.unbox mapl)
     | EAppOp
         {
-          op = Op.Fold;
+          op = Op.Fold, _;
           args = [f; init; (EArray [e'], _)];
           tys = [_; tinit; (TArray tx, _)];
         } ->

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -348,14 +348,6 @@ let operator : type a. ?debug:bool -> Format.formatter -> a operator -> unit =
 let runtime_error ppf err =
   Format.fprintf ppf "@{<red>%s@}" (Runtime.error_to_string err)
 
-let except (fmt : Format.formatter) (exn : except) : unit =
-  op_style fmt
-    (match exn with
-    | Empty -> "Empty"
-    | ConflictError _ -> "ConflictError"
-    | Crash s -> Printf.sprintf "Crash %S" s
-    | NoValueProvided -> "NoValueProvided")
-
 let var_debug fmt v =
   Format.fprintf fmt "%s_%d" (Bindlib.name_of v) (Bindlib.uid_of v)
 
@@ -682,9 +674,9 @@ module ExprGen (C : EXPR_PARAM) = struct
       | ECatchEmpty { body; handler } ->
         Format.fprintf fmt
           "@[<hv 0>@[<hov 2>%a@ %a@]@ @[<hov 2>%a@ %a ->@ %a@]@]" keyword "try"
-          expr body keyword "with" except Empty (rhs exprc) handler
+          expr body keyword "with" op_style "Empty" (rhs exprc) handler
       | ERaiseEmpty ->
-        Format.fprintf fmt "@[<hov 2>%a@ %a@]" keyword "raise" except Empty
+        Format.fprintf fmt "@[<hov 2>%a@ %a@]" keyword "raise" op_style "Empty"
       | ELocation loc -> location fmt loc
       | EDStructAccess { e; field; _ } ->
         Format.fprintf fmt "@[<hv 2>%a%a@,%a%a%a@]" (lhs exprc) e punctuation

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -348,7 +348,7 @@ let operator : type a. ?debug:bool -> Format.formatter -> a operator -> unit =
 let except (fmt : Format.formatter) (exn : except) : unit =
   op_style fmt
     (match exn with
-    | EmptyError -> "EmptyError"
+    | Empty -> "Empty"
     | ConflictError _ -> "ConflictError"
     | Crash s -> Printf.sprintf "Crash %S" s
     | NoValueProvided -> "NoValueProvided")

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -1051,13 +1051,13 @@ module UserFacing = struct
      and some others not, adding confusion. *)
 
   let date (lang : Global.backend_lang) ppf d =
-    let y, m, d = Dates_calc.Dates.date_to_ymd d in
+    let y, m, d = Runtime.date_to_years_months_days d in
     match lang with
     | En | Pl -> Format.fprintf ppf "%04d-%02d-%02d" y m d
     | Fr -> Format.fprintf ppf "%02d/%02d/%04d" d m y
 
   let duration (lang : Global.backend_lang) ppf dr =
-    let y, m, d = Dates_calc.Dates.period_to_ymds dr in
+    let y, m, d = Runtime.duration_to_years_months_days dr in
     let rec filter0 = function
       | (0, _) :: (_ :: _ as r) -> filter0 r
       | x :: r -> x :: List.filter (fun (n, _) -> n <> 0) r

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -48,6 +48,7 @@ val lit : Format.formatter -> lit -> unit
 val operator : ?debug:bool -> Format.formatter -> 'a operator -> unit
 val log_entry : Format.formatter -> log_entry -> unit
 val except : Format.formatter -> except -> unit
+val runtime_error : Format.formatter -> Runtime.error -> unit
 val var : Format.formatter -> 'e Var.t -> unit
 val var_debug : Format.formatter -> 'e Var.t -> unit
 

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -47,7 +47,6 @@ val typ : decl_ctx -> Format.formatter -> typ -> unit
 val lit : Format.formatter -> lit -> unit
 val operator : ?debug:bool -> Format.formatter -> 'a operator -> unit
 val log_entry : Format.formatter -> log_entry -> unit
-val except : Format.formatter -> except -> unit
 val runtime_error : Format.formatter -> Runtime.error -> unit
 val var : Format.formatter -> 'e Var.t -> unit
 val var_debug : Format.formatter -> 'e Var.t -> unit

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -354,13 +354,11 @@ let polymorphic_op_return_type
 let resolve_overload_ret_type
     ~flags
     (ctx : A.decl_ctx)
-    e
-    (op : Operator.overloaded A.operator)
+    _e
+    (op : Operator.overloaded A.operator Mark.pos)
     tys : unionfind_typ =
   let op_ty =
-    Operator.overload_type ctx
-      (Mark.add (Expr.pos e) op)
-      (List.map (typ_to_ast ~flags) tys)
+    Operator.overload_type ctx op (List.map (typ_to_ast ~flags) tys)
   in
   ast_to_typ (Type.arrow_return op_ty)
 
@@ -887,17 +885,14 @@ and typecheck_expr_top_down :
     let t_args = List.map ast_to_typ tys in
     let t_func = unionfind (TArrow (t_args, tau)) in
     let args =
-      Operator.kind_dispatch op
+      Operator.kind_dispatch (Mark.set pos_e op)
         ~polymorphic:(fun op ->
           (* Type the operator first, then right-to-left: polymorphic operators
              are required to allow the resolution of all type variables this
              way *)
           if not env.flags.assume_op_types then
-            unify ctx e (polymorphic_op_type (Mark.add pos_e op)) t_func
-          else
-            unify ctx e
-              (polymorphic_op_return_type ctx e (Mark.add pos_e op) t_args)
-              tau;
+            unify ctx e (polymorphic_op_type op) t_func
+          else unify ctx e (polymorphic_op_return_type ctx e op t_args) tau;
           List.rev_map2
             (typecheck_expr_top_down ctx env)
             (List.rev t_args) (List.rev args))
@@ -908,15 +903,11 @@ and typecheck_expr_top_down :
           args')
         ~monomorphic:(fun op ->
           (* Here it doesn't matter but may affect the error messages *)
-          unify ctx e
-            (ast_to_typ (Operator.monomorphic_type (Mark.add pos_e op)))
-            t_func;
+          unify ctx e (ast_to_typ (Operator.monomorphic_type op)) t_func;
           List.map2 (typecheck_expr_top_down ctx env) t_args args)
         ~resolved:(fun op ->
           (* This case should not fail *)
-          unify ctx e
-            (ast_to_typ (Operator.resolved_type (Mark.add pos_e op)))
-            t_func;
+          unify ctx e (ast_to_typ (Operator.resolved_type op)) t_func;
           List.map2 (typecheck_expr_top_down ctx env) t_args args)
     in
     (* All operator applications are monomorphised at this point *)

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -754,11 +754,11 @@ and typecheck_expr_top_down :
         args
     in
     Expr.escopecall ~scope ~args:args' mark
-  | A.ERaise ex -> Expr.eraise ex context_mark
-  | A.ECatch { body; exn; handler } ->
+  | A.ERaiseEmpty -> Expr.eraiseempty context_mark
+  | A.ECatchEmpty { body; handler } ->
     let body' = typecheck_expr_top_down ctx env tau body in
     let handler' = typecheck_expr_top_down ctx env tau handler in
-    Expr.ecatch body' exn handler' context_mark
+    Expr.ecatchempty body' handler' context_mark
   | A.EVar v ->
     let tau' =
       match Env.get env v with
@@ -949,8 +949,9 @@ and typecheck_expr_top_down :
       typecheck_expr_top_down ctx env (unionfind ~pos:e1 (TLit TBool)) e1
     in
     Expr.eassert e1' mark
-  | A.EEmptyError ->
-    Expr.eemptyerror (ty_mark (TDefault (unionfind (TAny (Any.fresh ())))))
+  | A.EFatalError err -> Expr.efatalerror err context_mark
+  | A.EEmpty ->
+    Expr.eempty (ty_mark (TDefault (unionfind (TAny (Any.fresh ())))))
   | A.EErrorOnEmpty e1 ->
     let tau' = unionfind (TDefault tau) in
     let e1' = typecheck_expr_top_down ctx env tau' e1 in

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -145,6 +145,7 @@ and literal =
   | LDate of literal_date
 
 and collection_op =
+  | Member of { element : expression }
   | Exists of { predicate : lident Mark.pos list * expression }
   | Forall of { predicate : lident Mark.pos list * expression }
   | Map of { f : lident Mark.pos list * expression }
@@ -175,8 +176,7 @@ and naked_expression =
   | IfThenElse of expression * expression * expression
   | Binop of binop Mark.pos * expression * expression
   | Unop of unop Mark.pos * expression
-  | CollectionOp of collection_op * expression
-  | MemCollection of expression * expression
+  | CollectionOp of collection_op Mark.pos * expression
   | TestMatchCase of expression * match_case_pattern Mark.pos
   | FunCall of expression * expression list
   | ScopeCall of

--- a/compiler/surface/dune
+++ b/compiler/surface/dune
@@ -8,7 +8,6 @@
   re
   zarith
   zarith_stubs_js
-  dates_calc
   shared_ast)
  (preprocess
   (pps sedlex.ppx visitors.ppx)))

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -40,7 +40,7 @@ let rec conjunction_exprs (exprs : typed expr list) (mark : typed mark) :
   | hd :: tl ->
     ( EAppOp
         {
-          op = And;
+          op = And, Expr.mark_pos mark;
           tys = [TLit TBool, Expr.pos hd; TLit TBool, Expr.pos hd];
           args = [hd; conjunction_exprs tl mark];
         },
@@ -54,7 +54,7 @@ let conjunction (args : vc_return list) (mark : typed mark) : vc_return =
     (fun acc arg ->
       ( EAppOp
           {
-            op = And;
+            op = And, Expr.mark_pos mark;
             tys = [TLit TBool, Expr.pos acc; TLit TBool, Expr.pos arg];
             args = [arg; acc];
           },
@@ -62,7 +62,13 @@ let conjunction (args : vc_return list) (mark : typed mark) : vc_return =
     acc list
 
 let negation (arg : vc_return) (mark : typed mark) : vc_return =
-  EAppOp { op = Not; tys = [TLit TBool, Expr.pos arg]; args = [arg] }, mark
+  ( EAppOp
+      {
+        op = Not, Expr.mark_pos mark;
+        tys = [TLit TBool, Expr.pos arg];
+        args = [arg];
+      },
+    mark )
 
 let disjunction (args : vc_return list) (mark : typed mark) : vc_return =
   let acc, list =
@@ -72,7 +78,7 @@ let disjunction (args : vc_return list) (mark : typed mark) : vc_return =
     (fun (acc : vc_return) arg ->
       ( EAppOp
           {
-            op = Or;
+            op = Or, Expr.mark_pos mark;
             tys = [TLit TBool, Expr.pos acc; TLit TBool, Expr.pos arg];
             args = [arg; acc];
           },

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -171,7 +171,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
             (Mark.get e);
         ])
       (Mark.get e)
-  | EEmptyError -> Mark.copy e (ELit (LBool false))
+  | EEmpty -> Mark.copy e (ELit (LBool false))
   | EVar _
   (* Per default calculus semantics, you cannot call a function with an argument
      that evaluates to the empty error. Thus, all variable evaluate to
@@ -202,7 +202,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
                            can be ignored *)
                         let _vars, body = Bindlib.unmbind binder in
                         match Mark.remove body with
-                        | EEmptyError -> Mark.copy field (ELit (LBool true))
+                        | EEmpty -> Mark.copy field (ELit (LBool true))
                         | _ ->
                           (* same as basic [EAbs case]*)
                           generate_vc_must_not_return_empty ctx field)

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -19,7 +19,7 @@ open Shared_ast
 open Dcalc
 open Ast
 open Z3
-module StringMap : Map.S with type key = String.t = Map.Make (String)
+module StringMap = String.Map
 module Runtime = Runtime_ocaml.Runtime
 
 type context = {
@@ -746,6 +746,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
         "[Z3 encoding] EApp node: Catala function calls should only include \
          operators or function names")
   | EAssert e -> translate_expr ctx e
+  | EFatalError _ -> failwith "[Z3 encoding] EFatalError unsupported"
   | EDefault _ -> failwith "[Z3 encoding] EDefault unsupported"
   | EPureDefault _ -> failwith "[Z3 encoding] EPureDefault unsupported"
   | EIfThenElse { cond = e_if; etrue = e_then; efalse = e_else } ->
@@ -756,7 +757,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     let ctx, z3_then = translate_expr ctx e_then in
     let ctx, z3_else = translate_expr ctx e_else in
     ctx, Boolean.mk_ite ctx.ctx_z3 z3_if z3_then z3_else
-  | EEmptyError -> failwith "[Z3 encoding] LEmptyError literals not supported"
+  | EEmpty -> failwith "[Z3 encoding] 'Empty' literals not supported"
   | EErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
   | _ -> .
 

--- a/doc/syntax/syntax_en.catala_en
+++ b/doc/syntax/syntax_en.catala_en
@@ -65,9 +65,8 @@ declaration x content integer equals
     round of $9.99
   ) in
   let x equals (
-    get_day of 0,
-    get_month of 0,
-    get_year of 0
+    get_month of |2003-01-02|,
+    first_day_of_month of |2003-01-02|
   ) in
   let x equals (
     a +! b,    # integer
@@ -214,17 +213,17 @@ declaration x content integer equals
     for all x among lst we have x > 2
   in
   let x equals
-    x + 2 for x among lst
+    (x + 2) for x among lst
   in
   let x equals
     list of x among lst such that x > 2
   in
   let x equals
-    x - 2 for x among lst
+    (x - 2) for x among lst
       such that x > 2
   in
   let x equals
-    x + y for (x, y) among (lst1, lst2)
+    (x + y) for (x, y) among (lst1, lst2)
   in
   let x equals
     lst1 ++ lst2

--- a/doc/syntax/syntax_en.catala_en
+++ b/doc/syntax/syntax_en.catala_en
@@ -254,9 +254,9 @@ to ensure that the *syntax* is correct.
 $ catala typecheck
 [ERROR] No scope named Scope0 found
 
-┌─⯈ doc/syntax/syntax_en.catala_en:95.14-95.20:
+┌─⯈ doc/syntax/syntax_en.catala_en:94.14-94.20:
 └──┐
-95 │   sub1 scope Scope0
+94 │   sub1 scope Scope0
    │              ‾‾‾‾‾‾
    └─ Metadata declaration
 #return code 123#

--- a/doc/syntax/syntax_en.tex
+++ b/doc/syntax/syntax_en.tex
@@ -378,8 +378,8 @@
   \\
   \begin{catala}
     ```catala
-    get_day of ...    get_month of ...
-    get_year of ...
+    get_month of ...
+    first_day_of_month of ...
     ```
   \end{catala}
   & Date parts
@@ -674,7 +674,7 @@
   \\
   \begin{catala}
     ```catala
-    x + 2 for x among lst
+    (x + 2) for x among lst
     ```
   \end{catala}
   & Mapping
@@ -688,7 +688,7 @@
   \\
   \begin{catala}
     ```catala
-    x - 2 for x among lst
+    (x - 2) for x among lst
       such that x > 2
     ```
   \end{catala}
@@ -696,7 +696,7 @@
   \\
   \begin{catala}
     ```catala
-    x + y for (x, y) among (lst1, lst2)
+    (x + y) for (x, y) among (lst1, lst2)
     ```
   \end{catala}
   & Multiple mapping

--- a/doc/syntax/syntax_fr.catala_fr
+++ b/doc/syntax/syntax_fr.catala_fr
@@ -63,9 +63,8 @@ déclaration x contenu entier égal à
     arrondi de 9,99€
   ) dans
   soit x égal à (
-    accès_jour de 0 ,
-    accès_mois de 0 ,
-    accès_année de 0
+    accès_année de |2003-01-02|,
+    premier_jour_du_mois de |2003-01-02|
   ) dans
   soit x égal à (
     a +! b,    # entier
@@ -212,17 +211,17 @@ déclaration x contenu entier égal à
     pour tout x parmi lst on a x >= 2
   dans
   soit x égal à
-    x + 2 pour x parmi lst
+    (x + 2) pour x parmi lst
   dans
   soit x égal à
     liste de x parmi lst tel que x > 2
   dans
   soit x égal à
-    x - 2 pour x parmi lst
+    (x - 2) pour x parmi lst
       tel que x > 2
   dans
   soit x égal à
-    x + y pour (x, y) parmi (lst1, lst2)
+    (x + y) pour (x, y) parmi (lst1, lst2)
   dans
   soit x égal à
     lst1 ++ lst2

--- a/doc/syntax/syntax_fr.catala_fr
+++ b/doc/syntax/syntax_fr.catala_fr
@@ -252,9 +252,9 @@ to ensure that the *syntax* is correct.
 $ catala typecheck
 [ERROR] No scope named Scope0 found
 
-┌─⯈ doc/syntax/syntax_fr.catala_fr:93.28-93.34:
+┌─⯈ doc/syntax/syntax_fr.catala_fr:92.28-92.34:
 └──┐
-93 │   sub1 champ d'application Scope0
+92 │   sub1 champ d'application Scope0
    │                            ‾‾‾‾‾‾
    └─ Déclaration des métadonnées
 #return code 123#

--- a/doc/syntax/syntax_fr.tex
+++ b/doc/syntax/syntax_fr.tex
@@ -380,8 +380,8 @@
   \\
   \begin{catala}
     ```catala
-    accès_jour de ...  accès_mois de ...
     accès_année de ...
+    premier_jour_du_mois de ...
     ```
   \end{catala}
   & Éléments de dates
@@ -679,7 +679,7 @@
   \\
   \begin{catala}
     ```catala
-    x + 2 pour x parmi lst
+    (x + 2) pour x parmi lst
     ```
   \end{catala}
   & Application un-à-un
@@ -693,7 +693,7 @@
   \\
   \begin{catala}
     ```catala
-    x - 2 pour x parmi lst
+    (x - 2) pour x parmi lst
       tel que x > 2
     ```
   \end{catala}
@@ -701,7 +701,7 @@
   \\
   \begin{catala}
     ```catala
-    x + y pour (x, y) parmi (lst1, lst2)
+    (x + y) pour (x, y) parmi (lst1, lst2)
     ```
   \end{catala}
   & Multiple mapping

--- a/runtimes/c/runtime.c
+++ b/runtimes/c/runtime.c
@@ -4,12 +4,14 @@
 
 typedef enum catala_fatal_error_code
 {
-    catala_no_value_provided,
-    catala_conflict,
-    catala_crash,
-    catala_empty,
-    catala_assertion_failure,
-    catala_malloc_error,
+  catala_assertion_failed,
+  catala_no_value,
+  catala_conflict,
+  catala_division_by_zero,
+  catala_not_same_length,
+  catala_uncomparable_durations,
+  catala_indivisible_durations,
+  catala_malloc_error,
 } catala_fatal_error_code;
 
 typedef struct catala_code_position

--- a/runtimes/jsoo/runtime.ml
+++ b/runtimes/jsoo/runtime.ml
@@ -60,11 +60,16 @@ let date_of_js d =
     if String.contains d 'T' then d |> String.split_on_char 'T' |> List.hd
     else d
   in
+  let fail () = failwith "date_of_js: invalid date" in
   match String.split_on_char '-' d with
-  | [year; month; day] ->
-    R_ocaml.date_of_numbers (int_of_string year) (int_of_string month)
-      (int_of_string day)
-  | _ -> failwith "date_of_js: invalid date"
+  | [year; month; day] -> (
+    match
+      R_ocaml.date_of_numbers (int_of_string year) (int_of_string month)
+        (int_of_string day)
+    with
+    | Some d -> d
+    | None -> fail ())
+  | _ -> fail ()
 
 let date_to_js d = Js.string @@ R_ocaml.date_to_string d
 

--- a/runtimes/jsoo/runtime.ml
+++ b/runtimes/jsoo/runtime.ml
@@ -63,12 +63,10 @@ let date_of_js d =
   let fail () = failwith "date_of_js: invalid date" in
   match String.split_on_char '-' d with
   | [year; month; day] -> (
-    match
+    try
       R_ocaml.date_of_numbers (int_of_string year) (int_of_string month)
         (int_of_string day)
-    with
-    | Some d -> d
-    | None -> fail ())
+    with Failure _ -> fail ())
   | _ -> fail ()
 
 let date_to_js d = Js.string @@ R_ocaml.date_to_string d

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -64,13 +64,17 @@ let error_to_string = function
   | IndivisibleDurations -> "IndivisibleDurations"
 
 let error_message = function
-  | AssertionFailed -> "this assertion doesn't hold"
-  | NoValue -> "no computation with valid conditions found"
-  | Conflict -> "two or more concurring valid computations"
-  | DivisionByZero -> "division by zero"
+  | AssertionFailed -> "an assertion doesn't hold"
+  | NoValue -> "no applicable rule to define this variable in this situation"
+  | Conflict ->
+    "conflict between multiple valid consequences for assigning the same \
+     variable"
+  | DivisionByZero ->
+    "a value is being used as denominator in a division and it computed to zero"
   | NotSameLength -> "traversing multiple lists of different lengths"
   | UncomparableDurations ->
-    "comparing durations in different units (e.g. months vs. days)"
+    "ambiguous comparison between durations in different units (e.g. months \
+     vs. days)"
   | IndivisibleDurations -> "dividing durations that are not in days"
 
 exception Error of error * source_position list

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -206,10 +206,15 @@ let day_of_month_of_date (d : date) : integer =
 (* This could fail, but is expected to only be called with known, already
    validated arguments by the generated code *)
 let date_of_numbers (year : int) (month : int) (day : int) : date =
-  Dates_calc.Dates.make_date ~year ~month ~day
+  try Dates_calc.Dates.make_date ~year ~month ~day
+  with Dates_calc.Dates.InvalidDate ->
+    failwith "date_of_numbers: invalid date"
 
 let date_to_string (d : date) : string =
   Format.asprintf "%a" Dates_calc.Dates.format_date d
+
+let date_to_years_months_days (d : date) : int * int * int =
+  Dates_calc.Dates.date_to_ymd d
 
 let first_day_of_month = Dates_calc.Dates.first_day_of_month
 let last_day_of_month = Dates_calc.Dates.last_day_of_month
@@ -219,19 +224,6 @@ let duration_of_numbers (year : int) (month : int) (day : int) : duration =
 
 let duration_to_string (d : duration) : string =
   Format.asprintf "%a" Dates_calc.Dates.format_period d
-(* breaks previous format *)
-(* let x, y, z = CalendarLib.Date.Period.ymd d in
- * let to_print =
- *   List.filter (fun (a, _) -> a <> 0) [x, "years"; y, "months"; z, "days"]
- * in
- * match to_print with
- * | [] -> "empty duration"
- * | _ ->
- *   Format.asprintf "%a"
- *     (Format.pp_print_list
- *        ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
- *        (fun fmt (d, l) -> Format.fprintf fmt "%d %s" d l))
- *     to_print *)
 
 let duration_to_years_months_days (d : duration) : int * int * int =
   Dates_calc.Dates.period_to_ymds d

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -85,7 +85,7 @@ val error_to_string : error -> string
 val error_message : error -> string
 (** Returns a short explanation message about the error *)
 
-exception Error of error * source_position
+exception Error of error * source_position list
 exception Empty
 
 (** {1 Value Embedding} *)
@@ -333,17 +333,21 @@ val duration_to_string : duration -> string
 (**{1 Defaults} *)
 
 val handle_default :
-  source_position -> (unit -> 'a) array -> (unit -> bool) -> (unit -> 'a) -> 'a
-(** @raise EmptyError
-    @raise ConflictError *)
+  source_position array ->
+  (unit -> 'a) array ->
+  (unit -> bool) ->
+  (unit -> 'a) ->
+  'a
+(** @raise Empty
+    @raise Error Conflict *)
 
 val handle_default_opt :
-  source_position ->
+  source_position array ->
   'a Eoption.t array ->
   (unit -> bool) ->
   (unit -> 'a Eoption.t) ->
   'a Eoption.t
-(** @raise ConflictError *)
+(** @raise Error Conflict *)
 
 (**{1 Operators} *)
 

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -69,14 +69,24 @@ type io_log = {
 
 (** {1 Exceptions} *)
 
-exception EmptyError
-exception AssertionFailed of source_position
-exception ConflictError of source_position
-exception UncomparableDurations
-exception IndivisibleDurations
-exception ImpossibleDate
-exception NoValueProvided of source_position
-exception Division_by_zero (* Shadows the stdlib definition *)
+type error =
+  | AssertionFailed  (** An assertion in the program doesn't hold *)
+  | NoValue  (** No computation with valid conditions found *)
+  | Conflict  (** Two different valid computations at that point *)
+  | DivisionByZero  (** The denominator happened to be 0 here *)
+  | NotSameLength  (** Traversing multiple lists of different lengths *)
+  | UncomparableDurations
+      (** Comparing durations in different units (e.g. months vs. days) *)
+  | IndivisibleDurations  (** Dividing durations that are not in days *)
+
+val error_to_string : error -> string
+(** Returns the capitalized tag of the error as a string *)
+
+val error_message : error -> string
+(** Returns a short explanation message about the error *)
+
+exception Error of error * source_position
+exception Empty
 
 (** {1 Value Embedding} *)
 
@@ -305,9 +315,7 @@ val year_of_date : date -> integer
 val date_to_string : date -> string
 
 val date_of_numbers : int -> int -> int -> date
-(** Usage: [date_of_numbers year month day]
-
-    @raise ImpossibleDate *)
+(** Usage: [date_of_numbers year month day] *)
 
 val first_day_of_month : date -> date
 val last_day_of_month : date -> date
@@ -337,12 +345,11 @@ val handle_default_opt :
   'a Eoption.t
 (** @raise ConflictError *)
 
-val no_input : unit -> 'a
-
 (**{1 Operators} *)
 
 module Oper : sig
-  (* The types **must** match with Shared_ast.Operator.*_type *)
+  (* The types **must** match with Shared_ast.Operator.*_type ; but for the
+     added first argument [pos] for any operator that might trigger an error. *)
   val o_not : bool -> bool
   val o_length : 'a array -> integer
   val o_torat_int : integer -> decimal
@@ -365,7 +372,8 @@ module Oper : sig
   val o_eq : 'a -> 'a -> bool
   val o_map : ('a -> 'b) -> 'a array -> 'b array
 
-  val o_map2 : ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
+  val o_map2 :
+    source_position -> ('a -> 'b -> 'c) -> 'a array -> 'b array -> 'c array
   (** @raise [NotSameLength] *)
 
   val o_reduce : ('a -> 'a -> 'a) -> 'a -> 'a array -> 'a
@@ -386,35 +394,35 @@ module Oper : sig
   val o_mult_rat_rat : decimal -> decimal -> decimal
   val o_mult_mon_rat : money -> decimal -> money
   val o_mult_dur_int : duration -> integer -> duration
-  val o_div_int_int : integer -> integer -> decimal
-  val o_div_rat_rat : decimal -> decimal -> decimal
-  val o_div_mon_mon : money -> money -> decimal
-  val o_div_mon_rat : money -> decimal -> money
-  val o_div_dur_dur : duration -> duration -> decimal
+  val o_div_int_int : source_position -> integer -> integer -> decimal
+  val o_div_rat_rat : source_position -> decimal -> decimal -> decimal
+  val o_div_mon_mon : source_position -> money -> money -> decimal
+  val o_div_mon_rat : source_position -> money -> decimal -> money
+  val o_div_dur_dur : source_position -> duration -> duration -> decimal
   val o_lt_int_int : integer -> integer -> bool
   val o_lt_rat_rat : decimal -> decimal -> bool
   val o_lt_mon_mon : money -> money -> bool
-  val o_lt_dur_dur : duration -> duration -> bool
+  val o_lt_dur_dur : source_position -> duration -> duration -> bool
   val o_lt_dat_dat : date -> date -> bool
   val o_lte_int_int : integer -> integer -> bool
   val o_lte_rat_rat : decimal -> decimal -> bool
   val o_lte_mon_mon : money -> money -> bool
-  val o_lte_dur_dur : duration -> duration -> bool
+  val o_lte_dur_dur : source_position -> duration -> duration -> bool
   val o_lte_dat_dat : date -> date -> bool
   val o_gt_int_int : integer -> integer -> bool
   val o_gt_rat_rat : decimal -> decimal -> bool
   val o_gt_mon_mon : money -> money -> bool
-  val o_gt_dur_dur : duration -> duration -> bool
+  val o_gt_dur_dur : source_position -> duration -> duration -> bool
   val o_gt_dat_dat : date -> date -> bool
   val o_gte_int_int : integer -> integer -> bool
   val o_gte_rat_rat : decimal -> decimal -> bool
   val o_gte_mon_mon : money -> money -> bool
-  val o_gte_dur_dur : duration -> duration -> bool
+  val o_gte_dur_dur : source_position -> duration -> duration -> bool
   val o_gte_dat_dat : date -> date -> bool
   val o_eq_int_int : integer -> integer -> bool
   val o_eq_rat_rat : decimal -> decimal -> bool
   val o_eq_mon_mon : money -> money -> bool
-  val o_eq_dur_dur : duration -> duration -> bool
+  val o_eq_dur_dur : source_position -> duration -> duration -> bool
   val o_eq_dat_dat : date -> date -> bool
   val o_fold : ('a -> 'b -> 'a) -> 'a -> 'b array -> 'a
 end

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -315,10 +315,12 @@ val year_of_date : date -> integer
 val date_to_string : date -> string
 
 val date_of_numbers : int -> int -> int -> date
-(** Usage: [date_of_numbers year month day] *)
+(** Usage: [date_of_numbers year month day].
+    @raise Failure on invalid inputs *)
 
 val first_day_of_month : date -> date
 val last_day_of_month : date -> date
+val date_to_years_months_days : date -> int * int * int
 
 (**{2 Durations} *)
 
@@ -326,6 +328,7 @@ val duration_of_numbers : int -> int -> int -> duration
 (** Usage : [duration_of_numbers year mounth day]. *)
 
 val duration_to_years_months_days : duration -> int * int * int
+
 (**{2 Times} *)
 
 val duration_to_string : duration -> string

--- a/tests/arithmetic/bad/division_by_zero.catala_en
+++ b/tests/arithmetic/bad/division_by_zero.catala_en
@@ -32,54 +32,39 @@ scope Money:
 
 
 ```catala-test-inline
-$ catala Interpret -s Dec
+$ catala test-scope Dec
 [ERROR] Error during evaluation: division by zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.23-20.30:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.26-20.27:
 └──┐
 20 │   definition i equals 1. / 0.
-   │                       ‾‾‾‾‾‾‾
-   └┬ `Division_by_zero` exception management
-    └─ with decimals
-#return code 123#
-```
-
-
-Fixme: the following should give the same result as above, but the optimisation pass propagates the position surrounding the `ErrorOnEmpty` and loses the position of the actual division expression which was in the `cons` of the default term. Unfortunately this is non-trivial due to the bindlib boxing tricks.
-```catala-test-inline
-$ catala Interpret -O -s Dec
-[ERROR] Error during evaluation: division by zero.
-
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:17.10-17.11:
-└──┐
-17 │   output i content decimal
-   │          ‾
+   │                          ‾
    └┬ `Division_by_zero` exception management
     └─ with decimals
 #return code 123#
 ```
 
 ```catala-test-inline
-$ catala interpret -s Int
+$ catala test-scope Int
 [ERROR] Error during evaluation: division by zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.23-10.28:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.25-10.26:
 └──┐
 10 │   definition i equals 1 / 0
-   │                       ‾‾‾‾‾
+   │                         ‾
    └┬ `Division_by_zero` exception management
     └─ with integers
 #return code 123#
 ```
 
 ```catala-test-inline
-$ catala Interpret -s Money
+$ catala test-scope Money
 [ERROR] Error during evaluation: division by zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.23-30.35:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.29-30.30:
 └──┐
 30 │   definition i equals $10.0 / $0.0
-   │                       ‾‾‾‾‾‾‾‾‾‾‾‾
+   │                             ‾
    └┬ `Division_by_zero` exception management
     └─ with money
 #return code 123#

--- a/tests/arithmetic/bad/division_by_zero.catala_en
+++ b/tests/arithmetic/bad/division_by_zero.catala_en
@@ -33,12 +33,13 @@ scope Money:
 
 ```catala-test-inline
 $ catala test-scope Dec
-[ERROR] Error during evaluation: division by zero.
+[ERROR] During evaluation: a value is being used as denominator in a division
+  and it computed to zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.26-20.27:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.28-20.30:
 └──┐
 20 │   definition i equals 1. / 0.
-   │                          ‾
+   │                            ‾‾
    └┬ `Division_by_zero` exception management
     └─ with decimals
 #return code 123#
@@ -46,12 +47,13 @@ $ catala test-scope Dec
 
 ```catala-test-inline
 $ catala test-scope Int
-[ERROR] Error during evaluation: division by zero.
+[ERROR] During evaluation: a value is being used as denominator in a division
+  and it computed to zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.25-10.26:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.27-10.28:
 └──┐
 10 │   definition i equals 1 / 0
-   │                         ‾
+   │                           ‾
    └┬ `Division_by_zero` exception management
     └─ with integers
 #return code 123#
@@ -59,12 +61,13 @@ $ catala test-scope Int
 
 ```catala-test-inline
 $ catala test-scope Money
-[ERROR] Error during evaluation: division by zero.
+[ERROR] During evaluation: a value is being used as denominator in a division
+  and it computed to zero.
 
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.29-30.30:
+┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.31-30.35:
 └──┐
 30 │   definition i equals $10.0 / $0.0
-   │                             ‾
+   │                               ‾‾‾‾
    └┬ `Division_by_zero` exception management
     └─ with money
 #return code 123#

--- a/tests/arithmetic/bad/division_by_zero.catala_en
+++ b/tests/arithmetic/bad/division_by_zero.catala_en
@@ -33,21 +33,12 @@ scope Money:
 
 ```catala-test-inline
 $ catala Interpret -s Dec
-[ERROR] division by zero at runtime
+[ERROR] Error during evaluation: division by zero.
 
-The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.23-20.30:
 └──┐
 20 │   definition i equals 1. / 0.
    │                       ‾‾‾‾‾‾‾
-   └┬ `Division_by_zero` exception management
-    └─ with decimals
-
-The null denominator:
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.28-20.30:
-└──┐
-20 │   definition i equals 1. / 0.
-   │                            ‾‾
    └┬ `Division_by_zero` exception management
     └─ with decimals
 #return code 123#
@@ -57,21 +48,12 @@ The null denominator:
 Fixme: the following should give the same result as above, but the optimisation pass propagates the position surrounding the `ErrorOnEmpty` and loses the position of the actual division expression which was in the `cons` of the default term. Unfortunately this is non-trivial due to the bindlib boxing tricks.
 ```catala-test-inline
 $ catala Interpret -O -s Dec
-[ERROR] division by zero at runtime
+[ERROR] Error during evaluation: division by zero.
 
-The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:17.10-17.11:
 └──┐
 17 │   output i content decimal
    │          ‾
-   └┬ `Division_by_zero` exception management
-    └─ with decimals
-
-The null denominator:
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:20.28-20.30:
-└──┐
-20 │   definition i equals 1. / 0.
-   │                            ‾‾
    └┬ `Division_by_zero` exception management
     └─ with decimals
 #return code 123#
@@ -79,21 +61,12 @@ The null denominator:
 
 ```catala-test-inline
 $ catala interpret -s Int
-[ERROR] division by zero at runtime
+[ERROR] Error during evaluation: division by zero.
 
-The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.23-10.28:
 └──┐
 10 │   definition i equals 1 / 0
    │                       ‾‾‾‾‾
-   └┬ `Division_by_zero` exception management
-    └─ with integers
-
-The null denominator:
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:10.27-10.28:
-└──┐
-10 │   definition i equals 1 / 0
-   │                           ‾
    └┬ `Division_by_zero` exception management
     └─ with integers
 #return code 123#
@@ -101,21 +74,12 @@ The null denominator:
 
 ```catala-test-inline
 $ catala Interpret -s Money
-[ERROR] division by zero at runtime
+[ERROR] Error during evaluation: division by zero.
 
-The division operator:
 ┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.23-30.35:
 └──┐
 30 │   definition i equals $10.0 / $0.0
    │                       ‾‾‾‾‾‾‾‾‾‾‾‾
-   └┬ `Division_by_zero` exception management
-    └─ with money
-
-The null denominator:
-┌─⯈ tests/arithmetic/bad/division_by_zero.catala_en:30.31-30.35:
-└──┐
-30 │   definition i equals $10.0 / $0.0
-   │                               ‾‾‾‾
    └┬ `Division_by_zero` exception management
     └─ with money
 #return code 123#

--- a/tests/backends/output/simple.c
+++ b/tests/backends/output/simple.c
@@ -180,7 +180,7 @@ baz_struct baz_func(baz_in_struct baz_in) {
       option_1_enum match_arg = temp_a_3;
       if (match_arg.code == option_1_enum_none_1_cons) {
         void* /* unit */ dummy_var = match_arg.payload.none_1_cons;
-        catala_fatal_error_raised.code = catala_no_value_provided;
+        catala_fatal_error_raised.code = catala_no_value;
         catala_fatal_error_raised.position.filename = "tests/backends/simple.catala_en";
         catala_fatal_error_raised.position.start_line = 11;
         catala_fatal_error_raised.position.start_column = 11;
@@ -202,7 +202,7 @@ baz_struct baz_func(baz_in_struct baz_in) {
   option_1_enum match_arg_1 = temp_a_1;
   if (match_arg_1.code == option_1_enum_none_1_cons) {
     void* /* unit */ dummy_var = match_arg_1.payload.none_1_cons;
-    catala_fatal_error_raised.code = catala_no_value_provided;
+    catala_fatal_error_raised.code = catala_no_value;
     catala_fatal_error_raised.position.filename = "tests/backends/simple.catala_en";
     catala_fatal_error_raised.position.start_line = 11;
     catala_fatal_error_raised.position.start_column = 11;
@@ -360,7 +360,7 @@ baz_struct baz_func(baz_in_struct baz_in) {
   option_2_enum match_arg_4 = temp_b_1;
   if (match_arg_4.code == option_2_enum_none_2_cons) {
     void* /* unit */ dummy_var = match_arg_4.payload.none_2_cons;
-    catala_fatal_error_raised.code = catala_no_value_provided;
+    catala_fatal_error_raised.code = catala_no_value;
     catala_fatal_error_raised.position.filename = "tests/backends/simple.catala_en";
     catala_fatal_error_raised.position.start_line = 12;
     catala_fatal_error_raised.position.start_column = 10;
@@ -424,7 +424,7 @@ baz_struct baz_func(baz_in_struct baz_in) {
   option_3_enum match_arg_5 = temp_c_1;
   if (match_arg_5.code == option_3_enum_none_3_cons) {
     void* /* unit */ dummy_var = match_arg_5.payload.none_3_cons;
-    catala_fatal_error_raised.code = catala_no_value_provided;
+    catala_fatal_error_raised.code = catala_no_value;
     catala_fatal_error_raised.position.filename = "tests/backends/simple.catala_en";
     catala_fatal_error_raised.position.start_line = 13;
     catala_fatal_error_raised.position.start_column = 10;

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -98,8 +98,8 @@ def some_name(some_name_in:SomeNameIn):
             def temp_o_2(_:Unit):
                 return (i + integer_of_string("1"))
             return handle_default(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
-                                  start_line=7, start_column=10,
-                                  end_line=7, end_column=11,
+                                  start_line=10, start_column=23,
+                                  end_line=10, end_column=28,
                                   law_headings=[]), [], temp_o_1, temp_o_2)
         def temp_o_3(_:Unit):
             return False
@@ -126,8 +126,8 @@ def b(b_in:BIn):
             def temp_result_2(_:Unit):
                 return integer_of_string("1")
             return handle_default(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
-                                  start_line=16, start_column=14,
-                                  end_line=16, end_column=25,
+                                  start_line=16, start_column=33,
+                                  end_line=16, end_column=34,
                                   law_headings=[]), [], temp_result_1,
                                   temp_result_2)
         def temp_result_3(_:Unit):

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -104,18 +104,17 @@ def some_name(some_name_in:SomeNameIn):
         def temp_o_3(_:Unit):
             return False
         def temp_o_4(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_o_5 = handle_default(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
                                   start_line=7, start_column=10,
                                   end_line=7, end_column=11,
                                   law_headings=[]), [temp_o], temp_o_3,
                                   temp_o_4)
-    except EmptyError:
-        temp_o_5 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
-                                             start_line=7, start_column=10,
-                                             end_line=7, end_column=11,
-                                             law_headings=[]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/backends/python_name_clash.catala_en",
+                          start_line=7, start_column=10,
+                          end_line=7, end_column=11, law_headings=[]))
     o = temp_o_5
     return SomeName(o = o)
 
@@ -134,18 +133,17 @@ def b(b_in:BIn):
         def temp_result_3(_:Unit):
             return False
         def temp_result_4(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_result_5 = handle_default(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
                                        start_line=16, start_column=14,
                                        end_line=16, end_column=25,
                                        law_headings=[]), [temp_result],
                                        temp_result_3, temp_result_4)
-    except EmptyError:
-        temp_result_5 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/backends/python_name_clash.catala_en",
-                                             start_line=16, start_column=14,
-                                             end_line=16, end_column=25,
-                                             law_headings=[]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/backends/python_name_clash.catala_en",
+                          start_line=16, start_column=14,
+                          end_line=16, end_column=25, law_headings=[]))
     result = some_name(SomeNameIn(i_in = temp_result_5))
     result_1 = SomeName(o = result.o)
     if True:

--- a/tests/date/bad/uncomparable_duration.catala_en
+++ b/tests/date/bad/uncomparable_duration.catala_en
@@ -42,8 +42,8 @@ scope Ge:
 
 ```catala-test-inline
 $ catala test-scope Ge
-[ERROR] Error during evaluation: comparing durations in different units (e.g.
-  months vs. days).
+[ERROR] During evaluation: ambiguous comparison between durations in
+  different units (e.g. months vs. days).
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.31-40.33:
 └──┐
@@ -56,8 +56,8 @@ $ catala test-scope Ge
 
 ```catala-test-inline
 $ catala test-scope Gt
-[ERROR] Error during evaluation: comparing durations in different units (e.g.
-  months vs. days).
+[ERROR] During evaluation: ambiguous comparison between durations in
+  different units (e.g. months vs. days).
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.31-30.32:
 └──┐
@@ -70,8 +70,8 @@ $ catala test-scope Gt
 
 ```catala-test-inline
 $ catala test-scope Le
-[ERROR] Error during evaluation: comparing durations in different units (e.g.
-  months vs. days).
+[ERROR] During evaluation: ambiguous comparison between durations in
+  different units (e.g. months vs. days).
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.31-20.33:
 └──┐
@@ -84,8 +84,8 @@ $ catala test-scope Le
 
 ```catala-test-inline
 $ catala test-scope Lt
-[ERROR] Error during evaluation: comparing durations in different units (e.g.
-  months vs. days).
+[ERROR] During evaluation: ambiguous comparison between durations in
+  different units (e.g. months vs. days).
 
 ┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.31-10.32:
 └──┐

--- a/tests/date/bad/uncomparable_duration.catala_en
+++ b/tests/date/bad/uncomparable_duration.catala_en
@@ -40,85 +40,61 @@ scope Ge:
   definition d equals 1 month >= 2 day
 ```
 
+*Fixme*: these tests should use `test-scope` rather than `interpret` ; however,
+compiling with optimisations enabled changes the positions at the moment, so
+they are restricted until that is fixed (see the same issue in division by 0 tests)
+
 ```catala-test-inline
-$ catala test-scope Ge
-[ERROR] Cannot compare together durations that cannot be converted to a
-  precise number of days
+$ catala interpret -s Ge
+[ERROR] Error during evaluation: comparing durations in different units (e.g.
+  months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.23-40.30:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.23-40.39:
 └──┐
 40 │   definition d equals 1 month >= 2 day
-   │                       ‾‾‾‾‾‾‾
-   └┬ `UncomparableDurations` exception management
-    └─ `>=` operator
-
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.34-40.39:
-└──┐
-40 │   definition d equals 1 month >= 2 day
-   │                                  ‾‾‾‾‾
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    └┬ `UncomparableDurations` exception management
     └─ `>=` operator
 #return code 123#
 ```
 
 ```catala-test-inline
-$ catala test-scope Gt
-[ERROR] Cannot compare together durations that cannot be converted to a
-  precise number of days
+$ catala interpret -s Gt
+[ERROR] Error during evaluation: comparing durations in different units (e.g.
+  months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.23-30.30:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.23-30.38:
 └──┐
 30 │   definition d equals 1 month > 2 day
-   │                       ‾‾‾‾‾‾‾
-   └┬ `UncomparableDurations` exception management
-    └─ `<=` operator
-
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.33-30.38:
-└──┐
-30 │   definition d equals 1 month > 2 day
-   │                                 ‾‾‾‾‾
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    └┬ `UncomparableDurations` exception management
     └─ `<=` operator
 #return code 123#
 ```
 
 ```catala-test-inline
-$ catala test-scope Le
-[ERROR] Cannot compare together durations that cannot be converted to a
-  precise number of days
+$ catala interpret -s Le
+[ERROR] Error during evaluation: comparing durations in different units (e.g.
+  months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.23-20.30:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.23-20.39:
 └──┐
 20 │   definition d equals 1 month <= 2 day
-   │                       ‾‾‾‾‾‾‾
-   └┬ `UncomparableDurations` exception management
-    └─ `<=` operator
-
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.34-20.39:
-└──┐
-20 │   definition d equals 1 month <= 2 day
-   │                                  ‾‾‾‾‾
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    └┬ `UncomparableDurations` exception management
     └─ `<=` operator
 #return code 123#
 ```
 
 ```catala-test-inline
-$ catala test-scope Lt
-[ERROR] Cannot compare together durations that cannot be converted to a
-  precise number of days
+$ catala interpret -s Lt
+[ERROR] Error during evaluation: comparing durations in different units (e.g.
+  months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.23-10.30:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.23-10.38:
 └──┐
 10 │   definition d equals 1 month < 2 day
-   │                       ‾‾‾‾‾‾‾
-   └┬ `UncomparableDurations` exception management
-    └─ `<` operator
-
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.33-10.38:
-└──┐
-10 │   definition d equals 1 month < 2 day
-   │                                 ‾‾‾‾‾
+   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
    └┬ `UncomparableDurations` exception management
     └─ `<` operator
 #return code 123#

--- a/tests/date/bad/uncomparable_duration.catala_en
+++ b/tests/date/bad/uncomparable_duration.catala_en
@@ -40,12 +40,8 @@ scope Ge:
   definition d equals 1 month >= 2 day
 ```
 
-*Fixme*: these tests should use `test-scope` rather than `interpret` ; however,
-compiling with optimisations enabled changes the positions at the moment, so
-they are restricted until that is fixed (see the same issue in division by 0 tests)
-
 ```catala-test-inline
-$ catala interpret -s Ge
+$ catala test-scope Ge
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
@@ -59,7 +55,7 @@ $ catala interpret -s Ge
 ```
 
 ```catala-test-inline
-$ catala interpret -s Gt
+$ catala test-scope Gt
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
@@ -73,7 +69,7 @@ $ catala interpret -s Gt
 ```
 
 ```catala-test-inline
-$ catala interpret -s Le
+$ catala test-scope Le
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
@@ -87,7 +83,7 @@ $ catala interpret -s Le
 ```
 
 ```catala-test-inline
-$ catala interpret -s Lt
+$ catala test-scope Lt
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 

--- a/tests/date/bad/uncomparable_duration.catala_en
+++ b/tests/date/bad/uncomparable_duration.catala_en
@@ -49,10 +49,10 @@ $ catala interpret -s Ge
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.23-40.39:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:40.31-40.33:
 └──┐
 40 │   definition d equals 1 month >= 2 day
-   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   │                               ‾‾
    └┬ `UncomparableDurations` exception management
     └─ `>=` operator
 #return code 123#
@@ -63,10 +63,10 @@ $ catala interpret -s Gt
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.23-30.38:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:30.31-30.32:
 └──┐
 30 │   definition d equals 1 month > 2 day
-   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   │                               ‾
    └┬ `UncomparableDurations` exception management
     └─ `<=` operator
 #return code 123#
@@ -77,10 +77,10 @@ $ catala interpret -s Le
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.23-20.39:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:20.31-20.33:
 └──┐
 20 │   definition d equals 1 month <= 2 day
-   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   │                               ‾‾
    └┬ `UncomparableDurations` exception management
     └─ `<=` operator
 #return code 123#
@@ -91,10 +91,10 @@ $ catala interpret -s Lt
 [ERROR] Error during evaluation: comparing durations in different units (e.g.
   months vs. days).
 
-┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.23-10.38:
+┌─⯈ tests/date/bad/uncomparable_duration.catala_en:10.31-10.32:
 └──┐
 10 │   definition d equals 1 month < 2 day
-   │                       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+   │                               ‾
    └┬ `UncomparableDurations` exception management
     └─ `<` operator
 #return code 123#

--- a/tests/default/bad/conflict.catala_en
+++ b/tests/default/bad/conflict.catala_en
@@ -11,8 +11,8 @@ scope A:
 
 ```catala-test-inline
 $ catala Interpret -s A --message=gnu
-tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR] There is a conflict between multiple valid consequences for assigning the same variable.
-tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR] This consequence has a valid justification:
-tests/default/bad/conflict.catala_en:9.56-9.57: [ERROR] This consequence has a valid justification:
+tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR] Error during evaluation: two or more concurring valid computations.
+tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR]
+tests/default/bad/conflict.catala_en:9.56-9.57: [ERROR]
 #return code 123#
 ```

--- a/tests/default/bad/conflict.catala_en
+++ b/tests/default/bad/conflict.catala_en
@@ -11,7 +11,7 @@ scope A:
 
 ```catala-test-inline
 $ catala Interpret -s A --message=gnu
-tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR] Error during evaluation: two or more concurring valid computations.
+tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR] During evaluation: conflict between multiple valid consequences for assigning the same variable.
 tests/default/bad/conflict.catala_en:8.56-8.57: [ERROR]
 tests/default/bad/conflict.catala_en:9.56-9.57: [ERROR]
 #return code 123#

--- a/tests/default/bad/empty.catala_en
+++ b/tests/default/bad/empty.catala_en
@@ -19,7 +19,8 @@ $ catala test-scope A
 6 │   output y content boolean
   │          ‾
   └─ Article
-[ERROR] Error during evaluation: no computation with valid conditions found.
+[ERROR] During evaluation: no applicable rule to define this variable in this
+  situation.
 
 ┌─⯈ tests/default/bad/empty.catala_en:6.10-6.11:
 └─┐

--- a/tests/default/bad/empty.catala_en
+++ b/tests/default/bad/empty.catala_en
@@ -19,8 +19,7 @@ $ catala test-scope A
 6 │   output y content boolean
   │          ‾
   └─ Article
-[ERROR] This variable evaluated to an empty term (no rule that defined it
-  applied in this situation)
+[ERROR] Error during evaluation: no computation with valid conditions found.
 
 ┌─⯈ tests/default/bad/empty.catala_en:6.10-6.11:
 └─┐

--- a/tests/default/bad/empty_with_rules.catala_en
+++ b/tests/default/bad/empty_with_rules.catala_en
@@ -14,8 +14,7 @@ scope A:
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR] This variable evaluated to an empty term (no rule that defined it
-  applied in this situation)
+[ERROR] Error during evaluation: no computation with valid conditions found.
 
 ┌─⯈ tests/default/bad/empty_with_rules.catala_en:5.10-5.11:
 └─┐

--- a/tests/default/bad/empty_with_rules.catala_en
+++ b/tests/default/bad/empty_with_rules.catala_en
@@ -14,7 +14,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR] Error during evaluation: no computation with valid conditions found.
+[ERROR] During evaluation: no applicable rule to define this variable in this
+  situation.
 
 ┌─⯈ tests/default/bad/empty_with_rules.catala_en:5.10-5.11:
 └─┐

--- a/tests/default/bad/empty_with_rules.catala_en
+++ b/tests/default/bad/empty_with_rules.catala_en
@@ -13,7 +13,7 @@ scope A:
 ```
 
 ```catala-test-inline
-$ catala interpret -s A
+$ catala test-scope A
 [ERROR] Error during evaluation: no computation with valid conditions found.
 
 ┌─⯈ tests/default/bad/empty_with_rules.catala_en:5.10-5.11:

--- a/tests/exception/bad/two_exceptions.catala_en
+++ b/tests/exception/bad/two_exceptions.catala_en
@@ -19,17 +19,14 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR] There is a conflict between multiple valid consequences for assigning
-  the same variable.
+[ERROR] Error during evaluation: two or more concurring valid computations.
 
-This consequence has a valid justification:
 ┌─⯈ tests/exception/bad/two_exceptions.catala_en:12.23-12.24:
 └──┐
 12 │   definition x equals 1
    │                       ‾
    └─ Test
 
-This consequence has a valid justification:
 ┌─⯈ tests/exception/bad/two_exceptions.catala_en:15.23-15.24:
 └──┐
 15 │   definition x equals 2

--- a/tests/exception/bad/two_exceptions.catala_en
+++ b/tests/exception/bad/two_exceptions.catala_en
@@ -15,10 +15,8 @@ scope A:
   definition x equals 2
 ```
 
-Note: ideally this could use test-scope but some positions are lost during translation to lcalc
-
 ```catala-test-inline
-$ catala interpret -s A
+$ catala test-scope A
 [ERROR] Error during evaluation: two or more concurring valid computations.
 
 ┌─⯈ tests/exception/bad/two_exceptions.catala_en:12.23-12.24:

--- a/tests/exception/bad/two_exceptions.catala_en
+++ b/tests/exception/bad/two_exceptions.catala_en
@@ -17,7 +17,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR] Error during evaluation: two or more concurring valid computations.
+[ERROR] During evaluation: conflict between multiple valid consequences for
+  assigning the same variable.
 
 ┌─⯈ tests/exception/bad/two_exceptions.catala_en:12.23-12.24:
 └──┐

--- a/tests/func/bad/bad_func.catala_en
+++ b/tests/func/bad/bad_func.catala_en
@@ -31,17 +31,14 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s S
-[ERROR] There is a conflict between multiple valid consequences for assigning
-  the same variable.
+[ERROR] Error during evaluation: two or more concurring valid computations.
 
-This consequence has a valid justification:
 ┌─⯈ tests/func/bad/bad_func.catala_en:14.65-14.70:
 └──┐
 14 │   definition f of x under condition (x >= x) consequence equals x + x
    │                                                                 ‾‾‾‾‾
    └─ Article
 
-This consequence has a valid justification:
 ┌─⯈ tests/func/bad/bad_func.catala_en:15.62-15.67:
 └──┐
 15 │   definition f of x under condition not b consequence equals x * x

--- a/tests/func/bad/bad_func.catala_en
+++ b/tests/func/bad/bad_func.catala_en
@@ -27,10 +27,8 @@ $ catala test-scope R
 [RESULT] r = 30
 ```
 
-Note: ideally this could use test-scope but some positions are lost during translation to lcalc
-
 ```catala-test-inline
-$ catala interpret -s S
+$ catala test-scope S
 [ERROR] Error during evaluation: two or more concurring valid computations.
 
 ┌─⯈ tests/func/bad/bad_func.catala_en:14.65-14.70:

--- a/tests/func/bad/bad_func.catala_en
+++ b/tests/func/bad/bad_func.catala_en
@@ -29,7 +29,8 @@ $ catala test-scope R
 
 ```catala-test-inline
 $ catala test-scope S
-[ERROR] Error during evaluation: two or more concurring valid computations.
+[ERROR] During evaluation: conflict between multiple valid consequences for
+  assigning the same variable.
 
 ┌─⯈ tests/func/bad/bad_func.catala_en:14.65-14.70:
 └──┐

--- a/tests/func/good/closure_conversion_reduce.catala_en
+++ b/tests/func/good/closure_conversion_reduce.catala_en
@@ -75,7 +75,7 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
          (λ () → false)
          (λ () → ENone ()))
     with
-    | ENone → raise NoValueProvided
+    | ENone → error NoValue
     | ESome arg → arg
   in
   return { S y = y; }

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -124,7 +124,7 @@ let scope Foo
     match
       (handle_default_opt [b.0 b.1 ()] (λ () → true) (λ () → ESome true))
     with
-    | ENone → raise NoValueProvided
+    | ENone → error NoValue
     | ESome arg → arg
   in
   let set r :

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -66,7 +66,7 @@ let half_ : integer -> decimal =
   fun (x_: integer) ->
     o_div_int_int
       {filename="tests/modules/good/mod_def.catala_en";
-       start_line=21; start_column=10; end_line=21; end_column=15;
+       start_line=21; start_column=12; end_line=21; end_column=13;
        law_headings=["Test modules + inclusions 1"]} x_ (integer_of_string
       "2")
 

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -66,7 +66,7 @@ let half_ : integer -> decimal =
   fun (x_: integer) ->
     o_div_int_int
       {filename="tests/modules/good/mod_def.catala_en";
-       start_line=21; start_column=12; end_line=21; end_column=13;
+       start_line=21; start_column=14; end_line=21; end_column=15;
        law_headings=["Test modules + inclusions 1"]} x_ (integer_of_string
       "2")
 

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -29,43 +29,36 @@ let s (s_in: S_in.t) : S.t =
   let sr_: money =
     try
       (handle_default
-         {filename="tests/modules/good/mod_def.catala_en";
-          start_line=16; start_column=10; end_line=16; end_column=12;
-          law_headings=["Test modules + inclusions 1"]}
+         [|{filename="tests/modules/good/mod_def.catala_en";
+            start_line=16; start_column=10; end_line=16; end_column=12;
+            law_headings=["Test modules + inclusions 1"]}|]
          ([|(fun (_: unit) ->
-               handle_default
-                 {filename="tests/modules/good/mod_def.catala_en";
-                  start_line=16; start_column=10; end_line=16; end_column=12;
-                  law_headings=["Test modules + inclusions 1"]} ([||])
-                 (fun (_: unit) -> true)
+               handle_default [||] ([||]) (fun (_: unit) -> true)
                  (fun (_: unit) -> money_of_cents_string "100000"))|])
          (fun (_: unit) -> false) (fun (_: unit) -> raise Empty))
-    with
-    Empty -> (raise
-      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/modules/good/mod_def.catala_en";
-                                              start_line=16; start_column=10;
-                                              end_line=16; end_column=12;
-                                              law_headings=["Test modules + inclusions 1"]})))
+    with Empty ->
+    (raise
+    (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
+                                             start_line=16; start_column=10;
+                                             end_line=16; end_column=12;
+                                             law_headings=["Test modules + inclusions 1"]}])))
     in
   let e1_: Enum1.t =
     try
       (handle_default
-         {filename="tests/modules/good/mod_def.catala_en";
-          start_line=17; start_column=10; end_line=17; end_column=12;
-          law_headings=["Test modules + inclusions 1"]}
+         [|{filename="tests/modules/good/mod_def.catala_en";
+            start_line=17; start_column=10; end_line=17; end_column=12;
+            law_headings=["Test modules + inclusions 1"]}|]
          ([|(fun (_: unit) ->
-               handle_default
-                 {filename="tests/modules/good/mod_def.catala_en";
-                  start_line=17; start_column=10; end_line=17; end_column=12;
-                  law_headings=["Test modules + inclusions 1"]} ([||])
-                 (fun (_: unit) -> true) (fun (_: unit) -> Enum1.Maybe ()))|])
+               handle_default [||] ([||]) (fun (_: unit) -> true)
+                 (fun (_: unit) -> Enum1.Maybe ()))|])
          (fun (_: unit) -> false) (fun (_: unit) -> raise Empty))
-    with
-    Empty -> (raise
-      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/modules/good/mod_def.catala_en";
-                                              start_line=17; start_column=10;
-                                              end_line=17; end_column=12;
-                                              law_headings=["Test modules + inclusions 1"]})))
+    with Empty ->
+    (raise
+    (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
+                                             start_line=17; start_column=10;
+                                             end_line=17; end_column=12;
+                                             law_headings=["Test modules + inclusions 1"]}])))
     in
   {S.sr = sr_; S.e1 = e1_}
 

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -30,7 +30,7 @@ let s (s_in: S_in.t) : S.t =
     try
       (handle_default
          [|{filename="tests/modules/good/mod_def.catala_en";
-            start_line=16; start_column=10; end_line=16; end_column=12;
+            start_line=26; start_column=24; end_line=26; end_column=30;
             law_headings=["Test modules + inclusions 1"]}|]
          ([|(fun (_: unit) ->
                handle_default [||] ([||]) (fun (_: unit) -> true)
@@ -47,7 +47,7 @@ let s (s_in: S_in.t) : S.t =
     try
       (handle_default
          [|{filename="tests/modules/good/mod_def.catala_en";
-            start_line=17; start_column=10; end_line=17; end_column=12;
+            start_line=27; start_column=24; end_line=27; end_column=29;
             law_headings=["Test modules + inclusions 1"]}|]
          ([|(fun (_: unit) ->
                handle_default [||] ([||]) (fun (_: unit) -> true)

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -29,46 +29,53 @@ let s (s_in: S_in.t) : S.t =
   let sr_: money =
     try
       (handle_default
-         {filename = "tests/modules/good/mod_def.catala_en"; start_line=16;
-           start_column=10; end_line=16; end_column=12;
-           law_headings=["Test modules + inclusions 1"]}
+         {filename="tests/modules/good/mod_def.catala_en";
+          start_line=16; start_column=10; end_line=16; end_column=12;
+          law_headings=["Test modules + inclusions 1"]}
          ([|(fun (_: unit) ->
                handle_default
-                 {filename = "tests/modules/good/mod_def.catala_en";
-                   start_line=16; start_column=10;
-                   end_line=16; end_column=12;
-                   law_headings=["Test modules + inclusions 1"]} ([||])
+                 {filename="tests/modules/good/mod_def.catala_en";
+                  start_line=16; start_column=10; end_line=16; end_column=12;
+                  law_headings=["Test modules + inclusions 1"]} ([||])
                  (fun (_: unit) -> true)
                  (fun (_: unit) -> money_of_cents_string "100000"))|])
-         (fun (_: unit) -> false) (fun (_: unit) -> raise EmptyError))
+         (fun (_: unit) -> false) (fun (_: unit) -> raise Empty))
     with
-    EmptyError -> (raise (NoValueProvided
-      {filename = "tests/modules/good/mod_def.catala_en"; start_line=16;
-        start_column=10; end_line=16; end_column=12;
-        law_headings=["Test modules + inclusions 1"]})) in
+    Empty -> (raise
+      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/modules/good/mod_def.catala_en";
+                                              start_line=16; start_column=10;
+                                              end_line=16; end_column=12;
+                                              law_headings=["Test modules + inclusions 1"]})))
+    in
   let e1_: Enum1.t =
     try
       (handle_default
-         {filename = "tests/modules/good/mod_def.catala_en"; start_line=17;
-           start_column=10; end_line=17; end_column=12;
-           law_headings=["Test modules + inclusions 1"]}
+         {filename="tests/modules/good/mod_def.catala_en";
+          start_line=17; start_column=10; end_line=17; end_column=12;
+          law_headings=["Test modules + inclusions 1"]}
          ([|(fun (_: unit) ->
                handle_default
-                 {filename = "tests/modules/good/mod_def.catala_en";
-                   start_line=17; start_column=10;
-                   end_line=17; end_column=12;
-                   law_headings=["Test modules + inclusions 1"]} ([||])
+                 {filename="tests/modules/good/mod_def.catala_en";
+                  start_line=17; start_column=10; end_line=17; end_column=12;
+                  law_headings=["Test modules + inclusions 1"]} ([||])
                  (fun (_: unit) -> true) (fun (_: unit) -> Enum1.Maybe ()))|])
-         (fun (_: unit) -> false) (fun (_: unit) -> raise EmptyError))
+         (fun (_: unit) -> false) (fun (_: unit) -> raise Empty))
     with
-    EmptyError -> (raise (NoValueProvided
-      {filename = "tests/modules/good/mod_def.catala_en"; start_line=17;
-        start_column=10; end_line=17; end_column=12;
-        law_headings=["Test modules + inclusions 1"]})) in
+    Empty -> (raise
+      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/modules/good/mod_def.catala_en";
+                                              start_line=17; start_column=10;
+                                              end_line=17; end_column=12;
+                                              law_headings=["Test modules + inclusions 1"]})))
+    in
   {S.sr = sr_; S.e1 = e1_}
 
 let half_ : integer -> decimal =
-  fun (x_: integer) -> o_div_int_int x_ (integer_of_string "2")
+  fun (x_: integer) ->
+    o_div_int_int
+      {filename="tests/modules/good/mod_def.catala_en";
+       start_line=21; start_column=10; end_line=21; end_column=15;
+       law_headings=["Test modules + inclusions 1"]} x_ (integer_of_string
+      "2")
 
 let () =
   Runtime_ocaml.Runtime.register_module "Mod_def"

--- a/tests/modules/good/prorata_external.ml
+++ b/tests/modules/good/prorata_external.ml
@@ -5,12 +5,14 @@ open Oper
 
 let mzero = money_of_units_int 0
 
+let pos = {filename=__FILE__; start_line=0; start_column=0; end_line=0; end_column=0; law_headings=[]}
+
 let prorata_ : money -> (money array) -> (money array) =
   fun (amount: money) (weights: money array) ->
   let w_total = Array.fold_left o_add_mon_mon mzero weights in
   let rem, a =
     Array.fold_left_map (fun rem w ->
-        let r = o_mult_mon_rat amount (o_div_mon_mon w w_total) in
+        let r = o_mult_mon_rat amount (o_div_mon_mon pos w w_total) in
         o_sub_mon_mon rem r, r)
       amount weights
   in
@@ -25,7 +27,7 @@ let prorata2_ : money -> (money array) -> (money array) =
         let r =
           o_mult_mon_rat
             rem_amount
-            (o_div_mon_mon w rem_weights) in
+            (o_div_mon_mon pos w rem_weights) in
         (o_sub_mon_mon rem_amount r, o_sub_mon_mon rem_weights w), r)
       (amount, w_total) weights
   in

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -59,7 +59,7 @@ let s (s_in: S_in.t) : S.t =
             try
               (handle_default
                  [|{filename="tests/name_resolution/good/let_in2.catala_en";
-                    start_line=7; start_column=18; end_line=7; end_column=19;
+                    start_line=11; start_column=5; end_line=13; end_column=6;
                     law_headings=["Article"]}|]
                  ([|(fun (_: unit) ->
                        handle_default [||] ([||]) (fun (_: unit) -> true)

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -51,38 +51,40 @@ let s (s_in: S_in.t) : S.t =
   let a_: bool =
     try
       (handle_default
-         {filename = "tests/name_resolution/good/let_in2.catala_en";
-           start_line=7; start_column=18; end_line=7; end_column=19;
-           law_headings=["Article"]} ([|(fun (_: unit) -> a_ ())|])
+         {filename="tests/name_resolution/good/let_in2.catala_en";
+          start_line=7; start_column=18; end_line=7; end_column=19;
+          law_headings=["Article"]} ([|(fun (_: unit) -> a_ ())|])
          (fun (_: unit) -> true)
          (fun (_: unit) ->
             try
               (handle_default
-                 {filename = "tests/name_resolution/good/let_in2.catala_en";
-                   start_line=7; start_column=18; end_line=7; end_column=19;
-                   law_headings=["Article"]}
+                 {filename="tests/name_resolution/good/let_in2.catala_en";
+                  start_line=7; start_column=18; end_line=7; end_column=19;
+                  law_headings=["Article"]}
                  ([|(fun (_: unit) ->
                        handle_default
-                         {filename = "tests/name_resolution/good/let_in2.catala_en";
-                           start_line=7; start_column=18;
-                           end_line=7; end_column=19;
-                           law_headings=["Article"]} ([||])
+                         {filename="tests/name_resolution/good/let_in2.catala_en";
+                          start_line=7; start_column=18;
+                          end_line=7; end_column=19;
+                          law_headings=["Article"]} ([||])
                          (fun (_: unit) -> true)
                          (fun (_: unit) -> (let a_ : bool = false
                             in
                             (let a_ : bool = (o_or a_ true) in
                             a_))))|]) (fun (_: unit) -> false)
-                 (fun (_: unit) -> raise EmptyError))
+                 (fun (_: unit) -> raise Empty))
             with
-            EmptyError -> (raise (NoValueProvided
-              {filename = "tests/name_resolution/good/let_in2.catala_en";
-                start_line=7; start_column=18; end_line=7; end_column=19;
-                law_headings=["Article"]}))))
+            Empty -> (raise
+              (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/name_resolution/good/let_in2.catala_en";
+                                                      start_line=7; start_column=18;
+                                                      end_line=7; end_column=19;
+                                                      law_headings=["Article"]})))))
     with
-    EmptyError -> (raise (NoValueProvided
-      {filename = "tests/name_resolution/good/let_in2.catala_en";
-        start_line=7; start_column=18; end_line=7; end_column=19;
-        law_headings=["Article"]})) in
+    Empty -> (raise
+      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/name_resolution/good/let_in2.catala_en";
+                                              start_line=7; start_column=18;
+                                              end_line=7; end_column=19;
+                                              law_headings=["Article"]}))) in
   {S.a = a_}
 
 let () =

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -51,40 +51,35 @@ let s (s_in: S_in.t) : S.t =
   let a_: bool =
     try
       (handle_default
-         {filename="tests/name_resolution/good/let_in2.catala_en";
-          start_line=7; start_column=18; end_line=7; end_column=19;
-          law_headings=["Article"]} ([|(fun (_: unit) -> a_ ())|])
+         [|{filename="tests/name_resolution/good/let_in2.catala_en";
+            start_line=7; start_column=18; end_line=7; end_column=19;
+            law_headings=["Article"]}|] ([|(fun (_: unit) -> a_ ())|])
          (fun (_: unit) -> true)
          (fun (_: unit) ->
             try
               (handle_default
-                 {filename="tests/name_resolution/good/let_in2.catala_en";
-                  start_line=7; start_column=18; end_line=7; end_column=19;
-                  law_headings=["Article"]}
+                 [|{filename="tests/name_resolution/good/let_in2.catala_en";
+                    start_line=7; start_column=18; end_line=7; end_column=19;
+                    law_headings=["Article"]}|]
                  ([|(fun (_: unit) ->
-                       handle_default
-                         {filename="tests/name_resolution/good/let_in2.catala_en";
-                          start_line=7; start_column=18;
-                          end_line=7; end_column=19;
-                          law_headings=["Article"]} ([||])
-                         (fun (_: unit) -> true)
+                       handle_default [||] ([||]) (fun (_: unit) -> true)
                          (fun (_: unit) -> (let a_ : bool = false
                             in
                             (let a_ : bool = (o_or a_ true) in
                             a_))))|]) (fun (_: unit) -> false)
                  (fun (_: unit) -> raise Empty))
-            with
-            Empty -> (raise
-              (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/name_resolution/good/let_in2.catala_en";
-                                                      start_line=7; start_column=18;
-                                                      end_line=7; end_column=19;
-                                                      law_headings=["Article"]})))))
-    with
-    Empty -> (raise
-      (Runtime_ocaml.Runtime.Error (NoValue, {filename="tests/name_resolution/good/let_in2.catala_en";
-                                              start_line=7; start_column=18;
-                                              end_line=7; end_column=19;
-                                              law_headings=["Article"]}))) in
+            with Empty ->
+            (raise
+            (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
+                                                     start_line=7; start_column=18;
+                                                     end_line=7; end_column=19;
+                                                     law_headings=["Article"]}])))))
+    with Empty ->
+    (raise
+    (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
+                                             start_line=7; start_column=18;
+                                             end_line=7; end_column=19;
+                                             law_headings=["Article"]}]))) in
   {S.a = a_}
 
 let () =

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -133,10 +133,10 @@ let S2_6 (S2_in_10: S2_in) =
       return false;
     decl temp_a_21 : unit → decimal;
     let func temp_a_21 (__22 : unit) =
-      raise EmptyError;
+      raise Empty;
     temp_a_12 = handle_default [temp_a_13] temp_a_19 temp_a_21
-  with EmptyError:
-    raise NoValueProvided;
+  with Empty:
+    fatal NoValue;
   decl a_11 : decimal;
   a_11 = temp_a_12;
   return S2 {"a": a_11}
@@ -158,10 +158,10 @@ let S3_7 (S3_in_23: S3_in) =
       return false;
     decl temp_a_34 : unit → decimal;
     let func temp_a_34 (__35 : unit) =
-      raise EmptyError;
+      raise Empty;
     temp_a_25 = handle_default [temp_a_26] temp_a_32 temp_a_34
-  with EmptyError:
-    raise NoValueProvided;
+  with Empty:
+    fatal NoValue;
   decl a_24 : decimal;
   a_24 = temp_a_25;
   return S3 {"a": a_24}
@@ -183,10 +183,10 @@ let S4_8 (S4_in_36: S4_in) =
       return false;
     decl temp_a_47 : unit → decimal;
     let func temp_a_47 (__48 : unit) =
-      raise EmptyError;
+      raise Empty;
     temp_a_38 = handle_default [temp_a_39] temp_a_45 temp_a_47
-  with EmptyError:
-    raise NoValueProvided;
+  with Empty:
+    fatal NoValue;
   decl a_37 : decimal;
   a_37 = temp_a_38;
   return S4 {"a": a_37}
@@ -208,10 +208,10 @@ let S_9 (S_in_49: S_in) =
       return false;
     decl temp_a_72 : unit → decimal;
     let func temp_a_72 (__73 : unit) =
-      raise EmptyError;
+      raise Empty;
     temp_a_63 = handle_default [temp_a_64] temp_a_70 temp_a_72
-  with EmptyError:
-    raise NoValueProvided;
+  with Empty:
+    fatal NoValue;
   decl a_50 : decimal;
   a_50 = temp_a_63;
   decl temp_b_52 : A {y: bool; z: decimal};
@@ -230,10 +230,10 @@ let S_9 (S_in_49: S_in) =
       return false;
     decl temp_b_61 : unit → A {y: bool; z: decimal};
     let func temp_b_61 (__62 : unit) =
-      raise EmptyError;
+      raise Empty;
     temp_b_52 = handle_default [temp_b_53] temp_b_59 temp_b_61
-  with EmptyError:
-    raise NoValueProvided;
+  with Empty:
+    fatal NoValue;
   decl b_51 : A {y: bool; z: decimal};
   b_51 = temp_b_52;
   return S {"a": a_50, "b": b_51}
@@ -433,18 +433,18 @@ def s2(s2_in:S2In):
         def temp_a_3(_:Unit):
             return False
         def temp_a_4(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_a_5 = handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
                                   start_line=45, start_column=10,
                                   end_line=45, end_column=11,
                                   law_headings=["Test toplevel function defs"]), [temp_a],
                                   temp_a_3, temp_a_4)
-    except EmptyError:
-        temp_a_5 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=45, start_column=10,
-                                             end_line=45, end_column=11,
-                                             law_headings=["Test toplevel function defs"]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                          start_line=45, start_column=10,
+                          end_line=45, end_column=11,
+                          law_headings=["Test toplevel function defs"]))
     a = temp_a_5
     return S2(a = a)
 
@@ -465,18 +465,18 @@ def s3(s3_in:S3In):
         def temp_a_9(_:Unit):
             return False
         def temp_a_10(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_a_11 = handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
                                    start_line=65, start_column=10,
                                    end_line=65, end_column=11,
                                    law_headings=["Test function def with two args"]), [temp_a_6],
                                    temp_a_9, temp_a_10)
-    except EmptyError:
-        temp_a_11 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=65, start_column=10,
-                                             end_line=65, end_column=11,
-                                             law_headings=["Test function def with two args"]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                          start_line=65, start_column=10,
+                          end_line=65, end_column=11,
+                          law_headings=["Test function def with two args"]))
     a_1 = temp_a_11
     return S3(a = a_1)
 
@@ -495,18 +495,18 @@ def s4(s4_in:S4In):
         def temp_a_15(_:Unit):
             return False
         def temp_a_16(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_a_17 = handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
                                    start_line=88, start_column=10,
                                    end_line=88, end_column=11,
                                    law_headings=["Test inline defs in toplevel defs"]), [temp_a_12],
                                    temp_a_15, temp_a_16)
-    except EmptyError:
-        temp_a_17 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=88, start_column=10,
-                                             end_line=88, end_column=11,
-                                             law_headings=["Test inline defs in toplevel defs"]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                          start_line=88, start_column=10,
+                          end_line=88, end_column=11,
+                          law_headings=["Test inline defs in toplevel defs"]))
     a_2 = temp_a_17
     return S4(a = a_2)
 
@@ -525,18 +525,18 @@ def s(s_in:SIn):
         def temp_a_21(_:Unit):
             return False
         def temp_a_22(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_a_23 = handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
                                    start_line=7, start_column=10,
                                    end_line=7, end_column=11,
                                    law_headings=["Test basic toplevel values defs"]), [temp_a_18],
                                    temp_a_21, temp_a_22)
-    except EmptyError:
-        temp_a_23 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=7, start_column=10,
-                                             end_line=7, end_column=11,
-                                             law_headings=["Test basic toplevel values defs"]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                          start_line=7, start_column=10,
+                          end_line=7, end_column=11,
+                          law_headings=["Test basic toplevel values defs"]))
     a_3 = temp_a_23
     try:
         def temp_b(_:Unit):
@@ -552,18 +552,18 @@ def s(s_in:SIn):
         def temp_b_3(_:Unit):
             return False
         def temp_b_4(_:Unit):
-            raise EmptyError
+            raise Empty
         temp_b_5 = handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
                                   start_line=8, start_column=10,
                                   end_line=8, end_column=11,
                                   law_headings=["Test basic toplevel values defs"]), [temp_b],
                                   temp_b_3, temp_b_4)
-    except EmptyError:
-        temp_b_5 = dead_value
-        raise NoValueProvided(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                             start_line=8, start_column=10,
-                                             end_line=8, end_column=11,
-                                             law_headings=["Test basic toplevel values defs"]))
+    except Empty:
+        raise NoValue(SourcePosition(
+                          filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                          start_line=8, start_column=10,
+                          end_line=8, end_column=11,
+                          law_headings=["Test basic toplevel values defs"]))
     b = temp_b_5
     return S(a = a_3, b = b)
 ```

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -426,8 +426,8 @@ def s2(s2_in:S2In):
                 return (glob3(money_of_cents_string("4400")) +
                     decimal_of_string("100."))
             return handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=45, start_column=10,
-                                  end_line=45, end_column=11,
+                                  start_line=48, start_column=24,
+                                  end_line=48, end_column=43,
                                   law_headings=["Test toplevel function defs"]), [],
                                   temp_a_1, temp_a_2)
         def temp_a_3(_:Unit):
@@ -458,8 +458,8 @@ def s3(s3_in:S3In):
                     glob4(money_of_cents_string("4400"),
                           decimal_of_string("55.")))
             return handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=65, start_column=10,
-                                  end_line=65, end_column=11,
+                                  start_line=68, start_column=24,
+                                  end_line=68, end_column=47,
                                   law_headings=["Test function def with two args"]), [],
                                   temp_a_7, temp_a_8)
         def temp_a_9(_:Unit):
@@ -488,8 +488,8 @@ def s4(s4_in:S4In):
             def temp_a_14(_:Unit):
                 return (glob5 + decimal_of_string("1."))
             return handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=88, start_column=10,
-                                  end_line=88, end_column=11,
+                                  start_line=91, start_column=24,
+                                  end_line=91, end_column=34,
                                   law_headings=["Test inline defs in toplevel defs"]), [],
                                   temp_a_13, temp_a_14)
         def temp_a_15(_:Unit):
@@ -518,8 +518,8 @@ def s(s_in:SIn):
             def temp_a_20(_:Unit):
                 return (glob1 * glob1)
             return handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=7, start_column=10,
-                                  end_line=7, end_column=11,
+                                  start_line=18, start_column=24,
+                                  end_line=18, end_column=37,
                                   law_headings=["Test basic toplevel values defs"]), [],
                                   temp_a_19, temp_a_20)
         def temp_a_21(_:Unit):
@@ -545,8 +545,8 @@ def s(s_in:SIn):
             def temp_b_2(_:Unit):
                 return glob2
             return handle_default(SourcePosition(filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                                  start_line=8, start_column=10,
-                                  end_line=8, end_column=11,
+                                  start_line=19, start_column=24,
+                                  end_line=19, end_column=29,
                                   law_headings=["Test basic toplevel values defs"]), [],
                                   temp_b_1, temp_b_2)
         def temp_b_3(_:Unit):

--- a/tests/scope/bad/scope.catala_en
+++ b/tests/scope/bad/scope.catala_en
@@ -14,10 +14,8 @@ scope A:
   definition b under condition not c consequence equals 0
 ```
 
-Note: ideally this could use test-scope but some positions are lost during translation to lcalc
-
 ```catala-test-inline
-$ catala interpret -s A
+$ catala test-scope A
 [ERROR] Error during evaluation: two or more concurring valid computations.
 
 ┌─⯈ tests/scope/bad/scope.catala_en:13.57-13.61:

--- a/tests/scope/bad/scope.catala_en
+++ b/tests/scope/bad/scope.catala_en
@@ -16,7 +16,8 @@ scope A:
 
 ```catala-test-inline
 $ catala test-scope A
-[ERROR] Error during evaluation: two or more concurring valid computations.
+[ERROR] During evaluation: conflict between multiple valid consequences for
+  assigning the same variable.
 
 ┌─⯈ tests/scope/bad/scope.catala_en:13.57-13.61:
 └──┐

--- a/tests/scope/bad/scope.catala_en
+++ b/tests/scope/bad/scope.catala_en
@@ -18,17 +18,14 @@ Note: ideally this could use test-scope but some positions are lost during trans
 
 ```catala-test-inline
 $ catala interpret -s A
-[ERROR] There is a conflict between multiple valid consequences for assigning
-  the same variable.
+[ERROR] Error during evaluation: two or more concurring valid computations.
 
-This consequence has a valid justification:
 ┌─⯈ tests/scope/bad/scope.catala_en:13.57-13.61:
 └──┐
 13 │   definition b under condition not c consequence equals 1337
    │                                                         ‾‾‾‾
    └─ Article
 
-This consequence has a valid justification:
 ┌─⯈ tests/scope/bad/scope.catala_en:14.57-14.58:
 └──┐
 14 │   definition b under condition not c consequence equals 0

--- a/tests/scope/good/nothing.catala_en
+++ b/tests/scope/good/nothing.catala_en
@@ -33,7 +33,7 @@ $ catala Scalc -s Foo2 -O -t
   └─ Test
 let Foo2_3 (Foo2_in_2: Foo2_in) =
   decl temp_bar_4 : integer;
-  raise NoValueProvided;
+  fatal NoValue;
   decl bar_3 : integer;
   bar_3 = temp_bar_4;
   return Foo2 {"bar": bar_3}

--- a/tests/scope/good/simple.catala_en
+++ b/tests/scope/good/simple.catala_en
@@ -24,8 +24,8 @@ let scope Foo (Foo_in: Foo_in): Foo {bar: integer} =
       handle_default
         [λ () → handle_default [] (λ () → true) (λ () → 0)]
         (λ () → false)
-        (λ () → raise EmptyError)
-    with EmptyError -> raise NoValueProvided
+        (λ () → raise Empty)
+    with Empty -> error NoValue
   in
   return { Foo bar = bar; }
 ```


### PR DESCRIPTION
- Clearly distinguish Exceptions from Errors. The only catchable exception
 available in our AST is `EmptyError`, so the corresponding nodes are made less
 generic, and a node `FatalError` is added

- Runtime errors are defined as a specific type in the OCaml runtime, with a
 carrier exception and printing functions. These are used throughout, and
 consistently by the interpreter. They always carry a position, that can be
 converted to be printed with the fancy compiler location printer, or in a
 simpler way from the backends.

- All operators that might be subject to an error take a position as argument,
 in order to print an informative message without relying on backtraces from
 the backend


BONUS: this PR also includes a tweak to have message adapt to the terminal
width, and fixes to the cheat-sheets.