### PR TITLE
Multiple typing errors reporting

### DIFF
--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -199,6 +199,12 @@ module Flags = struct
             "Behave as if run from the given directory for file and error \
              reporting. Does not affect resolution of files in arguments."
 
+    let stop_on_error =
+      value
+      & flag
+      & info ["x"; "stop-on-error"]
+          ~doc:"Stops the compilation as soon as an error is encountered."
+
     let flags =
       let make
           language
@@ -209,7 +215,8 @@ module Flags = struct
           plugins_dirs
           disable_warnings
           max_prec_digits
-          directory : options =
+          directory
+          stop_on_error : options =
         if debug then Printexc.record_backtrace true;
         let path_rewrite =
           match directory with
@@ -223,7 +230,8 @@ module Flags = struct
         (* This sets some global refs for convenience, but most importantly
            returns the options record. *)
         Global.enforce_options ~language ~debug ~color ~message_format ~trace
-          ~plugins_dirs ~disable_warnings ~max_prec_digits ~path_rewrite ()
+          ~plugins_dirs ~disable_warnings ~max_prec_digits ~path_rewrite
+          ~stop_on_error ()
       in
       Term.(
         const make
@@ -235,7 +243,8 @@ module Flags = struct
         $ plugins_dirs
         $ disable_warnings
         $ max_prec_digits
-        $ directory)
+        $ directory
+        $ stop_on_error)
 
     let options =
       let make input_src name directory options : options =

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -37,6 +37,7 @@ type options = {
   mutable disable_warnings : bool;
   mutable max_prec_digits : int;
   mutable path_rewrite : raw_file -> file;
+  mutable stop_on_error : bool;
 }
 
 (* Note: we force that the global options (ie options common to all commands)
@@ -56,6 +57,7 @@ let options =
     disable_warnings = false;
     max_prec_digits = 20;
     path_rewrite = (fun _ -> assert false);
+    stop_on_error = false;
   }
 
 let enforce_options
@@ -69,6 +71,7 @@ let enforce_options
     ?disable_warnings
     ?max_prec_digits
     ?path_rewrite
+    ?stop_on_error
     () =
   Option.iter (fun x -> options.input_src <- x) input_src;
   Option.iter (fun x -> options.language <- x) language;
@@ -80,6 +83,7 @@ let enforce_options
   Option.iter (fun x -> options.disable_warnings <- x) disable_warnings;
   Option.iter (fun x -> options.max_prec_digits <- x) max_prec_digits;
   Option.iter (fun x -> options.path_rewrite <- x) path_rewrite;
+  Option.iter (fun x -> options.stop_on_error <- x) stop_on_error;
   options
 
 let input_src_file = function FileName f | Contents (_, f) | Stdin f -> f

--- a/compiler/catala_utils/global.mli
+++ b/compiler/catala_utils/global.mli
@@ -56,6 +56,7 @@ type options = private {
   mutable disable_warnings : bool;
   mutable max_prec_digits : int;
   mutable path_rewrite : raw_file -> file;
+  mutable stop_on_error : bool;
 }
 (** Global options, common to all subcommands (note: the fields are internally
     mutable only for purposes of the [globals] toplevel value defined below) *)
@@ -76,6 +77,7 @@ val enforce_options :
   ?disable_warnings:bool ->
   ?max_prec_digits:int ->
   ?path_rewrite:(raw_file -> file) ->
