### PR TITLE
Clerk reports: postprocess diff output

### DIFF
--- a/compiler/catala_utils/string.ml
+++ b/compiler/catala_utils/string.ml
@@ -50,6 +50,18 @@ let remove_prefix ~prefix s =
     sub s plen (length s - plen)
   else s
 
+let trim_end s =
+  let rec stop n =
+    if n < 0 then n
+    else
+      match get s n with
+      | ' ' | '\x0c' | '\n' | '\r' | '\t' -> stop (n - 1)
+      | _ -> n
+  in
+  let last = length s - 1 in
+  let i = stop last in
+  if i = last then s else sub s 0 (i + 1)
+
 (* Note: this should do, but remains incorrect for combined unicode characters
    that display as one (e.g. `e` + postfix `'`). We should switch to Uuseg at
    some poing *)

--- a/compiler/catala_utils/string.mli
+++ b/compiler/catala_utils/string.mli
@@ -50,6 +50,9 @@ val remove_prefix : prefix:string -> string -> string
     - if [str] starts with [prefix], a string [s] such that [prefix ^ s = str]
     - otherwise, [str] unchanged *)
 
+val trim_end : string -> string
+(** Like [Stdlib.String.trim], but only trims at the end of the string *)
+
 val format : Format.formatter -> string -> unit
 
 val width : string -> int


### PR DESCRIPTION
This relies less on specific color flags of GNU diff, and reformats and colorises the output.
(it may still depend on the specific layout of GNU diff with the `-y` flag though)

Since we already have `diffutils` advertised as dev-mode dependency this should be OK
(alpine / busybox basic diff doesn't even support `-y` anyway)