### PR TITLE
Literate output: adjust catala-metadata margins

### DIFF
--- a/compiler/literate/latex.ml
+++ b/compiler/literate/latex.ml
@@ -317,7 +317,8 @@ let rec law_structure_to_latex
     Format.fprintf fmt
       "\\begin{tcolorbox}[colframe=OliveGreen, breakable, \
        title=\\textcolor{black}{\\texttt{%s}},title after \
-       break=\\textcolor{black}{\\texttt{%s}},before skip=1em, after skip=1em]\n\
+       break=\\textcolor{black}{\\texttt{%s}},before skip=1em, after skip=1em, \
+       left=0.6em, right=0.6em]\n\
        %a\n\
        \\end{tcolorbox}"
       metadata_title metadata_title


### PR DESCRIPTION
to make sure that 80 characters fit in the line