### PR TITLE
Add error messages numbering

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -326,14 +326,18 @@ module Content = struct
         ppf content;
       Format.pp_print_newline ppf ()
 
-  let emit_n (target : level) (contents : t list) : unit =
-    let len = List.length contents in
-    List.iteri
-      (fun i c ->
-        let extra_label = Printf.sprintf "(%d/%d)" (succ i) len in
-        let pp_marker ?extra_label:_ = pp_marker ~extra_label in
-        emit ~pp_marker c target)
-      contents
+  let emit_n (target : level) = function
+    | [content] -> emit content target
+    | contents ->
+      let ppf = get_ppf target in
+      let len = List.length contents in
+      List.iteri
+        (fun i c ->
+          if i > 0 then Format.pp_print_newline ppf ();
+          let extra_label = Printf.sprintf "(%d/%d)" (succ i) len in
+          let pp_marker ?extra_label:_ = pp_marker ~extra_label in
+          emit ~pp_marker c target)
+        contents
 
   let emit (content : t) (target : level) = emit content target
 end

--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -112,7 +112,7 @@ let print_time_marker =
     if delta > 50. then
       Format.fprintf ppf "@{<bold;black>[TIME] %.0fms@}@\n" delta
 
-let pp_marker target ppf =
+let pp_marker ?extra_label target ppf =
   let open Ocolor_types in
   let tags, str =
     match target with
@@ -121,6 +121,11 @@ let pp_marker target ppf =
     | Warning -> [Bold; Fg (C4 yellow)], "WARNING"
     | Result -> [Bold; Fg (C4 green)], "RESULT"
     | Log -> [Bold; Fg (C4 black)], "LOG"
+  in
+  let str =
+    match extra_label with
+    | None -> str
+    | Some lbl -> Printf.sprintf "%s %s" str lbl
   in
   if target = Debug then print_time_marker ppf ();
   Format.pp_open_stag ppf (Ocolor_format.Ocolor_styles_tag tags);
@@ -165,7 +170,7 @@ module Content = struct
   let of_string (s : string) : t =
     [MainMessage (fun ppf -> Format.pp_print_text ppf s)]
 
-  let basic_msg ppf target content =
+  let basic_msg ?(pp_marker = pp_marker) ppf target content =
     Format.pp_open_vbox ppf 0;
     Format.pp_print_list
       ~pp_sep:(fun ppf () -> Format.fprintf ppf "@,@,")
@@ -184,7 +189,7 @@ module Content = struct
     Format.pp_close_box ppf ();
     Format.pp_print_newline ppf ()
 
-  let fancy_msg ppf target content =
+  let fancy_msg ?(pp_marker = pp_marker) ppf target content =
     let ppf_out_fcts = Format.pp_get_formatter_out_functions ppf () in
     let restore_ppf () =
       Format.pp_print_flush ppf ();
@@ -269,13 +274,13 @@ module Content = struct
     restore_ppf ();
     Format.pp_print_newline ppf ()
 
-  let emit (content : t) (target : level) : unit =
+  let emit ?(pp_marker = pp_marker) (content : t) (target : level) : unit =
     match Global.options.message_format with
     | Global.Human -> (
       let ppf = get_ppf target in
       match target with
-      | Debug | Log -> basic_msg ppf target content
-      | Result | Warning | Error -> fancy_msg ppf target content)
+      | Debug | Log -> basic_msg ~pp_marker ppf target content
+      | Result | Warning | Error -> fancy_msg ~pp_marker ppf target content)
     | Global.GNU ->
       (* The top message doesn't come with a position, which is not something
          the GNU standard allows. So we look the position list and put the top
@@ -320,6 +325,17 @@ module Content = struct
           | None -> ())
         ppf content;
       Format.pp_print_newline ppf ()
+
+  let emit_n (target : level) (contents : t list) : unit =
+    let len = List.length contents in
+    List.iteri
+      (fun i c ->
+        let extra_label = Printf.sprintf "(%d/%d)" (succ i) len in
+        let pp_marker ?extra_label:_ = pp_marker ~extra_label in
+        emit ~pp_marker c target)
+      contents
+
+  let emit (content : t) (target : level) = emit content target
 end
 
 open Content
@@ -443,6 +459,9 @@ let with_delayed_errors
   | Some [] ->
     global_errors.errors <- None;
     r
