### PR TITLE
Add LSP required features

### DIFF
--- a/build_system/dune
+++ b/build_system/dune
@@ -1,16 +1,23 @@
 (library
+ (name clerk_config)
+ (public_name catala.clerk_config)
+ (libraries catala.catala_utils otoml)
+ (modules clerk_config))
+
+(library
  (name clerk_driver)
  (public_name catala.clerk_driver)
  (libraries
   catala.runtime_ocaml
   catala.catala_utils
   catala.surface
+  catala.clerk_config
   ninja_utils
   cmdliner
   re
   ocolor
   otoml)
- (modules clerk_scan clerk_report clerk_runtest clerk_config clerk_driver))
+ (modules clerk_scan clerk_report clerk_runtest clerk_driver))
 
 (rule
  (target custom_linking.sexp)

--- a/compiler/catala_utils/pos.ml
+++ b/compiler/catala_utils/pos.ml
@@ -135,7 +135,7 @@ let format_loc_text_parts (pos : t) =
         let ic, input_line_opt =
           let from_contents =
             match Global.options.input_src with
-            | Contents (str, _) when str = filename -> Some str
+            | Contents (str, uri) when uri = filename -> Some str
             | _ -> None
           in
           match from_contents with

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -224,7 +224,7 @@ let record_type_error _ctx (A.AnyExpr e) t1 t2 =
           t2_pos );
       ]
   in
-  Message.delayed_error () ~fmt_pos
+  Message.delayed_error ~kind:Typing () ~fmt_pos
     "Error during typechecking, incompatible types:@\n\
      @[<v>@{<blue>@<2>%s@} @[<hov>%a@]@,\
      @{<blue>@<2>%s@} @[<hov>%a@]@]" "─➤" pp_typ t1_repr "─➤" pp_typ t2_repr

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -58,10 +58,11 @@ let code_buffer : Buffer.t = Buffer.create 4000
 let update_acc (lexbuf : lexbuf) : unit =
   Buffer.add_string code_buffer (Utf8.lexeme lexbuf)
 
+exception Lexing_error of (Pos.t * string)
+
 (** Error-generating helper *)
 let raise_lexer_error (loc : Pos.t) (token : string) =
-  Message.error ~pos:loc
-    "Parsing error after token \"%s\": what comes after is unknown" token
+  raise (Lexing_error (loc, token))
 
 (** Associative list matching each punctuation string part of the Catala syntax
     with its {!module: Surface.Parser} token. Same for all the input languages

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -31,6 +31,8 @@ val code_buffer : Buffer.t
 val update_acc : Sedlexing.lexbuf -> unit
 (** Updates {!val:code_buffer} with the current lexeme *)
 
+exception Lexing_error of (Catala_utils.Pos.t * string)
+
 val raise_lexer_error : Catala_utils.Pos.t -> string -> 'a
 (** Error-generating helper *)
 


### PR DESCRIPTION
This PR adds/exposes features required to implement the LSP server:

1. Refactoring of the error messages so that the LSP server is able to be notified on each encountered error;
2. Making `clerk_config` a sub-package in order to be reachable by the LSP server;
3. Fixes some small bugs: e.g., error reporting not considering the correct input source, leaking lexing errors, etc.

With this PR, the current state of LSP server will have all what it needs upstreamed (and thus, won't require to pin on a branch).