### PR TITLE
Fix inconsistent marks

### DIFF
--- a/compiler/catala_utils/uid.ml
+++ b/compiler/catala_utils/uid.ml
@@ -30,6 +30,7 @@ module type Id = sig
 
   val fresh : info -> t
   val get_info : t -> info
+  val map_info : (info -> info) -> t -> t
   val compare : t -> t -> int
   val equal : t -> t -> bool
   val format : Format.formatter -> t -> unit
@@ -70,6 +71,7 @@ module Make (X : Info) (S : Style) () : Id with type info = X.info = struct
     { id = !counter; info }
 
   let get_info (uid : t) : X.info = uid.info
+  let map_info f { id; info } = { id; info = f info }
   let id (x : t) : int = x.id
   let to_string t = X.to_string t.info
   let hash t = X.hash t.info

--- a/compiler/catala_utils/uid.mli
+++ b/compiler/catala_utils/uid.mli
@@ -47,6 +47,7 @@ module type Id = sig
 
   val fresh : info -> t
   val get_info : t -> info
+  val map_info : (info -> info) -> t -> t
   val compare : t -> t -> int
   val equal : t -> t -> bool
   val format : Format.formatter -> t -> unit


### PR DESCRIPTION
During the development of the Catala's LSP, I encountered weird cases where locations of structures and enumerations references and fields were inconsistent. These were overwrote by the position of their declaration.

This PR fixes this issue and retain the original mark for these constructs. While trying to do so, I needed a way to edit positions. I first tried to amend structures & enums ast nodes but the diff quickly bloated up. 
I settled for a compromise where I added a way to patch an existing `Uid`'s info which slightly breaks the abstraction but makes the changes quite trivial.