### PR TITLE
Fix OCaml backend bug regarding exception source positions

### DIFF
--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -400,11 +400,14 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
         | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_rat | Div_dur_dur ->
           Format.fprintf ppf "%a@ " format_pos (Expr.pos (List.nth args 1))
         | HandleExceptions ->
+          let excs =
+            match args with [(EArray ex, _)] -> ex | _ -> assert false
+          in
           Format.fprintf ppf "[|@[<hov>%a@]|]@ "
             (Format.pp_print_list
                ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
                format_pos)
-            (List.map Expr.pos args)
+            (List.map Expr.pos excs)
         | _ -> ())
       (Format.pp_print_list
          ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")

--- a/tests/modules/bool.catala_en
+++ b/tests/modules/bool.catala_en
@@ -1,0 +1,22 @@
+> Module Bool
+
+```catala-metadata
+declaration scope A:
+  input x content integer
+  input add_meaning_of_life content boolean
+  output out content integer
+```
+
+```catala
+scope A:
+  definition out equals x
+  definition out under condition add_meaning_of_life consequence equals x + 42
+```
+
+
+```catala-test-inline
+$ catala typecheck
+┌─[RESULT]─
+│ Typechecking successful!
+└─
+```

--- a/tests/modules/test_case_bool.catala_en
+++ b/tests/modules/test_case_bool.catala_en
@@ -1,0 +1,31 @@
+> Using Bool
+
+```catala
+declaration scope A_test:
+  output aout scope Bool.A
+
+scope A_test:
+  definition aout.x equals 22
+  definition aout.add_meaning_of_life equals true
+```
+
+
+```catala-test-inline
+$ catala interpret -s A_test
+┌─[ERROR]─
+│
+│  During evaluation: conflict between multiple valid consequences for
+│  assigning the same variable.
+│
+├─➤ tests/modules/bool.catala_en:12.25-12.26:
+│    │
+│ 12 │   definition out equals x
+│    │                         ‾
+│
+├─➤ tests/modules/bool.catala_en:13.73-13.79:
+│    │
+│ 13 │   definition out under condition add_meaning_of_life consequence equals x + 42
+│    │                                                                         ‾‾‾‾‾‾
+└─
+#return code 123#
+```


### PR DESCRIPTION
Without the fix, the code would contain an array of length 1 for the positions, and printing the conflict message would result in an `Array_out_of_bounds` exception.