### PR TITLE
Unify traces between interpreter and runtime

### DIFF
--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -60,7 +60,7 @@ let rec format_runtime_value lang ppf = function
          ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
          (format_runtime_value lang))
       (Array.to_list elts)
-  | Runtime.Unembeddable -> Format.pp_print_string ppf "<?>"
+  | Runtime.Unembeddable -> Format.pp_print_string ppf "<object>"
 
 let print_log lang entry =
   let pp_infos =

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -79,7 +79,7 @@ let raise_parser_error
         | None -> "Error token", error_loc
         | Some last_good_loc -> "Last good token", last_good_loc);
       ]
-    "Syntax error at %a@\n%t"
+    "@[<hov>Syntax error at %a:@ %t@]"
     (fun ppf string -> Format.fprintf ppf "@{<yellow>\"%s\"@}" string)
     token msg
 
@@ -131,10 +131,11 @@ module ParserAux (LocalisedLexer : Lexer_common.LocalisedLexer) = struct
       (match Parser_errors.message (state env) with
       | exception Not_found -> Format.fprintf ppf "@{<yellow>unexpected token@}"
       | msg ->
-        Format.fprintf ppf "@{<yellow>@<1>»@} @[<hov>%a@]" Format.pp_print_text
+        Format.fprintf ppf "@{<yellow>@<1>%s@} @[<hov>%a@]" "»"
+          Format.pp_print_text
           (String.trim (String.uncapitalize_ascii msg)));
       if acceptable_tokens <> [] then
-        Format.fprintf ppf "@,@[<hov>Those are valid at this point:@ %a@]"
+        Format.fprintf ppf "@\n@[<hov>Those are valid at this point:@ %a@]"
           (Format.pp_print_list
              ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
              (fun ppf string -> Format.fprintf ppf "@{<yellow>\"%s\"@}" string))

--- a/tests/default/bad/typing_or_logical_error.catala_en
+++ b/tests/default/bad/typing_or_logical_error.catala_en
@@ -13,7 +13,7 @@ scope A:
 $ catala test-scope A
 ┌─[ERROR]─
 │
-│  Syntax error at "="
+│  Syntax error at "=":
 │  » expected 'under condition' followed by a condition, 'equals' followed by
 │    the definition body, or the rest of the variable qualified name
 │  Those are valid at this point: "of", "state", "equals", "under condition",

--- a/tests/scope/good/scope_call3.catala_en
+++ b/tests/scope/good/scope_call3.catala_en
@@ -44,7 +44,7 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
 [DEBUG] Starting interpretation...
-[LOG] ≔  HousingComputation.f: <?>
+[LOG] ≔  HousingComputation.f: <object>
 [LOG] ☛ Definition applied:
       ─➤ tests/scope/good/scope_call3.catala_en:8.14-8.20:
         │
@@ -59,14 +59,15 @@ $ catala Interpret -t -s HousingComputation --debug
           │              ‾
 [LOG]   →  RentComputation.direct
 [LOG]     ≔  RentComputation.direct.input: RentComputation_in {  }
-[LOG]     ≔  RentComputation.g: <?>
-[LOG]     ≔  RentComputation.f: <?>
+[LOG]     ≔  RentComputation.g: <object>
+[LOG]     ≔  RentComputation.f: <object>
 [LOG]     ☛ Definition applied:
           ─➤ tests/scope/good/scope_call3.catala_en:7.29-7.54:
             │
           7 │   definition f of x equals (output of RentComputation).f of x
             │                             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-[LOG]     ≔  RentComputation.direct.output: RentComputation { -- f: <?> }
+[LOG]     ≔  RentComputation.direct.
+  output: RentComputation { -- f: <object> }
 [LOG]   ←  RentComputation.direct
 [LOG]   →  RentComputation.f
 [LOG]     ≔  RentComputation.f.input0: 1

--- a/tests/scope/good/scope_call3.catala_en
+++ b/tests/scope/good/scope_call3.catala_en
@@ -44,7 +44,7 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
 [DEBUG] Starting interpretation...
