### PR TITLE
Testing CI update

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -119,6 +119,7 @@ jobs:
       options: --user root
       env:
         DUNE_PROFILE: release
+        OPAMSWITCH: /home/ocaml/catala
     steps:
       - name: Fix home
         # Workaround Github actions issue, see
@@ -185,7 +186,7 @@ jobs:
           mv catala/_build/default/_doc/_html artifacts/api-doc
           mv catala/doc/syntax/syntax.pdf artifacts/
           mv catala/_build/default/*.html artifacts/
-          mv ~/.opam/catala/doc/catala-examples/tuto*/*.html artifacts/
+          mv catala/_opam/doc/catala-examples/tuto*/*.html artifacts/
           tar cz -hf "artifacts/french-law_ocaml.tar.gz" -C french-law/_build/install/default/lib french-law
           cp catala-examples/_build/french-law_npm.tar.gz artifacts/
           cp catala-examples/_build/french_law_python.tar.gz artifacts/

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install LaTeX deps
         # This is done late because caching would not benefit compared to
         # installation through apk (1,5G upload is slow)
-        run: sudo apk add texlive-xetex texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff
+        run: sudo apk add texlive-xetex texlive-dvi texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff
         # Fewer texmf deps should be required once
         # https://gitlab.alpinelinux.org/alpine/aports/-/issues/16190 is fixed
       - name: Build Catala extra docs

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Install LaTeX deps
         # This is done late because caching would not benefit compared to
         # installation through apk (1,5G upload is slow)
-        run: sudo apk add texlive-xetex texlive-dvi texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff
+        run: sudo apk add texlive-xetex texlive-dvi texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff libpng
         # Fewer texmf deps should be required once
         # https://gitlab.alpinelinux.org/alpine/aports/-/issues/16190 is fixed
       - name: Build Catala extra docs

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
     tags: ['*.*.*']
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
   # It is important to use `pull_request_target` and not `pull_request` here: it
   # means the version of this file from master is used rather than the one from
   # the PR. This allows writing to the docker caches, etc. from PRs ; but mind
@@ -127,7 +127,7 @@ jobs:
       - name: Install LaTeX deps
         # This is done late because caching would not benefit compared to
         # installation through apk (1,5G upload is slow)
-        run: sudo apk add texlive-xetex texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff texmf-dist-lang
+        run: sudo apk add texlive-xetex texmf-dist-latexextra texmf-dist-binextra texmf-dist-pictures texmf-dist-fontsrecommended font-dejavu groff
         # Fewer texmf deps should be required once
         # https://gitlab.alpinelinux.org/alpine/aports/-/issues/16190 is fixed
       - name: Build Catala extra docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # STAGE 1: setup an opam switch with all dependencies installed
 #
 # (only depends on the opam files)
-FROM ocamlpro/ocaml:4.14-2024-05-26 AS dev-build-context
+FROM ocamlpro/ocaml:4.14-2024-08-25 AS dev-build-context
 # Image from https://hub.docker.com/r/ocamlpro/ocaml
 
 RUN mkdir catala
@@ -18,12 +18,8 @@ ENV OPAMVAR_catalaz3mode=1
 # Get a switch with all the dependencies installed
 # DON'T run 'opam update' here. Instead use a newer parent Docker image
 # (update the 'FROM' line above)
-RUN opam --cli=2.1 switch create catala ocaml-system && \
-    opam --cli=2.1 install . --with-test --with-doc --depext-only && \
-    opam --cli=2.1 install . --with-test --with-doc --deps-only && \
+RUN opam --cli=2.2 switch create . --deps-only --with-test --with-doc && \
     opam clean
-# Note: just `opam switch create . --deps-only --with-test --with-doc && opam clean`
-# should be enough once opam 2.2 is released (see opam#5185)
 
 #
 # STAGE 2: get the whole repo and build


### PR DESCRIPTION
- alpine 3.20 fixed its latex packages
- opam 2.2 was released which means we can finally simplify depext setup instructions

NOTE: **do not merge as is** this changes the PR target stuff