### PR TITLE
Testing and debugging closure conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,8 @@ BRANCH = $(shell git branch --show-current 2>/dev/null || echo master)
 # its usage.
 local_tmp_clone = { \
   rm -rf $1.tmp && \
-  trap "rm -rf $1.tmp" EXIT && \
+  CLEANUP_TMP_GIT_CLONES="$${CLEANUP_TMP_GIT_CLONES}rm -rf $1.tmp; " && \
+  trap "$$CLEANUP_TMP_GIT_CLONES" EXIT && \
   git clone https://github.com/CatalaLang/$1 \
     --depth 1 --reference-if-able ../$1 \
     $1.tmp -b $(BRANCH) || \
@@ -336,8 +337,12 @@ alltest: dependencies-python
 	  bench_ocaml \
 	  bench_js \
 	  bench_python && \
-	printf "\n#             \e[42;30m[ ALL TESTS PASSED ]\e[m             \e[32m☺\e[m\n" || \
-	{ printf "\n#             \e[41;30m[   TESTS FAILED   ]\e[m             \e[31m☹\e[m\n" ; exit 1; }
+	printf "\n# Full Catala testsuite:\t\t\e[42;30m ALL TESTS PASSED \e[m\t\t\e[32m☺\e[m\n" || \
+	{ printf "\n# Full Catala testsuite:\t\t\e[41;30m   TESTS FAILED   \e[m\t\t\e[31m☹\e[m\n" ; exit 1; }
+
+#> alltest-					: Like 'alltest', but skips doc building and is much faster
+alltest-:
+	@$(MAKE) alltest NODOC=1
 
 #> clean					: Clean build artifacts
 clean:

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -488,7 +488,8 @@ let base_bindings catala_exe catala_flags build_dir include_dirs test_flags =
   let catala_flags_ocaml =
     List.filter
       (function
-        | "--avoid-exceptions" | "-O" | "--optimize" -> true | _ -> false)
+        | "--avoid-exceptions" | "-O" | "--optimize" | "--closure-conversion" ->
+          true | _ -> false)
       test_flags
   in
   let catala_flags_python =

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -489,7 +489,8 @@ let base_bindings catala_exe catala_flags build_dir include_dirs test_flags =
     List.filter
       (function
         | "--avoid-exceptions" | "-O" | "--optimize" | "--closure-conversion" ->
-          true | _ -> false)
+          true
+        | _ -> false)
       test_flags
   in
   let catala_flags_python =

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -124,9 +124,9 @@ let display ~build_dir file ppf t =
       (fun s -> if s = "--directory=" ^ build_dir then None else Some (pfile s))
       t.command_line
     |> (function
-        | catala :: cmd :: args ->
-          (catala :: cmd :: "-I" :: Filename.dirname file :: args)
-        | cl -> cl)
+         | catala :: cmd :: args ->
+           catala :: cmd :: "-I" :: Filename.dirname file :: args
+         | cl -> cl)
     |> function
     | catala :: cmd :: args
       when List.mem

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -111,17 +111,9 @@ let get_diff p1 p2 =
     File.process_out ~check_exit:(fun _ -> ()) cmd (args @ [f1; f2])
 
 let catala_commands_with_output_flag =
-  [
-    "makefile";
-    "html";
-    "latex";
-    "ocaml";
-    "python";
-    "r";
-    "c";
-  ]
+  ["makefile"; "html"; "latex"; "ocaml"; "python"; "r"; "c"]
 
-let display ~build_dir ppf t =
+let display ~build_dir file ppf t =
   let pfile f =
     f
     |> String.remove_prefix ~prefix:(build_dir ^ Filename.dir_sep)
@@ -131,6 +123,10 @@ let display ~build_dir ppf t =
     List.filter_map
       (fun s -> if s = "--directory=" ^ build_dir then None else Some (pfile s))
       t.command_line
+    |> (function
+        | catala :: cmd :: args ->
+          (catala :: cmd :: "-I" :: Filename.dirname file :: args)
+        | cl -> cl)
     |> function
     | catala :: cmd :: args
       when List.mem
@@ -176,7 +172,7 @@ let display_file ~build_dir ppf t =
     in
     Format.pp_print_break ppf 0 3;
     Format.pp_open_vbox ppf 0;
-    Format.pp_print_list (display ~build_dir) ppf tests;
+    Format.pp_print_list (display ~build_dir t.name) ppf tests;
     Format.pp_close_box ppf ()
   in
   if t.successful = t.total then (

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -115,11 +115,7 @@ let catala_commands_with_output_flag =
     "makefile";
     "html";
     "latex";
-    "scopelang";
-    "dcalc";
-    "lcalc";
     "ocaml";
-    "scalc";
     "python";
     "r";
     "c";

--- a/build_system/clerk_report.mli
+++ b/build_system/clerk_report.mli
@@ -34,7 +34,7 @@ type file = { name : File.t; successful : int; total : int; tests : test list }
 val write_to : File.t -> file -> unit
 val read_from : File.t -> file
 val read_many : File.t -> file list
-val display : build_dir:File.t -> Format.formatter -> test -> unit
+val display : build_dir:File.t -> File.t -> Format.formatter -> test -> unit
 
 val summary : build_dir:File.t -> file list -> bool
 (** Displays a summary to stdout; returns true if all tests succeeded *)

--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -76,7 +76,7 @@ let catala_test_command test_flags catala_exe catala_opts args out =
       let cmd0, flags =
         match String.lowercase_ascii cmd0, flags, test_flags with
         | "test-scope", scope_name :: flags, test_flags ->
-          "interpret", (("--scope=" ^ scope_name) :: flags) @ test_flags
+          "interpret", flags @ test_flags @ ["--scope=" ^ scope_name]
         | "test-scope", [], _ ->
           out_line out
             "[INVALID TEST] Invalid test command syntax, the 'test-scope' \

--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -126,7 +126,7 @@ let run_catala_test filename cmd program expected out_line =
         out_line result_line;
         match Seq.uncons expected with
         | Some (l, expected) -> success && String.equal result_line l, expected
-        | None -> false, expected)
+        | None -> false, Seq.empty)
       (true, expected) out_lines
   in
   let return_code =