+  | Some [err] ->
+    global_errors.errors <- None;
+    raise (CompilerError err)
   | Some errs ->
     global_errors.errors <- None;
     raise (CompilerErrors (List.rev errs))

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -55,6 +55,7 @@ module Content : sig
   (** {2 Content emission}*)
 
   val emit : t -> level -> unit
+  val emit_n : level -> t list -> unit
 end
 
 (** This functions emits the message according to the emission type defined by

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1206,7 +1206,7 @@ let main () =
     exit Cmd.Exit.some_error
   | exception Message.CompilerErrors contents ->
     let bt = Printexc.get_raw_backtrace () in
-    List.iter (fun c -> Message.Content.emit c Error) contents;
+    Message.Content.emit_n Error contents;
     if Global.options.debug then Printexc.print_raw_backtrace stderr bt;
     exit Cmd.Exit.some_error
   | exception Failure msg ->

--- a/tests/bool/bad/test_xor_with_int.catala_en
+++ b/tests/bool/bad/test_xor_with_int.catala_en
@@ -29,6 +29,7 @@ $ catala Typecheck
 │ 8 │   definition test_var equals 10 xor 20
 │   │                                 ‾‾‾
 └─ 'xor' should be a boolean operator
+
 ┌─[ERROR (2/2)]─
 │
 │  Error during typechecking, incompatible types:

--- a/tests/bool/bad/test_xor_with_int.catala_en
+++ b/tests/bool/bad/test_xor_with_int.catala_en
@@ -10,7 +10,7 @@ scope TestXorWithInt:
 
 ```catala-test-inline
 $ catala Typecheck
-┌─[ERROR]─
+┌─[ERROR (1/2)]─
 │
 │  Error during typechecking, incompatible types:
 │  ─➤ integer
@@ -29,7 +29,7 @@ $ catala Typecheck
 │ 8 │   definition test_var equals 10 xor 20
 │   │                                 ‾‾‾
 └─ 'xor' should be a boolean operator
-┌─[ERROR]─
+┌─[ERROR (2/2)]─
 │
 │  Error during typechecking, incompatible types:
 │  ─➤ integer

--- a/tests/parsing/bad/multiple_errors.catala_en
+++ b/tests/parsing/bad/multiple_errors.catala_en
@@ -32,6 +32,7 @@ $ catala test-scope A
 │
 │ Maybe you wanted to write : "definition" ?
 └─
+
 ┌─[ERROR (2/2)]─
 │
 │  Syntax error at "equal":

--- a/tests/parsing/bad/multiple_errors.catala_en
+++ b/tests/parsing/bad/multiple_errors.catala_en
@@ -18,7 +18,7 @@ scope B:
 
 ```catala-test-inline
 $ catala test-scope A
-┌─[ERROR]─
+┌─[ERROR (1/2)]─
 │
 │  Syntax error at "definitoin":
 │  » expected a scope use item: a rule, definition or assertion
@@ -32,7 +32,7 @@ $ catala test-scope A
 │
 │ Maybe you wanted to write : "definition" ?
 └─
-┌─[ERROR]─
+┌─[ERROR (2/2)]─
 │
 │  Syntax error at "equal":
 │  » expected 'under condition' followed by a condition, 'equals' followed by

--- a/tests/typing/bad/mult_errs1.catala_en
+++ b/tests/typing/bad/mult_errs1.catala_en
@@ -12,7 +12,7 @@ scope S:
 
 ```catala-test-inline
 $ catala Typecheck
-┌─[ERROR]─
+┌─[ERROR (1/2)]─
 │
 │  Error during typechecking, incompatible types:
 │  ─➤ decimal
@@ -30,7 +30,7 @@ $ catala Typecheck
 │ 8 │   data i content integer
 │   │                  ‾‾‾‾‾‾‾
 └─
-┌─[ERROR]─
+┌─[ERROR (2/2)]─
 │
 │  Error during typechecking, incompatible types:
 │  ─➤ decimal

--- a/tests/typing/bad/mult_errs1.catala_en
+++ b/tests/typing/bad/mult_errs1.catala_en
@@ -30,6 +30,7 @@ $ catala Typecheck
 │ 8 │   data i content integer
 │   │                  ‾‾‾‾‾‾‾
 └─
+
 ┌─[ERROR (2/2)]─
 │
 │  Error during typechecking, incompatible types:


### PR DESCRIPTION
This PR adds numbering to errors, e.g.,

![example](https://github.com/CatalaLang/catala/assets/2117049/ad3e0b3c-db24-4482-8e8f-917191f17405)