+  ?stop_on_error:bool ->
   unit ->
   options
 (** Sets up the global options (side-effect); for specific use-cases only, this

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -104,10 +104,13 @@ val results : Content.message list -> unit
 
 (** Multiple errors *)
 
-val with_delayed_errors : (unit -> 'a) -> 'a
-(** [with_delayed_errors f] calls [f] and registers each error triggered using
-    [delayed_error].
+val with_delayed_errors : ?stop_on_error:bool -> (unit -> 'a) -> 'a
+(** [with_delayed_errors ?stop_on_error f] calls [f] and registers each error
+    triggered using [delayed_error]. [stop_on_error] defaults to
+    [Global.options.stop_on_error].
 
-    @raise CompilerErrors when delayed errors were registered. *)
+    @raise CompilerErrors when delayed errors were registered.
+    @raise CompilerError
+      on the first error encountered when the [stop_on_error] flag is set. *)
 
 val delayed_error : 'b -> ('a, 'b) emitter

--- a/compiler/desugared/disambiguate.ml
+++ b/compiler/desugared/disambiguate.ml
@@ -112,3 +112,5 @@ let program prg =
     ScopeName.Map.map (scope prg.program_ctx env) prg.program_root.module_scopes
   in
   { prg with program_root = { module_topdefs; module_scopes } }
+
+let program prg = Message.with_delayed_errors (fun () -> program prg)

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -145,3 +145,5 @@ let type_program (type m) (prg : m program) : typed program =
       prg.program_scopes
   in
   { prg with program_topdefs; program_scopes }
+
+let type_program prg = Message.with_delayed_errors (fun () -> type_program prg)

--- a/tests/bool/bad/test_xor_with_int.catala_en
+++ b/tests/bool/bad/test_xor_with_int.catala_en
@@ -29,5 +29,24 @@ $ catala Typecheck
 │ 8 │   definition test_var equals 10 xor 20
 │   │                                 ‾‾‾
 └─ 'xor' should be a boolean operator
+┌─[ERROR]─
+│
+│  Error during typechecking, incompatible types:
+│  ─➤ integer
+│  ─➤ bool
+│
+│ This expression has type integer:
+├─➤ tests/bool/bad/test_xor_with_int.catala_en:8.37-8.39:
+│   │
+│ 8 │   definition test_var equals 10 xor 20
+│   │                                     ‾‾
+├─ 'xor' should be a boolean operator
+│
+│ Expected type bool coming from expression:
+├─➤ tests/bool/bad/test_xor_with_int.catala_en:8.33-8.36:
+│   │
+│ 8 │   definition test_var equals 10 xor 20
+│   │                                 ‾‾‾
+└─ 'xor' should be a boolean operator
 #return code 123#
 ```

--- a/tests/typing/bad/err2.catala_en
+++ b/tests/typing/bad/err2.catala_en
@@ -16,7 +16,7 @@ $ catala Typecheck
 │
 │  Error during typechecking, incompatible types:
 │  ─➤ decimal
-│  ─➤ list
+│  ─➤ list of any
 │
 │ This expression has type decimal:
 ├─➤ tests/typing/bad/err2.catala_en:10.39-10.42:
@@ -24,7 +24,7 @@ $ catala Typecheck
 │ 10 │   definition a equals number of (z ++ 1.1) / 2
 │    │                                       ‾‾‾
 │
-│ Expected type list coming from expression:
+│ Expected type list of any coming from expression:
 ├─➤ tests/typing/bad/err2.catala_en:10.36-10.38:
 │    │
 │ 10 │   definition a equals number of (z ++ 1.1) / 2

--- a/tests/typing/bad/mult_errs1.catala_en
+++ b/tests/typing/bad/mult_errs1.catala_en
@@ -1,0 +1,52 @@
+> Include: common.catala_en
+
+```catala
+scope S:
+  definition z equals [
+    Structure { -- i: 3.4 -- e: Int content x };
+    Structure { -- i: 4.1 -- e: y };
+    Structure { -- i: 5 -- e: Dat content |1970-01-01| }
+  ]
+  definition a equals number of (z ++ z) / 2
+```
+
+```catala-test-inline
+$ catala Typecheck
+┌─[ERROR]─
+│
+│  Error during typechecking, incompatible types:
+│  ─➤ decimal
+│  ─➤ integer
+│
+│ This expression has type decimal:
+├─➤ tests/typing/bad/mult_errs1.catala_en:6.23-6.26:
+│   │
+│ 6 │     Structure { -- i: 3.4 -- e: Int content x };
+│   │                       ‾‾‾
+│
+│ Expected type integer coming from expression:
+├─➤ tests/typing/bad/common.catala_en:8.18-8.25:
+│   │
+│ 8 │   data i content integer
+│   │                  ‾‾‾‾‾‾‾
+└─
+┌─[ERROR]─
+│
+│  Error during typechecking, incompatible types:
+│  ─➤ decimal
+│  ─➤ integer
+│
+│ This expression has type decimal:
+├─➤ tests/typing/bad/mult_errs1.catala_en:7.23-7.26:
+│   │
+│ 7 │     Structure { -- i: 4.1 -- e: y };
+│   │                       ‾‾‾
+│
+│ Expected type integer coming from expression:
+├─➤ tests/typing/bad/common.catala_en:8.18-8.25:
+│   │
+│ 8 │   data i content integer
+│   │                  ‾‾‾‾‾‾‾
+└─
+#return code 123#
+```


### PR DESCRIPTION
Depends on  #630, do not merge before it lands.

This PR is a follow-up of #630 where we add multiple error reporting for typing errors.

While this PR is easier than the previous one, I did a small hack in order to fix the consistency of delayed error pretty-printing messages. Indeed, in order for the typing to progress and discover more errors, a faulty unification is performed which unifies incompatible types. The delayed look-up performed during the error pretty-printing would then display confusing error messages such as:
```
Error during typechecking, incompatible types:
─➤ integer
─➤ integer
```
which is not ideal. 
Thus, I decided transform union-find types in AST ones when registering the error to fix this behavior.