### PR TITLE
Fix error message typo

### DIFF
--- a/compiler/desugared/linting.ml
+++ b/compiler/desugared/linting.ml
@@ -268,8 +268,8 @@ let detect_dead_code (p : program) : unit =
       let emit_unused_warning vx =
         Message.warning
           ~pos:(Mark.get (Dependency.Vertex.info vx))
-          "Unused varible:@ %a@ does@ not@ contribute@ to@ computing@ any@ of@ \
-           scope@ %a@ outputs.@ Did you forget something?"
+          "Unused variable:@ %a@ does@ not@ contribute@ to@ computing@ any@ \
+           of@ scope@ %a@ outputs.@ Did you forget something?"
           Dependency.Vertex.format vx ScopeName.format scope_name
       in
       Dependency.ScopeDependencies.iter_vertex

--- a/tests/func/good/context_func.catala_en
+++ b/tests/func/good/context_func.catala_en
@@ -21,8 +21,8 @@ scope B:
 $ catala Typecheck --check-invariants
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope B outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope B
+│  outputs. Did you forget something?
 │
 ├─➤ tests/func/good/context_func.catala_en:9.3-9.4:
 │   │
@@ -41,8 +41,8 @@ $ catala Typecheck --check-invariants
 $ catala Scopelang -s B
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope B outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope B
+│  outputs. Did you forget something?
 │
 ├─➤ tests/func/good/context_func.catala_en:9.3-9.4:
 │   │
@@ -58,8 +58,8 @@ let scope B (b: bool|input) (a: A {f: integer → integer}|internal) =
 $ catala Dcalc -s A
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope B outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope B
+│  outputs. Did you forget something?
 │
 ├─➤ tests/func/good/context_func.catala_en:9.3-9.4:
 │   │
@@ -83,8 +83,8 @@ let scope A
 $ catala Dcalc -s B
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope B outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope B
+│  outputs. Did you forget something?
 │
 ├─➤ tests/func/good/context_func.catala_en:9.3-9.4:
 │   │

--- a/tests/name_resolution/good/let_in.catala_en
+++ b/tests/name_resolution/good/let_in.catala_en
@@ -62,7 +62,7 @@ scope S2:
 $ catala test-scope S2
 ┌─[WARNING]─
 │
-│  Unused varible: x does not contribute to computing any of scope S2
+│  Unused variable: x does not contribute to computing any of scope S2
 │  outputs. Did you forget something?
 │
 ├─➤ tests/name_resolution/good/let_in.catala_en:52.4-52.5:

--- a/tests/scope/good/local-capture-subscope.catala_en
+++ b/tests/scope/good/local-capture-subscope.catala_en
@@ -22,8 +22,8 @@ scope S:
 $ catala test-scope S
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope S outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope S
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/local-capture-subscope.catala_en:7.3-7.4:
 │   │

--- a/tests/scope/good/scope_call2.catala_en
+++ b/tests/scope/good/scope_call2.catala_en
@@ -24,7 +24,7 @@ scope Titi:
 $ catala Typecheck --check-invariants
 ┌─[WARNING]─
 │
-│  Unused varible: toto does not contribute to computing any of scope Titi
+│  Unused variable: toto does not contribute to computing any of scope Titi
 │  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/scope_call2.catala_en:13.3-13.7:
@@ -44,7 +44,7 @@ $ catala Typecheck --check-invariants
 $ catala test-scope Titi
 ┌─[WARNING]─
 │
-│  Unused varible: toto does not contribute to computing any of scope Titi
+│  Unused variable: toto does not contribute to computing any of scope Titi
 │  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/scope_call2.catala_en:13.3-13.7:

--- a/tests/scope/good/sub_sub_scope.catala_en
+++ b/tests/scope/good/sub_sub_scope.catala_en
@@ -36,8 +36,8 @@ scope C:
 $ catala Typecheck --check-invariants
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 │    │
@@ -46,8 +46,8 @@ $ catala Typecheck --check-invariants
 └─ Article
 ┌─[WARNING]─
 │
-│  Unused varible: b does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: b does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 │    │
@@ -66,8 +66,8 @@ $ catala Typecheck --check-invariants
 $ catala test-scope A
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 │    │
@@ -76,8 +76,8 @@ $ catala test-scope A
 └─ Article
 ┌─[WARNING]─
 │
-│  Unused varible: b does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: b does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 │    │
@@ -94,8 +94,8 @@ $ catala test-scope A
 $ catala test-scope B
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 │    │
@@ -104,8 +104,8 @@ $ catala test-scope B
 └─ Article
 ┌─[WARNING]─
 │
-│  Unused varible: b does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: b does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 │    │
@@ -121,8 +121,8 @@ $ catala test-scope B
 $ catala test-scope C
 ┌─[WARNING]─
 │
-│  Unused varible: a does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: a does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:14.3-14.4:
 │    │
@@ -131,8 +131,8 @@ $ catala test-scope C
 └─ Article
 ┌─[WARNING]─
 │
-│  Unused varible: b does not contribute to computing any of scope C outputs.
-│  Did you forget something?
+│  Unused variable: b does not contribute to computing any of scope C
+│  outputs. Did you forget something?
 │
 ├─➤ tests/scope/good/sub_sub_scope.catala_en:15.3-15.4:
 │    │

--- a/tests/typing/good/common.catala_en
+++ b/tests/typing/good/common.catala_en
@@ -41,8 +41,8 @@ $ catala Typecheck --check-invariants
 └─
 ┌─[WARNING]─
 │
-│  Unused varible: x does not contribute to computing any of scope S outputs.
-│  Did you forget something?
+│  Unused variable: x does not contribute to computing any of scope S
+│  outputs. Did you forget something?
 │
 ├─➤ tests/typing/good/common.catala_en:12.9-12.10:
 │    │


### PR DESCRIPTION
Fix a small typo in error messages, i.e., `s/varible/variable/`