@@ -142,7 +142,7 @@ let run_catala_test filename cmd program expected out_line =
       match Seq.uncons expected with
       | Some (l, expected) when String.equal l line -> success, expected
       | Some (_, expected) -> false, expected
-      | None -> false, expected
+      | None -> false, Seq.empty
   in
   success && Seq.is_empty expected
 
@@ -171,7 +171,7 @@ let run_tests ~catala_exe ~catala_opts ~test_flags ~report ~out filename =
     | Some ((l, tok, _), lines) ->
       push_line l;
       if tok = L.LINE_BLOCK_END then lines else skip_block lines
-    | None -> lines
+    | None -> Seq.empty
   in
   let rec get_block acc lines =
     let return lines acc =
@@ -189,7 +189,7 @@ let run_tests ~catala_exe ~catala_opts ~test_flags ~report ~out filename =
       lines, block, (startpos, endpos)
     in
     match Seq.uncons lines with
-    | None -> return lines acc
+    | None -> return Seq.empty acc
     | Some ((_, L.LINE_BLOCK_END, _), lines) -> return lines acc
     | Some (li, lines) -> get_block (li :: acc) lines
   in
@@ -213,7 +213,7 @@ let run_tests ~catala_exe ~catala_opts ~test_flags ~report ~out filename =
           "[INVALID TEST] Missing test command, use '$ catala <args>'\n"
       in
       rtests := t :: !rtests;
-      None, lines
+      None, Seq.empty
     | Some ((str, L.LINE_BLOCK_END, _), lines) ->
       let t =
         broken_test

--- a/compiler/catala_utils/hash.ml
+++ b/compiler/catala_utils/hash.ml
@@ -47,6 +47,7 @@ end = struct
   type nonrec t = t
 
   let pass k ~avoid_exceptions ~closure_conversion ~monomorphize_types =
+    let avoid_exceptions = avoid_exceptions || closure_conversion in
     (* Should not affect the call convention or actual interfaces: include,
        optimize, check_invariants, typed *)
     !(avoid_exceptions : bool)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -837,10 +837,11 @@ module Commands = struct
       optimize
       check_invariants
       avoid_exceptions
+      closure_conversion
       ex_scope_opt =
     let prg, type_ordering =
       Passes.lcalc options ~includes ~optimize ~check_invariants
-        ~avoid_exceptions ~typed:Expr.typed ~closure_conversion:false
+        ~avoid_exceptions ~typed:Expr.typed ~closure_conversion
         ~monomorphize_types:false
     in
     let output_file, with_output =
@@ -853,7 +854,7 @@ module Commands = struct
       (Option.value ~default:"stdout" output_file);
     let exec_scope = Option.map (get_scope_uid prg.decl_ctx) ex_scope_opt in
     let hashf =
-      Hash.finalise ~avoid_exceptions ~closure_conversion:false
+      Hash.finalise ~avoid_exceptions ~closure_conversion
         ~monomorphize_types:false
     in
     Lcalc.To_ocaml.format_program fmt prg ?exec_scope ~hashf type_ordering
@@ -870,6 +871,7 @@ module Commands = struct
         $ Cli.Flags.optimize
         $ Cli.Flags.check_invariants
         $ Cli.Flags.avoid_exceptions
+        $ Cli.Flags.closure_conversion
         $ Cli.Flags.ex_scope_opt)
 
   let scalc

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -202,15 +202,9 @@ module Passes = struct
     in
     let (prg : ty Dcalc.Ast.program) =
       match typed with
-      | Typed _ -> (
+      | Typed _ ->
         Message.debug "Typechecking again...";
-        try Typing.program prg
-        with Message.CompilerError error_content ->
-          let bt = Printexc.get_raw_backtrace () in
-          Printexc.raise_with_backtrace
-            (Message.CompilerError
-               (Message.Content.to_internal_error error_content))
-            bt)
+        Typing.program ~internal_check:true prg
       | Untyped _ -> prg
       | Custom _ -> assert false
     in
@@ -269,7 +263,7 @@ module Passes = struct
     let prg =
       if not closure_conversion then (
         Message.debug "Retyping lambda calculus...";
-        Typing.program ~fail_on_any:false prg)
+        Typing.program ~fail_on_any:false ~internal_check:true prg)
       else (
         Message.debug "Performing closure conversion...";
         let prg = Lcalc.Closure_conversion.closure_conversion prg in
@@ -280,14 +274,14 @@ module Passes = struct
           else prg
         in
         Message.debug "Retyping lambda calculus...";
-        Typing.program ~fail_on_any:false prg)
+        Typing.program ~fail_on_any:false ~internal_check:true prg)
     in
     let prg, type_ordering =
       if monomorphize_types then (
         Message.debug "Monomorphizing types...";
         let prg, type_ordering = Lcalc.Monomorphize.program prg in
         Message.debug "Retyping lambda calculus...";
-        let prg = Typing.program ~fail_on_any:false ~assume_op_types:true prg in
+        let prg = Typing.program ~fail_on_any:false ~assume_op_types:true ~internal_check:true prg in
         prg, type_ordering)
       else prg, type_ordering
     in

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -281,7 +281,10 @@ module Passes = struct
         Message.debug "Monomorphizing types...";
         let prg, type_ordering = Lcalc.Monomorphize.program prg in
         Message.debug "Retyping lambda calculus...";
