### PR TITLE
Fix scopelang scope definition variable positions

### DIFF
--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -589,20 +589,21 @@ let translate_rule
   match rule with
   | S.ScopeVarDefinition { var; typ; e; _ }
   | S.SubScopeVarDefinition { var; typ; e; _ } ->
+    let scope_var = Mark.remove var in
+    let decl_pos = Mark.get (ScopeVar.get_info scope_var) in
     let pos_mark, _ = pos_mark_mk e in
     let scope_let_kind, io =
       match rule with
       | S.ScopeVarDefinition { io; _ } -> ScopeVarDefinition, io
       | S.SubScopeVarDefinition _ ->
-        let pos = Mark.get var in
         ( SubScopeVarDefinition,
-          { io_input = NoInput, pos; io_output = false, pos } )
+          { io_input = NoInput, decl_pos; io_output = false, decl_pos } )
       | S.Assertion _ -> assert false
     in
     let a_name = ScopeVar.get_info (Mark.remove var) in
     let a_var = Var.make (Mark.remove a_name) in
     let new_e = translate_expr ctx e in
-    let a_expr = Expr.make_var a_var (pos_mark (Mark.get var)) in
+    let a_expr = Expr.make_var a_var (pos_mark decl_pos) in
     let is_func = match Mark.remove typ with TArrow _ -> true | _ -> false in
     let merged_expr =
       match Mark.remove io.io_input with
@@ -629,7 +630,7 @@ let translate_rule
                   scope_let_typ = typ;
                   scope_let_expr = merged_expr;
                   scope_let_kind;
-                  scope_let_pos = Mark.get var;
+                  scope_let_pos = decl_pos;
                 },
                 next ))
           (Bindlib.bind_var a_var next)

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -40,13 +40,13 @@ let rec locations_used (e : 'm expr) : LocationSet.t =
 
 type 'm rule =
   | ScopeVarDefinition of {
-      var : ScopeVar.t Mark.pos;
+      var : (ScopeVar.t, Pos.t list) Mark.ed;
       typ : typ;
       io : Desugared.Ast.io;
       e : 'm expr;
     }
   | SubScopeVarDefinition of {
-      var : ScopeVar.t Mark.pos;
+      var : (ScopeVar.t, Pos.t list) Mark.ed;
       var_within_origin_scope : ScopeVar.t;
       typ : typ;
       e : 'm expr;

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -33,16 +33,14 @@ val locations_used : 'm expr -> LocationSet.t
 
 type 'm rule =
   | ScopeVarDefinition of {
-      var : ScopeVar.t Mark.pos;
+      var : ScopeVar.t * Pos.t list;
+          (** Scope variable and its list of definitions' positions *)
       typ : typ;
       io : Desugared.Ast.io;
       e : 'm expr;
     }
   | SubScopeVarDefinition of {
-      var : ScopeVar.t Mark.pos;  (** Variable within the current scope *)
-      (* scope: ScopeVar.t Mark.pos; (\** Variable pointing to the *\) *)
-      (* origin_var: ScopeVar.t Mark.pos;
-       * reentrant: bool; *)
+      var : ScopeVar.t * Pos.t list;  (** Variable within the current scope *)
       var_within_origin_scope : ScopeVar.t;
       typ : typ; (* non-thunked at this point for reentrant vars *)
       e : 'm expr;


### PR DESCRIPTION
This PR adds the positions of scope variables (possibly multiple) definitions in scopelang's AST which was missing. This is necessary in order to implement the LSP jump-to-def feature. Previously, the only position hauled from desugared was the declaration's one.