### PR TITLE
Update opam dependencies

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install LaTeX deps
         # This is done late because caching would not benefit compared to
         # installation through apk (1,5G upload is slow)
-        run: sudo apk add texlive-xetex texmf-dist-latexextra texmf-dist-pictures font-dejavu groff
+        run: sudo apk add texlive-xetex texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures font-dejavu groff
       - name: Build Catala extra docs
         run: |
           cd ~/catala

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: setup an opam switch with all dependencies installed
 #
 # (only depends on the opam files)
-FROM ocamlpro/ocaml:4.14-2024-01-14 AS dev-build-context
+FROM ocamlpro/ocaml:4.14-2024-05-26 AS dev-build-context
 # Image from https://hub.docker.com/r/ocamlpro/ocaml
 
 RUN mkdir catala
@@ -24,10 +24,6 @@ RUN opam --cli=2.1 switch create catala ocaml-system && \
     opam clean
 # Note: just `opam switch create . --deps-only --with-test --with-doc && opam clean`
 # should be enough once opam 2.2 is released (see opam#5185)
-
-# This is temporary, to avoid pulling in a dependency to Str, until it's merged
-# and release into dates_calc
-RUN opam --cli=2.1 pin dates_calc.0.0.5 git+https://github.com/AltGr/dates-calc#nostr
 
 #
 # STAGE 2: get the whole repo and build

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,13 @@ prepare-install:
 	dune build @install --promote-install-files
 
 install: prepare-install
-	if [ x$$($(OPAM) --version) = "x2.1.5" ]; then \
-	  $(OPAM) install . --working-dir; \
-	else \
-	  $(OPAM) install . --working-dir --assume-built; \
-	fi
+	case x$$($(OPAM) --version) in \
+	  x2.1.5|x2.1.6) $(OPAM) install . --working-dir;; \
+	  *) $(OPAM) install . --working-dir --assume-built;; \
+	esac
 # `dune install` would work, but does a dirty install to the opam prefix without
 # registering with opam.
-# --assume-built is broken in 2.1.5
+# --assume-built is broken in 2.1.5 and 2.1.6
 
 inst: prepare-install
 	@opam custom-install \

--- a/build_system/clerk_report.mli
+++ b/build_system/clerk_report.mli
@@ -43,6 +43,6 @@ val set_display_flags :
   ?files:[ `All | `Failed | `None ] ->
   ?tests:[ `All | `FailedFile | `Failed | `None ] ->
   ?diffs:bool ->
-  ?use_patdiff:bool ->
+  ?diff_command:string option option ->
   unit ->
   unit

--- a/catala.opam
+++ b/catala.opam
@@ -22,7 +22,7 @@ depends: [
   "bindlib" {>= "6.0"}
   "cmdliner" {>= "1.1.0"}
   "cppo" {>= "1"}
-  "dates_calc" {>= "0.0.4"}
+  "dates_calc" {>= "0.0.6"}
   "dune" {>= "3.11"}
   "js_of_ocaml-ppx" {= "4.1.0"}
   "menhir" {>= "20200211"}
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {!= "1.9.5"}
   "ocamlgraph" {>= "1.8.8"}
   "re" {>= "1.10"}
-  "sedlex" {>= "2.4"}
+  "sedlex" {>= "3.1"}
   "uutf" {>= "1.0.3"}
   "ubase" {>= "0.05"}
   "unionFind" {>= "20220109"}

--- a/catala.opam
+++ b/catala.opam
@@ -47,7 +47,6 @@ depends: [
   "conf-npm" {cataladevmode}
   "conf-python-3-dev" {cataladevmode}
   "cpdf" {cataladevmode}
-  "conf-diffutils" {cataladevmode}
   "conf-pandoc" {cataladevmode}
   "z3" {catalaz3mode}
   "conf-ninja"

--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -778,9 +778,6 @@ let lex_raw (lexbuf : lexbuf) : token =
     | _ -> (
         (* Nested match for lower priority; `_` matches length 0 so we effectively retry the
            sub-match at the same point *)
-        let lexbuf = lexbuf in
-        (* workaround sedlex bug, see https://github.com/ocaml-community/sedlex/issues/12
-           (fixed in 3.1) *)
         match%sedlex lexbuf with
         | Star (Compl '\n'), ('\n' | eof) -> LAW_TEXT (Utf8.lexeme lexbuf)
         | _ -> L.raise_lexer_error (Pos.from_lpos prev_pos) prev_lexeme)
@@ -817,9 +814,6 @@ let lex_law (lexbuf : lexbuf) : token =
     | _ -> (
         (* Nested match for lower priority; `_` matches length 0 so we effectively retry the
            sub-match at the same point *)
-        let lexbuf = lexbuf in
-        (* workaround sedlex bug, see https://github.com/ocaml-community/sedlex/issues/12
-           (fixed in 3.1) *)
         match%sedlex lexbuf with
         | Star (Compl '\n'), ('\n' | eof) -> LAW_TEXT (Utf8.lexeme lexbuf)
         | _ -> L.raise_lexer_error (Pos.from_lpos prev_pos) prev_lexeme)

--- a/runtimes/python/pyproject.toml
+++ b/runtimes/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "catala-runtime"
 description = "Runtime libraries needed to execute Catala programs compiled to Python"
 version = "0.10.0"
 dependencies = [
-  "gmpy2",
+  "gmpy2 ~= 2.2.0rc1",
   "typing",
   "mypy",
   "python-dateutil",

--- a/tests/literate/good/test_grave_char_en.catala_en
+++ b/tests/literate/good/test_grave_char_en.catala_en
@@ -1,6 +1,6 @@
 > Module Test_grave_char_en
 
-## Law text should be able to contain grave accent '`'.
+## Law text should be able to contain backquote chars `` ` ``.
 
 This is a block of law text containing `.
 This allows to:
@@ -60,7 +60,8 @@ $ catala latex
 
 \textbf{This defines the catala module \texttt{Test\_grave\_char\_en}}
 
-\subsection{Law text should be able to contain grave accent ``'.}
+\subsection{Law text should be able to contain backquote chars
+\texttt{\textasciigrave{}}.}
 
 This is a block of law text containing `. This allows to:
 


### PR DESCRIPTION
- The newer sedlex version allows us to remove a weird workaround (https://github.com/ocaml-community/sedlex/issues/12)
- dates_calc 0.0.6 is required (no dependency on `Str`) so we can remove specific pinning from the CI

This is stalled at the moment though because of Alpine 3.20 and Python stuff