-        let prg = Typing.program ~fail_on_any:false ~assume_op_types:true ~internal_check:true prg in
+        let prg =
+          Typing.program ~fail_on_any:false ~assume_op_types:true
+            ~internal_check:true prg
+        in
         prg, type_ordering)
       else prg, type_ordering
     in

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -118,21 +118,17 @@ let build_closure :
               ~op:(Operator.ToClosureEnv, pos)
               ~tys:
                 [
-                  ( (if free_vars = [] then TLit TUnit
-                     else TTuple free_vars_types),
+                  ( TTuple free_vars_types,
                     pos );
                 ]
               ~args:
                 [
-                  (if free_vars = [] then
-                     Expr.elit LUnit (mark_ty (TLit TUnit, pos))
-                   else
-                     Expr.etuple
-                       (List.map
-                          (fun (extra_var, m) ->
-                            Bindlib.box_var extra_var, Expr.with_pos pos m)
-                          free_vars)
-                       (mark_ty (TTuple free_vars_types, pos)));
+                  Expr.etuple
+                     (List.map
+                        (fun (extra_var, m) ->
+                           Bindlib.box_var extra_var, Expr.with_pos pos m)
+                        free_vars)
+                     (mark_ty (TTuple free_vars_types, pos));
                 ]
               (mark_ty (TClosureEnv, pos));
           ])

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -255,7 +255,7 @@ let rec transform_closures_expr :
     free_vars, build_closure ctx (Var.Map.bindings free_vars) body vars tys m
   | EAppOp
       {
-        op = ((HandleDefaultOpt | Fold | Map | Filter | Reduce), _) as op;
+        op = ((HandleDefaultOpt | Fold | Map | Map2 | Filter | Reduce), _) as op;
         tys;
         args;
       } ->

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -219,6 +219,7 @@ let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
   in
   match Mark.remove typ with
   | TLit l -> Format.fprintf fmt "%a" Print.tlit l
+  | TTuple [] -> Format.fprintf fmt "unit"
   | TTuple ts ->
     Format.fprintf fmt "@[<hov 2>(%a)@]"
       (Format.pp_print_list

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -240,7 +240,7 @@ let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
       (t1 @ [t2])
   | TArray t1 -> Format.fprintf fmt "@[%a@ array@]" format_typ_with_parens t1
   | TAny -> Format.fprintf fmt "_"
-  | TClosureEnv -> failwith "unimplemented!"
+  | TClosureEnv -> Format.fprintf fmt "Obj.t"
 
 let format_var_str (fmt : Format.formatter) (v : string) : unit =
   let lowercase_name = String.to_snake_case (String.to_ascii v) in

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -223,11 +223,11 @@ type typ = naked_typ Mark.pos
 
 and naked_typ =
   | TLit of typ_lit
+  | TArrow of typ list * typ
   | TTuple of typ list
   | TStruct of StructName.t
   | TEnum of EnumName.t
   | TOption of typ
-  | TArrow of typ list * typ
   | TArray of typ
   | TDefault of typ
   | TAny

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -566,7 +566,11 @@ let rec runtime_to_val :
       let e = runtime_to_val eval_expr ctx m ty (Obj.field o 0) in
       EInj { name = Expr.option_enum; cons = Expr.some_constr; e }, m
     | _ -> assert false)
-  | TClosureEnv -> assert false
+  | TClosureEnv ->
+    (* By construction, a closure environment can only be consumed from the same
+       scope where it was built (compiled or not) ; for this reason, we can
+       safely avoid converting in depth here *)
+    Obj.obj o, m
   | TArray ty ->
     ( EArray
         (List.map
@@ -656,6 +660,11 @@ and val_to_runtime :
     in
     curry [] targs
   | TDefault ty, _ -> val_to_runtime eval_expr ctx ty v
+  | TClosureEnv, v ->
+    (* By construction, a closure environment can only be consumed from the same
+       scope where it was built (compiled or not) ; for this reason, we can
+       safely avoid converting in depth here *)
+    Obj.repr v
   | _ ->
     Message.error ~internal:true
       "Could not convert value of type %a@ to@ runtime:@ %a" (Print.typ ctx) ty

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -1113,7 +1113,7 @@ module UserFacing = struct
            ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
            (value ~fallback lang))
         l
-    | ETuple [EAbs { tys = (TClosureEnv, _)::_ ; _ }, _; _] ->
+    | ETuple [(EAbs { tys = (TClosureEnv, _) :: _; _ }, _); _] ->
       Format.pp_print_string ppf "<function>"
     | ETuple l ->
       Format.fprintf ppf "@[<hv 2>(@,@[<hov>%a@]@;<0 -2>)@]"

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -102,7 +102,7 @@ let rec typ_gen
     Format.pp_open_hvbox fmt 2;
     pp_color_string (List.hd colors) fmt "(";
     (Format.pp_print_list
-       ~pp_sep:(fun fmt () -> Format.fprintf fmt " %a@ " op_style "*")
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt "%a@ " op_style ",")
        (typ ~colors:(List.tl colors)))
       fmt ts;
     Format.pp_close_box fmt ();

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -1113,6 +1113,8 @@ module UserFacing = struct
            ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
            (value ~fallback lang))
         l
