### PR TITLE
Add the possibility to override inputs of included files

### DIFF
--- a/compiler/surface/parser_driver.mli
+++ b/compiler/surface/parser_driver.mli
@@ -32,7 +32,11 @@ val load_interface :
     keeps type information. The list of submodules is initialised with names
     only and empty contents. *)
 
-val parse_top_level_file : File.t Global.input_src -> Ast.program
+val parse_top_level_file :
+  ?resolve_included_file:(string -> string Global.input_src) ->
+  File.t Global.input_src ->
+  Ast.program
 (** Parses a catala file (handling file includes) and returns a program.
     Interfaces of the used modules are returned empty, use [load_interface] to
-    fill them. *)
+    fill them. When provided [resolve_included_file] replaces file includes with
+    an user provided input source. *)


### PR DESCRIPTION
In the LSP server, when we try to process files that are included in an encapsulating file/module, we handle them by internally compiling an equivalent (fake) module in order to be able to retrieve appropriate errors. However, the parser expand those includes by reloading the given file when we would actually want to consider the actual state of the buffer/document which is potentially unsaved.

This PR adds an overriding mechanism which allows to replace inlined files by user-provided input sources.