-[LOG] ≔  HousingComputation.f: λ (x_67: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨(let result_68 : RentComputation = (#{→ RentComputation.direct} (λ (RentComputation_in_69: RentComputation_in) → let g_70 : integer → integer = #{≔ RentComputation.g} (λ (x1_71: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨x1_71 +! 1⟩⟩ | false ⊢ ∅ ⟩) in let f_72 : integer → integer = #{≔ RentComputation.f} (λ (x1_73: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨#{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} g_70) #{≔ RentComputation.g.input0} (x1_73 +! 1)⟩⟩ | false ⊢ ∅ ⟩) in { RentComputation f = f_72; })) #{≔ RentComputation.direct.input} {RentComputation_in} in let result1_74 : RentComputation = { RentComputation f = λ (param0_75: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} result_68.f) #{≔ RentComputation.f.input0} param0_75; } in #{← RentComputation.direct} #{≔ RentComputation.direct.output} if #{☛ RentComputation.direct.output} true then result1_74 else result1_74).f x_67⟩⟩ | false ⊢ ∅ ⟩
+[LOG] ≔  HousingComputation.f: <?>
 [LOG] ☛ Definition applied:
       ─➤ tests/scope/good/scope_call3.catala_en:8.14-8.20:
         │
@@ -58,15 +58,15 @@ $ catala Interpret -t -s HousingComputation --debug
         7 │   definition f of x equals (output of RentComputation).f of x
           │              ‾
 [LOG]   →  RentComputation.direct
-[LOG]     ≔  RentComputation.direct.input: {RentComputation_in}
-[LOG]     ≔  RentComputation.g: λ (x_76: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨x_76 +! 1⟩⟩ | false ⊢ ∅ ⟩
-[LOG]     ≔  RentComputation.f: λ (x_77: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨#{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_78: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨x1_78 +! 1⟩⟩ | false ⊢ ∅ ⟩)) #{≔ RentComputation.g.input0} (x_77 +! 1)⟩⟩ | false ⊢ ∅ ⟩
+[LOG]     ≔  RentComputation.direct.input: RentComputation_in {  }
+[LOG]     ≔  RentComputation.g: <?>
+[LOG]     ≔  RentComputation.f: <?>
 [LOG]     ☛ Definition applied:
           ─➤ tests/scope/good/scope_call3.catala_en:7.29-7.54:
             │
           7 │   definition f of x equals (output of RentComputation).f of x
             │                             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-[LOG]     ≔  RentComputation.direct.output: { RentComputation f = λ (param0_79: integer) → #{← RentComputation.f} #{≔ RentComputation.f.output} (#{→ RentComputation.f} { RentComputation f = λ (x_80: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨#{← RentComputation.g} #{≔ RentComputation.g.output} (#{→ RentComputation.g} (λ (x1_81: integer) → error_empty ⟨ ⟨#{☛ } true ⊢ ⟨x1_81 +! 1⟩⟩ | false ⊢ ∅ ⟩)) #{≔ RentComputation.g.input0} (x_80 +! 1)⟩⟩ | false ⊢ ∅ ⟩; }.f) #{≔ RentComputation.f.input0} param0_79; }
+[LOG]     ≔  RentComputation.direct.output: RentComputation { -- f: <?> }
 [LOG]   ←  RentComputation.direct
 [LOG]   →  RentComputation.f
 [LOG]     ≔  RentComputation.f.input0: 1


### PR DESCRIPTION
This is a first step into unifying trace handling. This patch only affects the interpreter, by delegating trace recording to the already existing runtime functions.

At end of interpretation, it recovers the registered trace from the runtime, and prints it.

NOTE: there are some limitations due to this approach, as runtime values going through this interface have to be converted to the "runtime embedded" type. In particular, functions can no longer be printed (which makes full sense if we want it to happen in the same way in compiled code) ; some information, like types, is lost, but it didn't appear to be used.

Also, a specific printer had to be added for runtime values (but it's very simple so that shouldn't be a problem).

@denismerigoux I'd like your input on how well this goes for your use-cases.

Further work should probably be cleanup and unification of the runtime logging interfaces ; there is already code for re-structuring the traces, printing to JSON, etc. which could be common to runtime and interpreter.