+    | ETuple [EAbs { tys = (TClosureEnv, _)::_ ; _ }, _; _] ->
+      Format.pp_print_string ppf "<function>"
     | ETuple l ->
       Format.fprintf ppf "@[<hv 2>(@,@[<hov>%a@]@;<0 -2>)@]"
         (Format.pp_print_list

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -1108,18 +1108,20 @@ let program ?fail_on_any ?assume_op_types ?(internal_check=false) prg =
     if internal_check then
       fun f ->
         try Message.with_delayed_errors f with
-        | Message.CompilerErrors errs ->
+        | Message.CompilerError _ | Message.CompilerErrors _ as exc ->
           let bt = Printexc.get_raw_backtrace () in
-          Printexc.raise_with_backtrace
-            (Message.CompilerErrors
-               (List.map Message.Content.to_internal_error errs))
-            bt
-        | Message.CompilerError err ->
-          let bt = Printexc.get_raw_backtrace () in
-          Printexc.raise_with_backtrace
-            (Message.CompilerError
-               (Message.Content.to_internal_error err))
-            bt
+          let err = match exc with
+            | Message.CompilerError err ->
+              Message.CompilerError
+                (Message.Content.to_internal_error err)
+            | Message.CompilerErrors errs ->
+              Message.CompilerErrors
+                (List.map Message.Content.to_internal_error errs)
+            | _ -> assert false
+          in
+          Message.debug "Faulty intermediate program:@ %a"
+            (Print.program ~debug:true) prg;
+          Printexc.raise_with_backtrace err bt
     else
       fun f -> Message.with_delayed_errors f
   in

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -1103,27 +1103,25 @@ let program ?fail_on_any ?assume_op_types prg =
       };
   }
 
-let program ?fail_on_any ?assume_op_types ?(internal_check=false) prg =
+let program ?fail_on_any ?assume_op_types ?(internal_check = false) prg =
   let wrap =
-    if internal_check then
-      fun f ->
-        try Message.with_delayed_errors f with
-        | Message.CompilerError _ | Message.CompilerErrors _ as exc ->
-          let bt = Printexc.get_raw_backtrace () in
-          let err = match exc with
-            | Message.CompilerError err ->
-              Message.CompilerError
-                (Message.Content.to_internal_error err)
-            | Message.CompilerErrors errs ->
-              Message.CompilerErrors
-                (List.map Message.Content.to_internal_error errs)
-            | _ -> assert false
-          in
-          Message.debug "Faulty intermediate program:@ %a"
-            (Print.program ~debug:true) prg;
-          Printexc.raise_with_backtrace err bt
-    else
-      fun f -> Message.with_delayed_errors f
+    if internal_check then (fun f ->
+      try Message.with_delayed_errors f
+      with (Message.CompilerError _ | Message.CompilerErrors _) as exc ->
+        let bt = Printexc.get_raw_backtrace () in
+        let err =
+          match exc with
+          | Message.CompilerError err ->
+            Message.CompilerError (Message.Content.to_internal_error err)
+          | Message.CompilerErrors errs ->
+            Message.CompilerErrors
+              (List.map Message.Content.to_internal_error errs)
+          | _ -> assert false
+        in
+        Message.debug "Faulty intermediate program:@ %a"
+          (Print.program ~debug:true)
+          prg;
+        Printexc.raise_with_backtrace err bt)
+    else fun f -> Message.with_delayed_errors f
   in
-  wrap @@ fun () ->
-  program ?fail_on_any ?assume_op_types prg
+  wrap @@ fun () -> program ?fail_on_any ?assume_op_types prg

--- a/compiler/shared_ast/typing.mli
+++ b/compiler/shared_ast/typing.mli
@@ -97,6 +97,7 @@ val check_expr :
 val program :
   ?fail_on_any:bool ->
   ?assume_op_types:bool ->
+  ?internal_check:bool ->
   ('a, 'm) gexpr program ->
   ('a, typed) gexpr program
 (** Typing on whole programs (as defined in Shared_ast.program, i.e. for the
@@ -104,4 +105,6 @@ val program :
 
     Any existing type annotations are checked for unification. Use
     [Program.untype] to remove them beforehand if this is not the desired
-    behaviour. *)
+    behaviour.
+
+    If [internal_check] is set to [true], typing errors will be marked as internal, and the faulty program will be printed if '--debug' is set. *)

--- a/compiler/shared_ast/typing.mli
+++ b/compiler/shared_ast/typing.mli
@@ -107,4 +107,5 @@ val program :
     [Program.untype] to remove them beforehand if this is not the desired
     behaviour.
 
-    If [internal_check] is set to [true], typing errors will be marked as internal, and the faulty program will be printed if '--debug' is set. *)
+    If [internal_check] is set to [true], typing errors will be marked as
+    internal, and the faulty program will be printed if '--debug' is set. *)

