### PR TITLE
Fix lexing of verbatim blocks

### DIFF
--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -42,7 +42,7 @@ let get_law_heading (lexbuf : lexbuf) : token =
   let precedence = calc_precedence (String.trim (R.get_substring rex 1)) in
   LAW_HEADING (title, article_id, is_archive, precedence)
 
-type lexing_context = Law | Code | Directive | Directive_args
+type lexing_context = Law | Raw | Code | Directive | Directive_args
 
 (** Boolean reference, used by the lexer as the mutable state to distinguish
     whether it is lexing code or law. *)

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -17,7 +17,7 @@
 
 (** Auxiliary functions used by all lexers. *)
 
-type lexing_context = Law | Code | Directive | Directive_args
+type lexing_context = Law | Raw | Code | Directive | Directive_args
 
 val context : lexing_context ref
 (** Reference, used by the lexer as the mutable state to distinguish whether it


### PR DESCRIPTION
Catala doesn't interpret them at all, but it needs to refrain from interpreting its contents as markdown (titles, etc.)