### PR TITLE
Multiple parsing errors reporting

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -413,7 +413,7 @@ let delayed_error x =
   make ~level:Error ~cont:(fun m _ ->
       match !global_errors with
       | None ->
-        failwith
+        error ~internal:true
           "delayed error called outside scope: encapsulate using \
            'with_delayed_errors' first"
       | Some l ->
@@ -423,10 +423,13 @@ let delayed_error x =
 let with_delayed_errors (f : unit -> 'a) : 'a =
   (match !global_errors with
   | None -> global_errors := Some []
-  | Some _ -> failwith "delayed error scope already initialized");
+  | Some _ ->
+    error ~internal:true
+      "delayed error called outside scope: encapsulate using \
+       'with_delayed_errors' first");
   let r = f () in
   match !global_errors with
-  | None -> assert false
+  | None -> error ~internal:true "intertwined delayed error scope"
   | Some [] ->
     global_errors := None;
     r

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -60,9 +60,10 @@ end
 (** This functions emits the message according to the emission type defined by
     [Cli.message_format_flag]. *)
 
-(** {1 Error exception} *)
+(** {1 Error exceptions} *)
 
 exception CompilerError of Content.t
+exception CompilerErrors of Content.t list
 
 (** {1 Some formatting helpers}*)
 
@@ -98,5 +99,15 @@ val log : ('a, unit) emitter
 val debug : ('a, unit) emitter
 val result : ('a, unit) emitter
 val warning : ('a, unit) emitter
-val error : ('a, 'b) emitter
+val error : ('a, 'exn) emitter
 val results : Content.message list -> unit
+
+(** Multiple errors *)
+
+val with_delayed_errors : (unit -> 'a) -> 'a
+(** [with_delayed_errors f] calls [f] and registers each error triggered using
+    [delayed_error].
+
+    @raise CompilerErrors when delayed errors were registered. *)
+
+val delayed_error : 'b -> ('a, 'b) emitter

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1204,6 +1204,11 @@ let main () =
     Message.Content.emit content Error;
     if Global.options.debug then Printexc.print_raw_backtrace stderr bt;
     exit Cmd.Exit.some_error
+  | exception Message.CompilerErrors contents ->
+    let bt = Printexc.get_raw_backtrace () in
+    List.iter (fun c -> Message.Content.emit c Error) contents;
+    if Global.options.debug then Printexc.print_raw_backtrace stderr bt;
+    exit Cmd.Exit.some_error
   | exception Failure msg ->
     let bt = Printexc.get_raw_backtrace () in
     Message.Content.emit (Message.Content.of_string msg) Error;

--- a/tests/default/bad/typing_or_logical_error.catala_en
+++ b/tests/default/bad/typing_or_logical_error.catala_en
@@ -16,14 +16,13 @@ $ catala test-scope A
 │  Syntax error at "=":
 │  » expected 'under condition' followed by a condition, 'equals' followed by
 │    the definition body, or the rest of the variable qualified name
-│  Those are valid at this point: "of", "state", "equals", "under condition",
-│  "."
+│  Those are valid at this point: ".", "under condition", "equals", "state",
+│  "of"
 │
-│ Last good token
-├─➤ tests/default/bad/typing_or_logical_error.catala_en:8.13-8.29:
+├─➤ tests/default/bad/typing_or_logical_error.catala_en:8.30-8.31:
 │   │
 │ 8 │  definition wrong_definition = 1
-│   │             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+│   │                              ‾
 │
 │ Maybe you wanted to write : "." ?
 └─

--- a/tests/parsing/bad/multiple_errors.catala_en
+++ b/tests/parsing/bad/multiple_errors.catala_en
@@ -1,0 +1,51 @@
+## Multiple parsing errors
+
+```catala
+declaration scope A:
+  output i content decimal
+
+declaration scope B:
+  internal x content integer
+  output i content money
+
+scope A:
+  definitoin i equals 3.
+
+scope B:
+  definition x equals 4
+  definition i equal money of (decimal of x)
+```
+
+```catala-test-inline
+$ catala test-scope A
+┌─[ERROR]─
+│
+│  Syntax error at "definitoin":
+│  » expected a scope use item: a rule, definition or assertion
+│  Those are valid at this point: "definition", "rule", "assertion",
+│  "exception", "label", "date"
+│
+├─➤ tests/parsing/bad/multiple_errors.catala_en:12.3-12.13:
+│    │
+│ 12 │   definitoin i equals 3.
+│    │   ‾‾‾‾‾‾‾‾‾‾
+│
+│ Maybe you wanted to write : "definition" ?
+└─
+┌─[ERROR]─
+│
+│  Syntax error at "equal":
+│  » expected 'under condition' followed by a condition, 'equals' followed by
+│    the definition body, or the rest of the variable qualified name
+│  Those are valid at this point: "equals", ".", "under condition", "state",
+│  "of"
+│
+├─➤ tests/parsing/bad/multiple_errors.catala_en:16.16-16.21:
+│    │
+│ 16 │   definition i equal money of (decimal of x)
+│    │                ‾‾‾‾‾
+│
+│ Maybe you wanted to write : "equals" ?
+└─
+#return code 123#
+```

--- a/tests/parsing/bad/single_error.catala_en
+++ b/tests/parsing/bad/single_error.catala_en
@@ -1,0 +1,27 @@
+## Single parsing error
+
+```catala
+declaration scope A:
+  output i contents decimal
+
+scope A:
+  definition i equals 1 / 0
+```
+
+```catala-test-inline
+$ catala test-scope A
+┌─[ERROR]─
+│
+│  Syntax error at "contents":
+│  unexpected token
+│  Those are valid at this point: "content", "condition", "scope"
+│
+├─➤ tests/parsing/bad/single_error.catala_en:5.12-5.20:
+│   │
+│ 5 │   output i contents decimal
+│   │            ‾‾‾‾‾‾‾‾
+│
+│ Maybe you wanted to write : "content" ?
+└─
+#return code 123#
+```


### PR DESCRIPTION
This PR is a partial attempt at fixing #250. 

We first focus on the surface parsing in order to display possible multiple parsing errors.
In its current state, the (very) naive heuristic used is that when encountering a unexpected token, the parser registers the error, replaces the faulty token by guessing a "candidate-token" that would either be syntactically close to the original input or to pick a random valid token among the expected ones. 

This approach may yield confusing errors in particular when the selected candidates are contextually bad.

We will need to further discuss which strategies to implement as the state of the art on this topic is broad.

**EDIT**

I went for a heuristic that, when an unexpected token is encountered, first checks whether the parser could continue without this faulty token and also checks with possible candidates tokens. Then, it chooses the best strategy, i.e., the token which allowed the parser to progress the furthest, records the error, and resumes the parsing applying this strategy on the eventual conflicts.

This approach seems to yield reasonable results on the invalid set of programs I crafted. This may require a bit more testing and fine-tuning.

~~I'm still struggling to find a clean way to combine error messages but perhaps this can be done afterwards.~~
Thanks to @AltGr suggestions, the changes required to adapt to the error messaging are now reasonable.