--- a/compiler/shared_ast/typing.mli
+++ b/compiler/shared_ast/typing.mli
@@ -100,7 +100,7 @@ val program :
   ('a, 'm) gexpr program ->
   ('a, typed) gexpr program
 (** Typing on whole programs (as defined in Shared_ast.program, i.e. for the
-    later dcalc/lcalc stages.
+    later dcalc/lcalc stages).
 
     Any existing type annotations are checked for unification. Use
     [Program.untype] to remove them beforehand if this is not the desired

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -884,6 +884,8 @@ module Oper = struct
   let o_eq_dur_dur pos d1 d2 = equal_periods pos d1 d2
   let o_eq_dat_dat d1 d2 = Dates_calc.Dates.compare_dates d1 d2 = 0
   let o_fold = Array.fold_left
+  let o_toclosureenv = Obj.repr
+  let o_fromclosureenv = Obj.obj
 end
 
 include Oper

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -432,6 +432,8 @@ module Oper : sig
   val o_eq_dur_dur : source_position -> duration -> duration -> bool
   val o_eq_dat_dat : date -> date -> bool
   val o_fold : ('a -> 'b -> 'a) -> 'a -> 'b array -> 'a
+  val o_toclosureenv : 'a -> Obj.t
+  val o_fromclosureenv : Obj.t -> 'a
 end
 
 include module type of Oper

--- a/tests/array/good/aggregation_3.catala_en
+++ b/tests/array/good/aggregation_3.catala_en
@@ -76,14 +76,14 @@ let scope S (x: integer|internal|output) =
             10.
             map (λ (i: integer) → to_rat i) [1; 2; 3])
          = 3.;
-  assert (let weights : list of (integer * decimal) =
+  assert (let weights : list of (integer, decimal) =
             map (λ (i: integer) →
                  (i, let i1 : integer = i in
                      to_rat ((2 - i1) * (2 - i1))))
               [1; 2; 3]
           in
           reduce
-            (λ (x1: (integer * decimal)) (x2: (integer * decimal)) →
+            (λ (x1: (integer, decimal)) (x2: (integer, decimal)) →
              if x1.1 < x2.1 then x1 else x2)
             let i : integer = 42 in
             (i, let i1 : integer = i in

--- a/tests/func/good/closure_conversion.catala_en
+++ b/tests/func/good/closure_conversion.catala_en
@@ -41,3 +41,69 @@ let scope S (S_in: S_in {x_in: bool}): S {z: integer} =
   return { S z = z; }
 
 ```
+
+
+```catala
+declaration scope S2:
+  output dummy content boolean
+  input output cfun2 content decimal depends on x content integer
+
+scope S2:
+  definition dummy equals false
+
+declaration scope S2Use:
+  internal fun content decimal depends on y content integer
+  output o content (S2, S2)
+
+declaration fun2 content decimal depends on y content integer equals y / 3
+
+scope S2Use:
+  definition fun of y equals y / 2
+  definition o equals
+      (output of S2 with { -- cfun2: fun },
+       output of S2 with { -- cfun2: fun2 })
+```
+
+```catala-test-inline
+$ catala Lcalc --avoid-exceptions -O --closure-conversion -s S2Use
+let scope S2Use
+  (S2Use_in: S2Use_in)
+  : S2Use {
+      o:
+        (S2 {
+           dummy: bool;
+           cfun2: ((closure_env, integer) → decimal, closure_env)
+         },
+          S2 {
+            dummy: bool;
+            cfun2: ((closure_env, integer) → decimal, closure_env)
+          })
+    }
+  =
+  let set fun : ((closure_env, integer) → decimal, closure_env) =
+    (closure_fun, to_closure_env ())
+  in
+  let set o :
+      (S2 {
+         dummy: bool;
+         cfun2: ((closure_env, integer) → decimal, closure_env)
+       },
+        S2 {
+          dummy: bool;
+          cfun2: ((closure_env, integer) → decimal, closure_env)
+        }) =
+    (let result : S2 = S2 { S2_in cfun2_in = fun; } in
+     { S2
+       dummy = result.dummy;
+       cfun2 = (closure_o, to_closure_env (result));
+     },
+      let result : S2 =
+        S2 { S2_in cfun2_in = (closure_o, to_closure_env ()); }
+      in
+      { S2
+        dummy = result.dummy;
+        cfun2 = (closure_o, to_closure_env (result));
+      })
+  in
+  return { S2Use o = o; }
+```

--- a/tests/func/good/closure_conversion.catala_en
+++ b/tests/func/good/closure_conversion.catala_en
@@ -34,7 +34,7 @@ let topval closure_f : (closure_env, integer) → integer =
   if (from_closure_env env).0 then y else - y
 let scope S (S_in: S_in {x_in: bool}): S {z: integer} =
   let get x : bool = S_in.x_in in
-  let set f : ((closure_env, integer) → integer * closure_env) =
+  let set f : ((closure_env, integer) → integer, closure_env) =
     (closure_f, to_closure_env (x))
   in
   let set z : integer = f.0 f.1 -1 in

--- a/tests/func/good/closure_conversion.catala_en
+++ b/tests/func/good/closure_conversion.catala_en
@@ -29,13 +29,13 @@ type Eoption =  | ENone of unit  | ESome of any
 type S_in = { x_in: bool; }
 type S = { z: integer; }
 
-let topval closure_f : (closure_env, integer) → integer =
+let topval closure_f1 : (closure_env, integer) → integer =
   λ (env: closure_env) (y: integer) →
   if (from_closure_env env).0 then y else - y
 let scope S (S_in: S_in {x_in: bool}): S {z: integer} =
   let get x : bool = S_in.x_in in
   let set f : ((closure_env, integer) → integer, closure_env) =
-    (closure_f, to_closure_env (x))
+    (closure_f1, to_closure_env (x))
   in
   let set z : integer = f.0 f.1 -1 in
   return { S z = z; }
@@ -81,7 +81,7 @@ let scope S2Use
     }
   =
   let set fun : ((closure_env, integer) → decimal, closure_env) =
-    (closure_fun, to_closure_env ())
+    (closure_fun1, to_closure_env ())
   in
   let set o :
       (S2 {
@@ -95,14 +95,14 @@ let scope S2Use
     (let result : S2 = S2 { S2_in cfun2_in = fun; } in
      { S2
        dummy = result.dummy;
-       cfun2 = (closure_o, to_closure_env (result));
+       cfun2 = (closure_o1, to_closure_env (result));
      },
       let result : S2 =
-        S2 { S2_in cfun2_in = (closure_o, to_closure_env ()); }
+        S2 { S2_in cfun2_in = (closure_o3, to_closure_env ()); }
       in
       { S2
         dummy = result.dummy;
-        cfun2 = (closure_o, to_closure_env (result));
+        cfun2 = (closure_o2, to_closure_env (result));
       })
   in
   return { S2Use o = o; }

--- a/tests/func/good/closure_conversion_reduce.catala_en
+++ b/tests/func/good/closure_conversion_reduce.catala_en
@@ -29,7 +29,7 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
   let get x : list of integer = S_in.x_in in
   let set y : integer =
     (reduce
-       (λ (x1: (integer * integer)) (x2: (integer * integer)) →
+       (λ (x1: (integer, integer)) (x2: (integer, integer)) →
         if x1.1 < x2.1 then x1 else x2)
        (-1, -1)
        map (λ (potential_max: integer) → (potential_max, potential_max)) x).0
@@ -60,7 +60,7 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
              (λ () → true)
              (λ () →
               ESome
-                (let weights : list of (integer * integer) =
+                (let weights : list of (integer, integer) =
                    map (λ (potential_max: integer) →
                         (potential_max,
                           let potential_max1 : integer = potential_max in
@@ -68,7 +68,7 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
                      x
                  in
                  reduce
-                   (λ (x1: (integer * integer)) (x2: (integer * integer)) →
+                   (λ (x1: (integer, integer)) (x2: (integer, integer)) →
                     if x1.1 < x2.1 then x1 else x2)
                    let potential_max : integer = -1 in
                    (potential_max,

--- a/tests/func/good/closure_return.catala_en
+++ b/tests/func/good/closure_return.catala_en
@@ -25,17 +25,17 @@ $ catala Typecheck --check-invariants
 $ catala Lcalc --avoid-exceptions -O --closure-conversion
 type Eoption =  | ENone of unit  | ESome of any 
 type S_in = { x_in: bool; }
-type S = { f: ((closure_env, integer) → integer * closure_env); }
+type S = { f: ((closure_env, integer) → integer, closure_env); }
 
 let topval closure_f : (closure_env, integer) → integer =
   λ (env: closure_env) (y: integer) →
   if (from_closure_env env).0 then y else - y
 let scope S
   (S_in: S_in {x_in: bool})
-  : S {f: ((closure_env, integer) → integer * closure_env)}
+  : S {f: ((closure_env, integer) → integer, closure_env)}
   =
   let get x : bool = S_in.x_in in
-  let set f : ((closure_env, integer) → integer * closure_env) =
+  let set f : ((closure_env, integer) → integer, closure_env) =
     (closure_f, to_closure_env (x))
   in
   return { S f = f; }

--- a/tests/func/good/closure_return.catala_en
+++ b/tests/func/good/closure_return.catala_en
@@ -27,7 +27,7 @@ type Eoption =  | ENone of unit  | ESome of any
 type S_in = { x_in: bool; }
 type S = { f: ((closure_env, integer) → integer, closure_env); }
 
-let topval closure_f : (closure_env, integer) → integer =
+let topval closure_f1 : (closure_env, integer) → integer =
   λ (env: closure_env) (y: integer) →
   if (from_closure_env env).0 then y else - y
 let scope S
@@ -36,7 +36,7 @@ let scope S
   =
   let get x : bool = S_in.x_in in
   let set f : ((closure_env, integer) → integer, closure_env) =
-    (closure_f, to_closure_env (x))
+    (closure_f1, to_closure_env (x))
   in
   return { S f = f; }
 

--- a/tests/func/good/closure_through_scope.catala_en
+++ b/tests/func/good/closure_through_scope.catala_en
@@ -32,11 +32,11 @@ $ catala Typecheck --check-invariants
 ```catala-test-inline
 $ catala Lcalc -s T --avoid-exceptions -O --closure-conversion
 let scope T (T_in: T_in): T {y: integer} =
-  let set s : S {f: ((closure_env, integer) → integer * closure_env)} =
+  let set s : S {f: ((closure_env, integer) → integer, closure_env)} =
     { S f = (closure_s, to_closure_env ()); }
   in
   let set y : integer =
-    let code_and_env : ((closure_env, integer) → integer * closure_env) =
+    let code_and_env : ((closure_env, integer) → integer, closure_env) =
       s.f
     in
     code_and_env.0 code_and_env.1 2

--- a/tests/func/good/closure_through_scope.catala_en
+++ b/tests/func/good/closure_through_scope.catala_en
@@ -33,7 +33,7 @@ $ catala Typecheck --check-invariants
 $ catala Lcalc -s T --avoid-exceptions -O --closure-conversion
 let scope T (T_in: T_in): T {y: integer} =
   let set s : S {f: ((closure_env, integer) → integer, closure_env)} =
-    { S f = (closure_s, to_closure_env ()); }
+    { S f = (closure_s1, to_closure_env ()); }
   in
   let set y : integer =
     let code_and_env : ((closure_env, integer) → integer, closure_env) =

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -56,20 +56,20 @@ $ catala Typecheck --check-invariants
 $ catala Lcalc --avoid-exceptions -O --closure-conversion 
 type Eoption =  | ENone of unit  | ESome of any 
 type Result = {
-  r: ((closure_env, integer) → integer * closure_env);
+  r: ((closure_env, integer) → integer, closure_env);
   q: integer;
 }
 type SubFoo1_in = { x_in: integer; }
 type SubFoo1 = {
   x: integer;
-  y: ((closure_env, integer) → integer * closure_env);
+  y: ((closure_env, integer) → integer, closure_env);
 }
 type SubFoo2_in = { x1_in: integer; x2_in: integer; }
 type SubFoo2 = {
   x1: integer;
-  y: ((closure_env, integer) → integer * closure_env);
+  y: ((closure_env, integer) → integer, closure_env);
 }
-type Foo_in = { b_in: ((closure_env, unit) → eoption bool * closure_env); }
+type Foo_in = { b_in: ((closure_env, unit) → eoption bool, closure_env); }
 type Foo = { z: integer; }
 
 let topval closure_y : (closure_env, integer) → integer =
@@ -79,49 +79,49 @@ let scope SubFoo1
   (SubFoo1_in: SubFoo1_in {x_in: integer})
   : SubFoo1 {
       x: integer;
-      y: ((closure_env, integer) → integer * closure_env)
+      y: ((closure_env, integer) → integer, closure_env)
     }
   =
   let get x : integer = SubFoo1_in.x_in in
-  let set y : ((closure_env, integer) → integer * closure_env) =
+  let set y : ((closure_env, integer) → integer, closure_env) =
     (closure_y, to_closure_env (x))
   in
   return { SubFoo1 x = x; y = y; }
 let topval closure_y : (closure_env, integer) → integer =
   λ (env: closure_env) (z: integer) →
-  let env1 : (integer * integer) = from_closure_env env in
+  let env1 : (integer, integer) = from_closure_env env in
   ((env1.1 + env1.0 + z))
 let scope SubFoo2
   (SubFoo2_in: SubFoo2_in {x1_in: integer; x2_in: integer})
   : SubFoo2 {
       x1: integer;
-      y: ((closure_env, integer) → integer * closure_env)
+      y: ((closure_env, integer) → integer, closure_env)
     }
   =
   let get x1 : integer = SubFoo2_in.x1_in in
   let get x2 : integer = SubFoo2_in.x2_in in
-  let set y : ((closure_env, integer) → integer * closure_env) =
+  let set y : ((closure_env, integer) → integer, closure_env) =
     (closure_y, to_closure_env (x2, x1))
   in
   return { SubFoo2 x1 = x1; y = y; }
 let topval closure_r : (closure_env, integer) → integer =
   λ (env: closure_env) (param0: integer) →
-  let code_and_env : ((closure_env, integer) → integer * closure_env) =
+  let code_and_env : ((closure_env, integer) → integer, closure_env) =
     (from_closure_env env).0.y
   in
   code_and_env.0 code_and_env.1 param0
 let topval closure_r : (closure_env, integer) → integer =
   λ (env: closure_env) (param0: integer) →
-  let code_and_env : ((closure_env, integer) → integer * closure_env) =
+  let code_and_env : ((closure_env, integer) → integer, closure_env) =
     (from_closure_env env).0.y
   in
   code_and_env.0 code_and_env.1 param0
 let scope Foo
   (Foo_in:
-     Foo_in {b_in: ((closure_env, unit) → eoption bool * closure_env)})
+     Foo_in {b_in: ((closure_env, unit) → eoption bool, closure_env)})
   : Foo {z: integer}
   =
-  let get b : ((closure_env, unit) → eoption bool * closure_env) =
+  let get b : ((closure_env, unit) → eoption bool, closure_env) =
     Foo_in.b_in
   in
   let set b : bool =
@@ -133,7 +133,7 @@ let scope Foo
   in
   let set r :
       Result {
-        r: ((closure_env, integer) → integer * closure_env);
+        r: ((closure_env, integer) → integer, closure_env);
         q: integer
       } =
     if b then
@@ -152,7 +152,7 @@ let scope Foo
       { Result r = f.y; q = f.x1; }
   in
   let set z : integer =
-    let code_and_env : ((closure_env, integer) → integer * closure_env) =
+    let code_and_env : ((closure_env, integer) → integer, closure_env) =
       r.r
     in
     code_and_env.0 code_and_env.1 1

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -72,7 +72,7 @@ type SubFoo2 = {
 type Foo_in = { b_in: ((closure_env, unit) → eoption bool, closure_env); }
 type Foo = { z: integer; }
 
-let topval closure_y : (closure_env, integer) → integer =
+let topval closure_y1 : (closure_env, integer) → integer =
   λ (env: closure_env) (z: integer) →
   (from_closure_env env).0 + z
 let scope SubFoo1
@@ -84,10 +84,10 @@ let scope SubFoo1
   =
   let get x : integer = SubFoo1_in.x_in in
   let set y : ((closure_env, integer) → integer, closure_env) =
-    (closure_y, to_closure_env (x))
+    (closure_y1, to_closure_env (x))
   in
   return { SubFoo1 x = x; y = y; }
-let topval closure_y : (closure_env, integer) → integer =
+let topval closure_y1 : (closure_env, integer) → integer =
   λ (env: closure_env) (z: integer) →
   let env1 : (integer, integer) = from_closure_env env in
   ((env1.1 + env1.0 + z))
@@ -101,16 +101,16 @@ let scope SubFoo2
   let get x1 : integer = SubFoo2_in.x1_in in
   let get x2 : integer = SubFoo2_in.x2_in in
   let set y : ((closure_env, integer) → integer, closure_env) =
-    (closure_y, to_closure_env (x2, x1))
+    (closure_y1, to_closure_env (x2, x1))
   in
   return { SubFoo2 x1 = x1; y = y; }
-let topval closure_r : (closure_env, integer) → integer =
+let topval closure_r2 : (closure_env, integer) → integer =
   λ (env: closure_env) (param0: integer) →
   let code_and_env : ((closure_env, integer) → integer, closure_env) =
     (from_closure_env env).0.y
   in
   code_and_env.0 code_and_env.1 param0
-let topval closure_r : (closure_env, integer) → integer =
+let topval closure_r1 : (closure_env, integer) → integer =
   λ (env: closure_env) (param0: integer) →
   let code_and_env : ((closure_env, integer) → integer, closure_env) =
     (from_closure_env env).0.y
@@ -139,7 +139,7 @@ let scope Foo
     if b then
       let f : SubFoo1 =
         let result : SubFoo1 = SubFoo1 { SubFoo1_in x_in = 10; } in
-        { SubFoo1 x = result.x; y = (closure_r, to_closure_env (result)); }
+        { SubFoo1 x = result.x; y = (closure_r1, to_closure_env (result)); }
       in
       { Result r = f.y; q = f.x; }
     else
@@ -147,7 +147,10 @@ let scope Foo
         let result : SubFoo2 =
           SubFoo2 { SubFoo2_in x1_in = 10; x2_in = 10; }
         in
-        { SubFoo2 x1 = result.x1; y = (closure_r, to_closure_env (result)); }
+        { SubFoo2
+          x1 = result.x1;
+          y = (closure_r2, to_closure_env (result));
+        }
       in
       { Result r = f.y; q = f.x1; }
   in

--- a/tests/tuples/good/tuplists.catala_en
+++ b/tests/tuples/good/tuplists.catala_en
@@ -99,55 +99,55 @@ in
 let lis3 : list of money =
   [¤20.00; ¤200.00; ¤10.00; ¤23.00; ¤25.00; ¤12.00]
 in
-let grok : (decimal, money, money) → (money * decimal) =
+let grok : (decimal, money, money) → (money, decimal) =
   λ (dec: decimal) (mon1: money) (mon2: money) →
   (mon1 * dec, mon1 / mon2)
 in
-let tlist : list of (decimal * money * money) =
+let tlist : list of (decimal, money, money) =
   map2
-    (λ (a: decimal) (b_c: (money * money)) → (a, b_c.0, b_c.1))
+    (λ (a: decimal) (b_c: (money, money)) → (a, b_c.0, b_c.1))
     lis1
     map2 (λ (b: money) (c: money) → (b, c)) lis2 lis3
 in
 let S : S_in → S =
   λ (S_in: S_in) →
-  let r1 : list of (money * decimal) =
-    map (λ (x: (decimal * money * money)) → grok x.0 x.1 x.2) tlist
+  let r1 : list of (money, decimal) =
+    map (λ (x: (decimal, money, money)) → grok x.0 x.1 x.2) tlist
   in
-  let r2 : list of (money * decimal) =
+  let r2 : list of (money, decimal) =
     map2
-      (λ (x: decimal) (zip: (money * money)) →
-       let x1 : (decimal * money * money) = (x, zip.0, zip.1) in
+      (λ (x: decimal) (zip: (money, money)) →
+       let x1 : (decimal, money, money) = (x, zip.0, zip.1) in
        grok x1.0 x1.1 x1.2)
       lis1
       map2 (λ (x: money) (zip: money) → (x, zip)) lis2 lis3
   in
-  let r3 : list of (money * decimal) =
+  let r3 : list of (money, decimal) =
     map2
-      (λ (x: decimal) (y_z: (money * money)) →
-       let x_y_z : (decimal * money * money) = (x, y_z.0, y_z.1) in
+      (λ (x: decimal) (y_z: (money, money)) →
+       let x_y_z : (decimal, money, money) = (x, y_z.0, y_z.1) in
        grok x_y_z.0 x_y_z.1 x_y_z.2)
       lis1
       map2 (λ (y: money) (z: money) → (y, z)) lis2 lis3
   in
-  let r4 : list of (money * decimal) =
-    map (λ (x_y_z: (decimal * money * money)) →
+  let r4 : list of (money, decimal) =
+    map (λ (x_y_z: (decimal, money, money)) →
          (x_y_z.1 * x_y_z.0, x_y_z.1 / x_y_z.2))
       tlist
   in
-  let r5 : list of (money * decimal) =
+  let r5 : list of (money, decimal) =
     map2
-      (λ (x: decimal) (y_z: (money * money)) →
-       let x_y_z : (decimal * money * money) = (x, y_z.0, y_z.1) in
+      (λ (x: decimal) (y_z: (money, money)) →
+       let x_y_z : (decimal, money, money) = (x, y_z.0, y_z.1) in
        (x_y_z.1 * x_y_z.0, x_y_z.1 / x_y_z.2))
       lis1
       map2 (λ (y: money) (z: money) → (y, z)) lis2 lis3
   in
-  let r6 : list of (money * decimal) =
+  let r6 : list of (money, decimal) =
     map2
-      (λ (xy: (decimal * money)) (z: money) →
-       let xy_z : ((decimal * money) * money) = (xy, z) in
-       let xy1 : (decimal * money) = xy_z.0 in
+      (λ (xy: (decimal, money)) (z: money) →
+       let xy_z : ((decimal, money), money) = (xy, z) in
+       let xy1 : (decimal, money) = xy_z.0 in
        let z1 : money = xy_z.1 in
        (xy1.1 * xy1.0, xy1.1 / z1))
       map2 (λ (x: decimal) (y: money) → (x, y)) lis1 lis2


### PR DESCRIPTION
This adds support for closure conversion in the OCaml backend (useful for testing, probably nothing else) ; brings support throughout the toolchain ; and fixes a number of small bugs, some of them nasty.

With this, `clerk test --test-flags=--lcalc,--closure-conversion` fully passes (it's not added to the default testsuite yet, though)

A few asides are included:
- fixed regression with printing internal typing errors (and now show full program in debug mode when they happen)
- some Clerk fine-tuning following the reporting feature
