### PR TITLE
Cleanup nested matches

### DIFF
--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -19,43 +19,6 @@ open Definitions
 
 type ('a, 'b, 'm) optimizations_ctx = { decl_ctx : decl_ctx }
 
-let all_match_cases_are_id_fun cases n =
-  EnumConstructor.Map.for_all
-    (fun i case ->
-      match Mark.remove case with
-      | EAbs { binder; _ } -> (
-        let var, body = Bindlib.unmbind binder in
-        (* because of invariant [invariant_match], the arity is always one. *)
-        let[@warning "-8"] [| var |] = var in
-        match Mark.remove body with
-        | EInj { cons = i'; name = n'; e = EVar x, _ } ->
-          EnumConstructor.equal i i'
-          && EnumName.equal n n'
-          && Bindlib.eq_vars x var
-        | EInj { cons = i'; name = n'; e = ELit LUnit, _ } ->
-          (* since unit is the only value of type unit. We don't need to check
-             the equality. *)
-          EnumConstructor.equal i i' && EnumName.equal n n'
-        | _ -> false)
-      | _ ->
-        (* because of invariant [invariant_match], there is always some EAbs in
-           each cases. *)
-        assert false)
-    cases
-
-let all_match_cases_map_to_same_constructor cases n =
-  EnumConstructor.Map.for_all
-    (fun i case ->
-      match Mark.remove case with
-      | EAbs { binder; _ } -> (
-        let _, body = Bindlib.unmbind binder in
-        match Mark.remove body with
-        | EInj { cons = i'; name = n'; _ } ->
-          EnumConstructor.equal i i' && EnumName.equal n n'
-        | _ -> false)
-      | _ -> assert false)
-    cases
-
 let binder_vars_used_at_most_once
     (binder :
       ( ('a dcalc_lcalc, 'a dcalc_lcalc, 'm) base_gexpr,
@@ -78,6 +41,113 @@ let binder_vars_used_at_most_once
         (Array.make (Array.length vars) 0)
   in
   not (Array.exists (fun c -> c > 1) (vars_count body))
+
+(* beta reduction when variables not used, and for variable aliases and
+   literal *)
+let simplified_apply f args tys =
+  match f with
+  | EAbs { binder; _ }, _
+    when binder_vars_used_at_most_once binder
+         || List.for_all
+              (function (EVar _ | ELit _), _ -> true | _ -> false)
+              args ->
+    Mark.remove (Bindlib.msubst binder (List.map fst args |> Array.of_list))
+  | _ -> EApp { f; args; tys }
+
+let literal_bool = function
+  | ELit (LBool b), _
+  | EAppOp { op = Log _, _; args = [(ELit (LBool b), _)]; _ }, _ ->
+    Some b
+  | _ -> None
+
+let simplified_ifthenelse cond etrue efalse m =
+  if Expr.equal etrue efalse then Mark.remove etrue
+  else
+    match literal_bool etrue, literal_bool efalse with
+    | Some true, Some false -> Mark.remove cond
+    | Some false, Some true ->
+      EAppOp
+        {
+          op = Not, Expr.mark_pos m;
+          tys = [TLit TBool, Expr.mark_pos m];
+          args = [cond];
+        }
+    | Some true, Some true | Some false, Some false -> Mark.remove etrue
+    | _ -> (
+      match literal_bool cond with
+      | Some true -> Mark.remove etrue
+      | Some false -> Mark.remove efalse
+      | None -> EIfThenElse { cond; etrue; efalse })
+
+(* builds a [EMatch] term, flattening nested matches/if-then-else: the matching
+   arg branching are explored, and if they all lead to enum constructor
+   literals, the surrounding match cases are inlined. Code duplication is
+   detected and aborts the inlining. *)
+let simplified_match enum_name match_arg cases mark =
+  let max_duplicate_inlining_size = 3 in
+  let allow_duplicate_inlining_cases =
+    EnumConstructor.Map.fold
+      (fun cons f acc ->
+        if Expr.size f <= max_duplicate_inlining_size then
+          EnumConstructor.Set.add cons acc
+        else acc)
+      cases EnumConstructor.Set.empty
+  in
+  let app_cases cons e =
+    simplified_apply
+      (EnumConstructor.Map.find cons cases)
+      [e]
+      [Expr.maybe_ty (Mark.get e)]
+  in
+  let ret_ty = Expr.maybe_ty mark in
+  let rec aux seen_constrs = function
+    | EInj { cons; e; _ }, m ->
+      if EnumConstructor.Set.mem cons seen_constrs then raise Exit;
+      (* Abort inlining to avoid code duplication *)
+      let seen_constrs =
+        if EnumConstructor.Set.mem cons allow_duplicate_inlining_cases then
+          seen_constrs
+        else EnumConstructor.Set.add cons seen_constrs
+      in
+      seen_constrs, (app_cases cons e, Expr.with_ty m ret_ty)
+    | EMatch ({ cases; _ } as ematch), m ->
+      let seen_constrs, cases =
+        EnumConstructor.Map.fold
+          (fun cons case (seen_constrs, acc) ->
+            match case with
+            | EAbs ({ binder; _ } as eabs), m ->
+              let vars, body = Bindlib.unmbind binder in
+              let seen_constrs, body = aux seen_constrs body in
+              let binder = Bindlib.unbox (Expr.bind vars (Expr.rebox body)) in
+              let m =
+                Expr.map_ty
+                  (function
+                    | TArrow (args, _), pos -> TArrow (args, ret_ty), pos
+                    | (TAny, _) as t -> t
+                    | _ -> assert false)
+                  m
+              in
+              ( seen_constrs,
+                EnumConstructor.Map.add cons (EAbs { eabs with binder }, m) acc
+              )
+            | _ -> assert false)
+          cases
+          (seen_constrs, EnumConstructor.Map.empty)
+      in
+      seen_constrs, (EMatch { ematch with cases }, Expr.with_ty m ret_ty)
+    | EIfThenElse { cond; etrue; efalse }, m ->
+      let seen_constrs, etrue = aux seen_constrs etrue in
+      let seen_constrs, efalse = aux seen_constrs efalse in
+      let mark = Expr.with_ty m ret_ty in
+      seen_constrs, (simplified_ifthenelse cond etrue efalse mark, mark)
+    | _ -> raise Exit
+  in
+  try
+    let _seen_contrs, e = aux EnumConstructor.Set.empty match_arg in
+    Mark.remove e
+  with Exit ->
+    (* Optimisation was aborted due a non-terminal or code duplication *)
+    EMatch { e = match_arg; cases; name = enum_name }
 
 let rec optimize_expr :
     type a b.
@@ -108,59 +178,8 @@ let rec optimize_expr :
     | EAppOp { op = And, _; args = [(e, _); (ELit (LBool b), _)]; _ } ->
       (* reduction of logical and *)
       if b then e else ELit (LBool false)
-    | EMatch { e = EInj { e = e'; cons; name = n' }, _; cases; name = n }
-    (* iota-reduction *)
-      when EnumName.equal n n' -> (
-      (* match E x with | E y -> e1 = e1[y |-> x]*)
-      match Mark.remove @@ EnumConstructor.Map.find cons cases with
-      (* holds because of invariant_match_inversion *)
-      | EAbs { binder; _ } ->
-        Mark.remove
-          (Bindlib.msubst binder ([e'] |> List.map fst |> Array.of_list))
-      | _ -> assert false)
-    | EMatch { e = e'; cases; name = n } when all_match_cases_are_id_fun cases n
-      ->
-      (* iota-reduction when the match is equivalent to an identity function *)
-      Mark.remove e'
-    | EMatch
-        {
-          e = EMatch { e = arg; cases = cases1; name = n1 }, _;
-          cases = cases2;
-          name = n2;
-        }
-      when EnumName.equal n1 n2
-           && all_match_cases_map_to_same_constructor cases1 n1 ->
-      (* iota-reduction when the matched expression is itself a match of the
-         same enum mapping all constructors to themselves *)
-      let cases =
-        EnumConstructor.Map.merge
-          (fun _i o1 o2 ->
-            match o1, o2 with
-            | Some b1, Some e2 -> (
-              match Mark.remove b1, Mark.remove e2 with
-              | EAbs { binder = b1; _ }, EAbs { binder = b2; tys } -> (
-                let v1, e1 = Bindlib.unmbind b1 in
-                match Mark.remove e1 with
-                | EInj { e = e1, _; _ } ->
-                  Some
-                    (Expr.unbox
-                       (Expr.make_abs v1
-                          (Expr.rebox (Bindlib.msubst b2 [| e1 |]))
-                          tys (Expr.pos e2)))
-                | _ -> assert false)
-              | _ -> assert false)
-            | _ -> assert false)
-          cases1 cases2
-      in
-      EMatch { e = arg; cases; name = n1 }
-    | EApp { f = EAbs { binder; _ }, _; args; _ }
-      when binder_vars_used_at_most_once binder
-           || List.for_all
-                (function (EVar _ | ELit _), _ -> true | _ -> false)
-                args ->
-      (* beta reduction when variables not used, and for variable aliases and
-         literal *)
-      Mark.remove (Bindlib.msubst binder (List.map fst args |> Array.of_list))
+    | EMatch { name; e; cases } -> simplified_match name e cases mark
+    | EApp { f; args; tys } -> simplified_apply f args tys
     | EStructAccess { name; field; e = EStruct { name = name1; fields }, _ }
       when StructName.equal name name1 ->
       Mark.remove (StructField.Map.find field fields)
@@ -193,12 +212,7 @@ let rec optimize_expr :
           ->
           (* No exceptions with condition [true] *)
           Mark.remove cons
-        | ( [],
-            ( ( ELit (LBool false)
-              | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
-              _ ) ) ->
-          (* No exceptions and condition false *)
-          EEmpty
+        | [], cond -> simplified_ifthenelse cond cons (EEmpty, mark) mark
         | ( [except],
             ( ( ELit (LBool false)
               | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
@@ -206,49 +220,8 @@ let rec optimize_expr :
           (* Single exception and condition false *)
           Mark.remove except
         | excepts, just -> EDefault { excepts; just; cons })
-    | EIfThenElse
-        {
-          cond =
-            ( ELit (LBool true), _
-            | EAppOp { op = Log _, _; args = [(ELit (LBool true), _)]; _ }, _ );
-          etrue;
-          _;
-        } ->
-      Mark.remove etrue
-    | EIfThenElse
-        {
-          cond =
-            ( ( ELit (LBool false)
-              | EAppOp { op = Log _, _; args = [(ELit (LBool false), _)]; _ } ),
-              _ );
-          efalse;
-          _;
-        } ->
-      Mark.remove efalse
-    | EIfThenElse
-        {
-          cond;
-          etrue =
-            ( ( ELit (LBool btrue)
-              | EAppOp { op = Log _, _; args = [(ELit (LBool btrue), _)]; _ } ),
-              _ );
-          efalse =
-            ( ( ELit (LBool bfalse)
-              | EAppOp { op = Log _, _; args = [(ELit (LBool bfalse), _)]; _ }
-                ),
-              _ );
-        } ->
-      if btrue && not bfalse then Mark.remove cond
-      else if (not btrue) && bfalse then
-        EAppOp
-          {
-            op = Not, Expr.mark_pos mark;
-            tys = [TLit TBool, Expr.mark_pos mark];
-            args = [cond];
-          }
-        (* note: this last call eliminates the condition & might skip log calls
-           as well *)
-      else (* btrue = bfalse *) ELit (LBool btrue)
+    | EIfThenElse { cond; etrue; efalse } ->
+      simplified_ifthenelse cond etrue efalse mark
     | EAppOp { op = Op.Fold, _; args = [_f; init; (EArray [], _)]; _ } ->
       (*reduces a fold with an empty list *)
       Mark.remove init

--- a/tests/backends/output/simple.c
+++ b/tests/backends/output/simple.c
@@ -22,15 +22,10 @@ typedef struct Foo {
   double y;
 } Foo;
 
-typedef struct Array_3 {
-  double * content2;
-  int length2;
-} Array_3;
-
-typedef struct Array_2 {
-  Option_2 * content1;
-  int length1;
-} Array_2;
+typedef struct Array_1 {
+  double * content;
+  int length;
+} Array_1;
 
 enum Bar_code {
   Bar_No,
@@ -47,7 +42,7 @@ typedef struct Bar {
 
 typedef struct Baz {
   double b;
-  Array_3 c;
+  Array_1 c;
 } Baz;
 
 enum Option_3_code {
@@ -59,7 +54,7 @@ typedef struct Option_3 {
   enum Option_3_code code;
   union {
     void* /* unit */ None_3;
-    Array_3 Some_3;
+    Array_1 Some_3;
   } payload;
 } Option_3;
 
@@ -75,16 +70,6 @@ typedef struct Option_1 {
     Bar Some_1;
   } payload;
 } Option_1;
-
-typedef struct Array_4 {
-  Option_3 * content3;
-  int length3;
-} Array_4;
-
-typedef struct Array_1 {
-  Option_1 * content;
-  int length;
-} Array_1;
 
 typedef struct Tuple_1 {
   Option_1 (*elt_0)(void * /* closure_env */ arg_0_typ, void* /* unit */ arg_1_typ);
@@ -107,68 +92,20 @@ Baz baz(Baz_in baz_in) {
   void * /* closure_env */ env;
   code = code_and_env.elt_0;
   env = code_and_env.elt_1;
-  Array_1 a4;
-  a4.content_field = catala_malloc(sizeof(Array_1));
-  a4.content_field[0] = code(env, NULL);
-  Option_1 a3 = catala_handle_exceptions(a4);
+  Option_1 a3 = code(env, NULL);
   switch (a3.code) {
     case Option_1_None_1:
-      if (1 /* TRUE */) {
-        Bar a3;
-        option_1 a4;
-        option_1 a6;
-        Array_1 a7;
-        a7.content_field = catala_malloc(sizeof(Array_1));
-        
-        Option_1 a8 = catala_handle_exceptions(a7);
-        switch (a8.code) {
-          case Option_1_None_1:
-            if (1 /* TRUE */) {
-              Bar a6 = {Bar_No, {No: NULL}};
-              option_1 a6 = {Option_1_Some_1, {Some_1: a6}};
-              
-            } else {
-              option_1 a6 = {Option_1_None_1, {None_1: NULL}};
-              
-            }
-            break;
-          case Option_1_Some_1:
-            Bar x1 = a8.payload.Some_1;
-            option_1 a6 = {Option_1_Some_1, {Some_1: x1}};
-            break;
-        }
-        Array_1 a5;
-        a5.content_field = catala_malloc(sizeof(Array_1));
-        a5.content_field[0] = a6;
-        Option_1 a9 = catala_handle_exceptions(a5);
-        switch (a9.code) {
-          case Option_1_None_1:
-            if (0 /* FALSE */) {
-              option_1 a4 = {Option_1_None_1, {None_1: NULL}};
-              
-            } else {
-              option_1 a4 = {Option_1_None_1, {None_1: NULL}};
-              
-            }
-            break;
-          case Option_1_Some_1:
-            Bar x1 = a9.payload.Some_1;
-            option_1 a4 = {Option_1_Some_1, {Some_1: x1}};
-            break;
-        }
-        switch (a4.code) {
-          case Option_1_None_1:
-            catala_raise_fatal_error (catala_no_value,
-              "tests/backends/simple.catala_en", 11, 11, 11, 12);
-            break;
-          case Option_1_Some_1: Bar arg = a4.payload.Some_1; a3 = arg; break;
-        }
-        option_1 a3 = {Option_1_Some_1, {Some_1: a3}};
-        
-      } else {
-        option_1 a3 = {Option_1_None_1, {None_1: NULL}};
-        
+      Bar a3;
+      Bar a5 = {Bar_No, {No: NULL}};
+      option_1 a4 = {Option_1_Some_1, {Some_1: a5}};
+      switch (a4.code) {
+        case Option_1_None_1:
+          catala_raise_fatal_error (catala_no_value,
+            "tests/backends/simple.catala_en", 11, 11, 11, 12);
+          break;
+        case Option_1_Some_1: Bar arg = a4.payload.Some_1; a3 = arg; break;
       }
+      option_1 a3 = {Option_1_Some_1, {Some_1: a3}};
       break;
     case Option_1_Some_1:
       Bar x1 = a3.payload.Some_1;
@@ -186,11 +123,62 @@ Baz baz(Baz_in baz_in) {
   a1 = a2;
   double b2;
   option_2 b3;
-  option_2 b5;
-  option_2 b7;
-  ┌─[ERROR]─
-│
-│  Unexpected error: Not_found
-│
-└─
-#return code 125#
+  Option_2 b4;
+  char /* bool */ b5;
+  switch (a1.code) {
+    case Bar_No: b5 = 1 /* TRUE */; break;
+    case Bar_Yes: Foo _ = a1.payload.Yes; b5 = 0 /* FALSE */; break;
+  }
+  if (b5) {
+    option_2 b4 = {Option_2_Some_2, {Some_2: 42.}};
+    
+  } else {
+    option_2 b4 = {Option_2_None_2, {None_2: NULL}};
+    
+  }
+  switch (b4.code) {
+    case Option_2_None_2:
+      double b6;
+      switch (a1.code) {
+        case Bar_No: b6 = 0.; break;
+        case Bar_Yes:
+          Foo foo = a1.payload.Yes;
+          double b6;
+          if (foo.x) {b6 = 1.; } else {b6 = 0.; }
+          b6 = (foo.y + b6);
+          break;
+      }
+      option_2 b3 = {Option_2_Some_2, {Some_2: b6}};
+      break;
+    case Option_2_Some_2:
+      double x1 = b4.payload.Some_2;
+      option_2 b3 = {Option_2_Some_2, {Some_2: x1}};
+      break;
+  }
+  switch (b3.code) {
+    case Option_2_None_2:
+      catala_raise_fatal_error (catala_no_value,
+        "tests/backends/simple.catala_en", 12, 10, 12, 11);
+      break;
+    case Option_2_Some_2: double arg = b3.payload.Some_2; b2 = arg; break;
+  }
+  double b1;
+  b1 = b2;
+  array_1 c2;
+  Array_1 c4;
+  c4.content_field = catala_malloc(sizeof(Array_1));
+  c4.content_field[0] = b1;
+  c4.content_field[1] = b1;
+  option_3 c3 = {Option_3_Some_3, {Some_3: c4}};
+  switch (c3.code) {
+    case Option_3_None_3:
+      catala_raise_fatal_error (catala_no_value,
+        "tests/backends/simple.catala_en", 13, 10, 13, 11);
+      break;
+    case Option_3_Some_3: Array_1 arg = c3.payload.Some_3; c2 = arg; break;
+  }
+  Array_1 c1;
+  c1 = c2;
+  Baz Baz = { b1, c1 };
+  return Baz;
+}

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -91,30 +91,7 @@ class BIn:
 
 def some_name(some_name_in:SomeNameIn):
     i = (some_name_in.i_in)
-    o4 = (handle_exceptions([], []))
-    if o4 is None:
-        if True:
-            o3 = ((i + integer_of_string("1")))
-        else:
-            o3 = (None)
-    else:
-        x = o4
-        o3 = (x)
-    o5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/backends/python_name_clash.catala_en",
-                   start_line=10, start_column=23,
-                   end_line=10, end_column=28, law_headings=[])],
-              [o3]
-          ))
-    if o5 is None:
-        if False:
-            o2 = (None)
-        else:
-            o2 = (None)
-    else:
-        x = o5
-        o2 = (x)
+    o2 = ((i + integer_of_string("1")))
     if o2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/backends/python_name_clash.catala_en",
@@ -127,30 +104,7 @@ def some_name(some_name_in:SomeNameIn):
     return SomeName(o = o)
 
 def b(b_in:BIn):
-    result4 = (handle_exceptions([], []))
-    if result4 is None:
-        if True:
-            result3 = (integer_of_string("1"))
-        else:
-            result3 = (None)
-    else:
-        x = result4
-        result3 = (x)
-    result5 = (handle_exceptions(
-                   [SourcePosition(
-                        filename="tests/backends/python_name_clash.catala_en",
-                        start_line=16, start_column=33,
-                        end_line=16, end_column=34, law_headings=[])],
-                   [result3]
-               ))
-    if result5 is None:
-        if False:
-            result2 = (None)
-        else:
-            result2 = (None)
-    else:
-        x = result5
-        result2 = (x)
+    result2 = (integer_of_string("1"))
     if result2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/backends/python_name_clash.catala_en",
@@ -160,11 +114,11 @@ def b(b_in:BIn):
         arg = result2
         result1 = (arg)
     result = (some_name(SomeNameIn(i_in = result1)))
-    result6 = (SomeName(o = result.o))
+    result3 = (SomeName(o = result.o))
     if True:
-        some_name2 = (result6)
+        some_name2 = (result3)
     else:
-        some_name2 = (result6)
+        some_name2 = (result3)
     some_name1 = (some_name2)
     return B(some_name = some_name1)
 ```

--- a/tests/func/good/closure_conversion_reduce.catala_en
+++ b/tests/func/good/closure_conversion_reduce.catala_en
@@ -53,34 +53,22 @@ let scope S (S_in: S_in {x_in: list of integer}): S {y: integer} =
   let get x : list of integer = S_in.x_in in
   let set y : integer =
     match
-      (match
-         (handle_exceptions
-            [
-              match (handle_exceptions []) with
-              | ENone →
-                if true then
-                  ESome
-                    (let weights : list of (integer, integer) =
-                       map (λ (potential_max: integer) →
-                            (potential_max,
-                              let potential_max1 : integer = potential_max in
-                              potential_max1))
-                         x
-                     in
-                     reduce
-                       (λ (x1: (integer, integer)) (x2: (integer, integer)) →
-                        if x1.1 < x2.1 then x1 else x2)
-                       let potential_max : integer = -1 in
-                       (potential_max,
-                         let potential_max1 : integer = potential_max in
-                         potential_max1)
-                       weights).0
-                else ENone ()
-              | ESome x → ESome x
-            ])
-       with
-       | ENone → if false then ENone () else ENone ()
-       | ESome x → ESome x)
+      (ESome
+         (let weights : list of (integer, integer) =
+            map (λ (potential_max: integer) →
+                 (potential_max,
+                   let potential_max1 : integer = potential_max in
+                   potential_max1))
+              x
+          in
+          reduce
+            (λ (x1: (integer, integer)) (x2: (integer, integer)) →
+             if x1.1 < x2.1 then x1 else x2)
+            let potential_max : integer = -1 in
+            (potential_max,
+              let potential_max1 : integer = potential_max in
+              potential_max1)
+            weights).0)
     with
     | ENone → error NoValue
     | ESome arg → arg

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -130,11 +130,9 @@ let scope Foo
   let get b : ((closure_env, unit) → option bool, closure_env) =
     Foo_in.b_in
   in
-  let set b : bool =
-    match (handle_exceptions [b.0 b.1 ()]) with
-    | ENone → true
-    | ESome x → x
-  in
+  let set b : bool = match (b.0 b.1 ()) with
+                     | ENone → true
+                     | ESome x → x in
   let set r :
       Result {
         r: ((closure_env, integer) → integer, closure_env);

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -131,13 +131,9 @@ let scope Foo
     Foo_in.b_in
   in
   let set b : bool =
-    match
-      (match (handle_exceptions [b.0 b.1 ()]) with
-       | ENone → ESome true
-       | ESome x → ESome x)
-    with
-    | ENone → error NoValue
-    | ESome arg → arg
+    match (handle_exceptions [b.0 b.1 ()]) with
+    | ENone → true
+    | ESome x → x
   in
   let set r :
       Result {

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -26,29 +26,7 @@ end
 
 let s (s_in: S_in.t) : S.t =
   let sr: money =
-    match
-      (match
-         (handle_exceptions
-            [|{filename="tests/modules/good/mod_def.catala_en";
-               start_line=16; start_column=10; end_line=16; end_column=12;
-               law_headings=["Test modules + inclusions 1"]}|]
-            ([|(match
-                  (handle_exceptions
-                     [|{filename="tests/modules/good/mod_def.catala_en";
-                        start_line=29; start_column=24;
-                        end_line=29; end_column=30;
-                        law_headings=["Test modules + inclusions 1"]}|]
-                     ([||]))
-                with
-                | Eoption.ENone _ ->
-                    ( if true then
-                       (Eoption.ESome (money_of_cents_string "100000")) else
-                       (Eoption.ENone ()))
-                | Eoption.ESome x -> (Eoption.ESome x))|]))
-       with
-       | Eoption.ENone _ ->
-           ( if false then (Eoption.ENone ()) else (Eoption.ENone ()))
-       | Eoption.ESome x -> (Eoption.ESome x))
+    match (Eoption.ESome (money_of_cents_string "100000"))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
@@ -57,28 +35,7 @@ let s (s_in: S_in.t) : S.t =
                                                  law_headings=["Test modules + inclusions 1"]}])))
     | Eoption.ESome arg -> arg in
   let e1: Enum1.t =
-    match
-      (match
-         (handle_exceptions
-            [|{filename="tests/modules/good/mod_def.catala_en";
-               start_line=17; start_column=10; end_line=17; end_column=12;
-               law_headings=["Test modules + inclusions 1"]}|]
-            ([|(match
-                  (handle_exceptions
-                     [|{filename="tests/modules/good/mod_def.catala_en";
-                        start_line=30; start_column=24;
-                        end_line=30; end_column=29;
-                        law_headings=["Test modules + inclusions 1"]}|]
-                     ([||]))
-                with
-                | Eoption.ENone _ ->
-                    ( if true then (Eoption.ESome (Enum1.Maybe ())) else
-                       (Eoption.ENone ()))
-                | Eoption.ESome x -> (Eoption.ESome x))|]))
-       with
-       | Eoption.ENone _ ->
-           ( if false then (Eoption.ENone ()) else (Eoption.ENone ()))
-       | Eoption.ESome x -> (Eoption.ESome x))
+    match (Eoption.ESome (Enum1.Maybe ()))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";

--- a/tests/monomorphisation/context_var.catala_en
+++ b/tests/monomorphisation/context_var.catala_en
@@ -14,10 +14,6 @@ type option_1 = | None_1 of unit | Some_1 of bool
 
 type TestXor_in = { t_in: unit → option_1[None_1: unit | Some_1: bool]; }
 type TestXor = { t: bool; }
-type array_1 = {
-  content: list of option_1[None_1: unit | Some_1: bool];
-  length: integer;
-}
 
 let scope TestXor
   (TestXor_in:
@@ -29,35 +25,12 @@ let scope TestXor
   in
   let set t : bool =
     match
-      (match
-         (handle_exceptions { array_1 content = [t ()]; length = 1; })
-       with
+      (match (t ()) with
        | None_1 →
-         if true then
-           Some_1
-             (match
-                (match
-                   (handle_exceptions
-                      { array_1
-                        content =
-                          [
-                            match
-                              (handle_exceptions
-                                 { array_1 content = []; length = 0; })
-                            with
-                            | None_1 →
-                              if true then Some_1 true else None_1 ()
-                            | Some_1 x → Some_1 x
-                          ];
-                        length = 1;
-                      })
-                 with
-                 | None_1 → if false then None_1 () else None_1 ()
-                 | Some_1 x → Some_1 x)
-              with
-              | None_1 → error NoValue
-              | Some_1 arg → arg)
-         else None_1 ()
+         Some_1
+           (match (Some_1 true) with
+            | None_1 → error NoValue
+            | Some_1 arg → arg)
        | Some_1 x → Some_1 x)
     with
     | None_1 → error NoValue
@@ -85,24 +58,7 @@ let scope TestXor2 (TestXor2_in: TestXor2_in): TestXor2 {o: bool} =
     if true then result1 else result1
   in
   let set o : bool =
-    match
-      (match
-         (handle_exceptions
-            { array_1
-              content =
-                [
-                  match
-                    (handle_exceptions { array_1 content = []; length = 0; })
-                  with
-                  | None_1 → if true then Some_1 t.t else None_1 ()
-                  | Some_1 x → Some_1 x
-                ];
-              length = 1;
-            })
-       with
-       | None_1 → if false then None_1 () else None_1 ()
-       | Some_1 x → Some_1 x)
-    with
+    match (Some_1 t.t) with
     | None_1 → error NoValue
     | Some_1 arg → arg
   in

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -54,50 +54,23 @@ let s (s_in: S_in.t) : S.t =
   let a: unit -> (bool) Eoption.t = s_in.S_in.a_in in
   let a1: bool =
     match
-      (match
-         (handle_exceptions
-            [|{filename="tests/name_resolution/good/let_in2.catala_en";
-               start_line=7; start_column=18; end_line=7; end_column=19;
-               law_headings=["Article"]}|] ([|(a ())|]))
+      (match (a ())
        with
        | Eoption.ENone _ ->
-           ( if true then
-              (Eoption.ESome
-                 (match
-                    (match
-                       (handle_exceptions
-                          [|{filename="tests/name_resolution/good/let_in2.catala_en";
-                             start_line=7; start_column=18;
-                             end_line=7; end_column=19;
-                             law_headings=["Article"]}|]
-                          ([|(match
-                                (handle_exceptions
-                                   [|{filename="tests/name_resolution/good/let_in2.catala_en";
-                                      start_line=11; start_column=5;
-                                      end_line=13; end_column=6;
-                                      law_headings=["Article"]}|] ([||]))
-                              with
-                              | Eoption.ENone _1 ->
-                                  ( if true then
-                                     (Eoption.ESome (let a1 : bool = false
-                                        in
-                                        (let a2 : bool = (o_or a1 true)
-                                        in
-                                        a2))) else (Eoption.ENone ()))
-                              | Eoption.ESome x -> (Eoption.ESome x))|]))
-                     with
-                     | Eoption.ENone _1 ->
-                         ( if false then (Eoption.ENone ()) else
-                            (Eoption.ENone ()))
-                     | Eoption.ESome x -> (Eoption.ESome x))
-                  with
-                  | Eoption.ENone _1 -> (raise
-                      (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
-                                                               start_line=7; start_column=18;
-                                                               end_line=7; end_column=19;
-                                                               law_headings=
-                                                               ["Article"]}])))
-                  | Eoption.ESome arg -> arg)) else (Eoption.ENone ()))
+           (Eoption.ESome
+              (match
+                 (Eoption.ESome (let a1 : bool = false
+                    in
+                    (let a2 : bool = (o_or a1 true) in
+                    a2)))
+               with
+               | Eoption.ENone _1 -> (raise
+                   (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
+                                                            start_line=7; start_column=18;
+                                                            end_line=7; end_column=19;
+                                                            law_headings=
+                                                            ["Article"]}])))
+               | Eoption.ESome arg -> arg))
        | Eoption.ESome x -> (Eoption.ESome x))
     with
     | Eoption.ENone _ -> (raise

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -126,26 +126,7 @@ let glob2 = A {"y": glob1 >= 30., "z": 123. * 17.}
 
 let S2 (S2_in: S2_in) =
   decl a1 : decimal;
-  decl a2 : option decimal;
-  decl a3 : option decimal;
-  a4 : option decimal = handle_exceptions [];
-  switch a4:
-  | ENone _ →
-    if true:
-      a3 = ESome glob3 ¤44.00 + 100.
-      else:
-        a3 = ENone ()
-  | ESome x →
-    a3 = ESome x;
-  a5 : option decimal = handle_exceptions [a3];
-  switch a5:
-  | ENone _ →
-    if false:
-      a2 = ENone ()
-      else:
-        a2 = ENone ()
-  | ESome x →
-    a2 = ESome x;
+  a2 : option decimal = ESome glob3 ¤44.00 + 100.;
   switch a2:
   | ENone _ →
     fatal NoValue
@@ -157,26 +138,7 @@ let S2 (S2_in: S2_in) =
 
 let S3 (S3_in: S3_in) =
   decl a1 : decimal;
-  decl a2 : option decimal;
-  decl a3 : option decimal;
-  a4 : option decimal = handle_exceptions [];
-  switch a4:
-  | ENone _ →
-    if true:
-      a3 = ESome 50. + glob4 ¤44.00 55.
-      else:
-        a3 = ENone ()
-  | ESome x →
-    a3 = ESome x;
-  a5 : option decimal = handle_exceptions [a3];
-  switch a5:
-  | ENone _ →
-    if false:
-      a2 = ENone ()
-      else:
-        a2 = ENone ()
-  | ESome x →
-    a2 = ESome x;
+  a2 : option decimal = ESome 50. + glob4 ¤44.00 55.;
   switch a2:
   | ENone _ →
     fatal NoValue
@@ -188,26 +150,7 @@ let S3 (S3_in: S3_in) =
 
 let S4 (S4_in: S4_in) =
   decl a1 : decimal;
-  decl a2 : option decimal;
-  decl a3 : option decimal;
-  a4 : option decimal = handle_exceptions [];
-  switch a4:
-  | ENone _ →
-    if true:
-      a3 = ESome glob5 + 1.
-      else:
-        a3 = ENone ()
-  | ESome x →
-    a3 = ESome x;
-  a5 : option decimal = handle_exceptions [a3];
-  switch a5:
-  | ENone _ →
-    if false:
-      a2 = ENone ()
-      else:
-        a2 = ENone ()
-  | ESome x →
-    a2 = ESome x;
+  a2 : option decimal = ESome glob5 + 1.;
   switch a2:
   | ENone _ →
     fatal NoValue
@@ -219,26 +162,7 @@ let S4 (S4_in: S4_in) =
 
 let S (S_in: S_in) =
   decl a1 : decimal;
-  decl a2 : option decimal;
-  decl a3 : option decimal;
-  a4 : option decimal = handle_exceptions [];
-  switch a4:
-  | ENone _ →
-    if true:
-      a3 = ESome glob1 * glob1
-      else:
-        a3 = ENone ()
-  | ESome x →
-    a3 = ESome x;
-  a5 : option decimal = handle_exceptions [a3];
-  switch a5:
-  | ENone _ →
-    if false:
-      a2 = ENone ()
-      else:
-        a2 = ENone ()
-  | ESome x →
-    a2 = ESome x;
+  a2 : option decimal = ESome glob1 * glob1;
   switch a2:
   | ENone _ →
     fatal NoValue
@@ -247,26 +171,7 @@ let S (S_in: S_in) =
   decl a : decimal;
   a = a1;
   decl b1 : A {y: bool; z: decimal};
-  decl b2 : option A {y: bool; z: decimal};
-  decl b3 : option A {y: bool; z: decimal};
-  b4 : option A {y: bool; z: decimal} = handle_exceptions [];
-  switch b4:
-  | ENone _ →
-    if true:
-      b3 = ESome glob2
-      else:
-        b3 = ENone ()
-  | ESome x →
-    b3 = ESome x;
-  b5 : option A {y: bool; z: decimal} = handle_exceptions [b3];
-  switch b5:
-  | ENone _ →
-    if false:
-      b2 = ENone ()
-      else:
-        b2 = ENone ()
-  | ESome x →
-    b2 = ESome x;
+  b2 : option A {y: bool; z: decimal} = ESome glob2;
   switch b2:
   | ENone _ →
     fatal NoValue
@@ -456,32 +361,7 @@ glob6 = (
 )
 
 def s2(s2_in:S2In):
-    a4 = (handle_exceptions([], []))
-    if a4 is None:
-        if True:
-            a3 = ((glob3(money_of_cents_string("4400")) +
-                decimal_of_string("100.")))
-        else:
-            a3 = (None)
-    else:
-        x = a4
-        a3 = (x)
-    a5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=53, start_column=24,
-                   end_line=53, end_column=43,
-                   law_headings=["Test toplevel function defs"])],
-              [a3]
-          ))
-    if a5 is None:
-        if False:
-            a2 = (None)
-        else:
-            a2 = (None)
-    else:
-        x = a5
-        a2 = (x)
+    a2 = ((glob3(money_of_cents_string("4400")) + decimal_of_string("100.")))
     if a2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/name_resolution/good/toplevel_defs.catala_en",
@@ -495,33 +375,8 @@ def s2(s2_in:S2In):
     return S2(a = a)
 
 def s3(s3_in:S3In):
-    a4 = (handle_exceptions([], []))
-    if a4 is None:
-        if True:
-            a3 = ((decimal_of_string("50.") +
-                glob4(money_of_cents_string("4400"),
-                      decimal_of_string("55."))))
-        else:
-            a3 = (None)
-    else:
-        x = a4
-        a3 = (x)
-    a5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=74, start_column=24,
-                   end_line=74, end_column=47,
-                   law_headings=["Test function def with two args"])],
-              [a3]
-          ))
-    if a5 is None:
-        if False:
-            a2 = (None)
-        else:
-            a2 = (None)
-    else:
-        x = a5
-        a2 = (x)
+    a2 = ((decimal_of_string("50.") +
+        glob4(money_of_cents_string("4400"), decimal_of_string("55."))))
     if a2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/name_resolution/good/toplevel_defs.catala_en",
@@ -535,31 +390,7 @@ def s3(s3_in:S3In):
     return S3(a = a)
 
 def s4(s4_in:S4In):
-    a4 = (handle_exceptions([], []))
-    if a4 is None:
-        if True:
-            a3 = ((glob5 + decimal_of_string("1.")))
-        else:
-            a3 = (None)
-    else:
-        x = a4
-        a3 = (x)
-    a5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=98, start_column=24,
-                   end_line=98, end_column=34,
-                   law_headings=["Test inline defs in toplevel defs"])],
-              [a3]
-          ))
-    if a5 is None:
-        if False:
-            a2 = (None)
-        else:
-            a2 = (None)
-    else:
-        x = a5
-        a2 = (x)
+    a2 = ((glob5 + decimal_of_string("1.")))
     if a2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/name_resolution/good/toplevel_defs.catala_en",
@@ -573,31 +404,7 @@ def s4(s4_in:S4In):
     return S4(a = a)
 
 def s5(s_in:SIn):
-    a4 = (handle_exceptions([], []))
-    if a4 is None:
-        if True:
-            a3 = ((glob1 * glob1))
-        else:
-            a3 = (None)
-    else:
-        x = a4
-        a3 = (x)
-    a5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=18, start_column=24,
-                   end_line=18, end_column=37,
-                   law_headings=["Test basic toplevel values defs"])],
-              [a3]
-          ))
-    if a5 is None:
-        if False:
-            a2 = (None)
-        else:
-            a2 = (None)
-    else:
-        x = a5
-        a2 = (x)
+    a2 = ((glob1 * glob1))
     if a2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/name_resolution/good/toplevel_defs.catala_en",
@@ -608,31 +415,7 @@ def s5(s_in:SIn):
         arg = a2
         a1 = (arg)
     a = (a1)
-    b4 = (handle_exceptions([], []))
-    if b4 is None:
-        if True:
-            b3 = (glob6)
-        else:
-            b3 = (None)
-    else:
-        x = b4
-        b3 = (x)
-    b5 = (handle_exceptions(
-              [SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=19, start_column=24,
-                   end_line=19, end_column=29,
-                   law_headings=["Test basic toplevel values defs"])],
-              [b3]
-          ))
-    if b5 is None:
-        if False:
-            b2 = (None)
-        else:
-            b2 = (None)
-    else:
-        x = b5
-        b2 = (x)
+    b2 = (glob6)
     if b2 is None:
         raise NoValue(SourcePosition(
                           filename="tests/name_resolution/good/toplevel_defs.catala_en",

--- a/tests/scope/good/simple.catala_en
+++ b/tests/scope/good/simple.catala_en
@@ -24,18 +24,7 @@ $ catala Typecheck --check-invariants
 $ catala Lcalc -s Foo
 let scope Foo (Foo_in: Foo_in): Foo {bar: integer} =
   let set bar : integer =
-    match
-      (match
-         (handle_exceptions
-            [
-              match (handle_exceptions []) with
-              | ENone → if true then ESome 0 else ENone ()
-              | ESome x → ESome x
-            ])
-       with
-       | ENone → if false then ENone () else ENone ()
-       | ESome x → ESome x)
-    with
+    match (ESome 0) with
     | ENone → error NoValue
     | ESome arg → arg
   in


### PR DESCRIPTION
This PR has two related patches, but with different scopes:

- When translating default terms from dcalc to matches with the
  `HandleExceptions` operator in dcalc, be a little more clever when there is 0
  or 1 exception. This makes un-optimised code much more readable, which is very
  helpful for debugging

- During the optimisation pass, handling of nested matches is generalised from
  the few specific cases that were handled. When a matched term has only literal
  constructors in terminal position, the surrounding match cases are inlined as
  long as this doesn't lead to code duplication.

  This should be robust and preserve traces, and is particularly helpful with
  nested option matches that really obfuscate the resulting code. For example,
  we can get the following code for a top-level definition in lcalc:

```
let set requirements_ownership_met : bool =
  (aggregate_periods_from_last_five_years.0
     aggregate_periods_from_last_five_years.1
     property_ownage)
  >= [0 years, 0 months, 730 days]
```

while we previously had 4 levels of nesting (and of course this
code still has gone through all the expected exceptions-related
validations)