### PR TITLE
Fix handling of the lexer context

### DIFF
--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -328,8 +328,8 @@ let run_tests ~catala_exe ~catala_opts ~test_flags ~report ~out filename =
       push_line str;
       run_inline_test lines
     | Some ((str, L.LINE_TEST id, _), lines) ->
-      push_line str;
-      run_output_test id lines
+      run_output_test id lines;
+      push_line str
     | Some ((str, _, _), lines) ->
       push_line str;
       process lines

--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -387,7 +387,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
   | "```" ->
       (* End of code section *)
       L.context := Law;
-      END_CODE (Buffer.contents L.code_buffer)
+      END_CODE (L.flush_acc ())
   | MR_SCOPE ->
       L.update_acc lexbuf;
       SCOPE
@@ -797,11 +797,9 @@ let lex_law (lexbuf : lexbuf) : token =
     | eof -> EOF
     | "```catala", Star white_space, ('\n' | eof) ->
         L.context := Code;
-        Buffer.clear L.code_buffer;
         BEGIN_CODE
     | "```catala-metadata", Star white_space, ('\n' | eof) ->
         L.context := Code;
-        Buffer.clear L.code_buffer;
         BEGIN_METADATA
     | "```", Star (idchar | '-') ->
         L.context := Raw;
@@ -832,7 +830,8 @@ let lexer (lexbuf : lexbuf) : token =
   | Code -> lex_code lexbuf
   | Directive -> lex_directive lexbuf
   | Directive_args -> lex_directive_args lexbuf
-
+  | Inactive ->
+    Message.error ~internal:true "Lexer started outside of an initialised context."
 
 (* -- Shallow lexing for dependency extraction -- *)
 

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -15,21 +15,30 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
+open Catala_utils
+
 (** Auxiliary functions used by all lexers. *)
 
-type lexing_context = Law | Raw | Code | Directive | Directive_args
+type lexing_context = Law | Raw | Code | Directive | Directive_args | Inactive
+
+val with_lexing_context : File.t -> (unit -> 'a) -> 'a
+(** Initialises the lexing context during the call of the supplied function,
+    which is required for using the lexer. Calls can be nested. Upon
+    termination, emits a warning if the lexer is not in a consistent state
+    ([Law] context, no pending code content) *)
 
 val context : lexing_context ref
 (** Reference, used by the lexer as the mutable state to distinguish whether it
     is lexing code or law. *)
 
-val code_buffer : Buffer.t
-(** Buffer that accumulates the string representation of the body of code being
-    lexed. This string representation is used in the literate programming
+val update_acc : Sedlexing.lexbuf -> unit
+(** Updates the current code buffer with the current lexeme. The underlying
+    buffer is used to accumulate the string representation of the body of code
+    being lexed. This string representation is used in the literate programming
     backends to faithfully capture the spacing pattern of the original program *)
 
-val update_acc : Sedlexing.lexbuf -> unit
-(** Updates {!val:code_buffer} with the current lexeme *)
+val flush_acc : unit -> string
+(** Flushes the code buffer and returns its contents (see [update_acc]) *)
 
 exception Lexing_error of (Catala_utils.Pos.t * string)
 

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -268,9 +268,14 @@ module ParserAux (LocalisedLexer : Lexer_common.LocalisedLexer) = struct
       (* The encapsulating [Message.with_delayed_errors] will raise an
          exception: we are safe returning a dummy value. *)
       Message.delayed_error ~kind:Lexing [] ~pos
-        "Parsing error after token \"%s\": what comes after is unknown" token
+        "Parsing error after token \"%s\": what comes after could not be \
+         recognised"
+        token
 
   let commands_or_includes (lexbuf : lexbuf) : Ast.source_file =
+    Lexer_common.with_lexing_context
+      (fst (Sedlexing.lexing_positions lexbuf)).pos_fname
+    @@ fun () ->
     sedlex_with_menhir LocalisedLexer.lexer LocalisedLexer.token_list
       Incremental.source_file lexbuf
 end

--- a/runtimes/c/dune
+++ b/runtimes/c/dune
@@ -20,8 +20,19 @@
  (target runtime-test.c.exe)
  (action
   (run
-   %{cc} --std=c89 -Wall -Werror -pedantic %{dep:runtime-test.c} -I. %{dep:catala_runtime.a} -lgmp -o %{target})))
+   %{cc}
+   --std=c89
+   -Wall
+   -Werror
+   -pedantic
+   %{dep:runtime-test.c}
+   -I.
+   %{dep:catala_runtime.a}
+   -lgmp
+   -o
+   %{target})))
 
 (rule
  (alias runtest)
- (action (run ./runtime-test.c.exe)))
+ (action
+  (run ./runtime-test.c.exe)))


### PR DESCRIPTION
The lexing context uses a global reference. This patch ensures it is handled carefully for the lifetime of lexing a given file.

Before that, very weird bugs could happen, for example when a file ended with an unclosed verbatim block, the parsing of module interfaces done later on would start in verbatim context and fail to parse e.g. module use definitions.

The patch additionally adds checks and warns about unclosed blocks at EOF, which before that would be silently accepted (with the above pitfall).