### PR TITLE
Dcalc: don't thunk context inputs anymore

### DIFF
--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -146,7 +146,7 @@ module To_jsoo = struct
         elts
     | TOption t ->
       Format.fprintf fmt
-        "(fun o -> Js.Opt.case o (fun () -> Eoption.ENone) (fun x -> \
+        "(fun o -> Js.Opt.case o (fun () -> Eoption.ENone ()) (fun x -> \
          Eoption.ESome (%a x)))"
         format_of_js t
     | TAny -> Format.fprintf fmt "Js.Unsafe.inject"

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -212,6 +212,8 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
                         | _ ->
                           (* same as basic [EAbs case]*)
                           generate_vc_must_not_return_empty ctx field)
+                      | EEmpty -> Mark.copy field (ELit (LBool true))
+                      | EPureDefault _ -> Mark.copy field (ELit (LBool false))
                       | _ -> generate_vc_must_not_return_empty ctx field)
                     (StructField.Map.values fields)
                 | _ -> [generate_vc_must_not_return_empty ctx arg])

--- a/tests/backends/output/simple.c
+++ b/tests/backends/output/simple.c
@@ -30,18 +30,14 @@ typedef struct Bar {
 } Bar;
 
 typedef struct Baz_in {
-  const catala_closure* a_in;
+  const CATALA_OPTION(Bar*) a_in;
 } Baz_in;
 
 static const Baz* baz (const Baz_in* baz_in)
 {
-  const catala_closure* a = baz_in->a_in;
+  const CATALA_OPTION(Bar*) a = baz_in->a_in;
   const Bar* a__1;
   const CATALA_OPTION(Bar*) a__2;
-  const catala_closure* code_and_env = a;
-  const CATALA_OPTION(Bar*) a__3 =
-    ((const CATALA_OPTION(Bar*)(*)(const CLOSURE_ENV, CATALA_UNIT))
-     code_and_env->funcp)(code_and_env->env, CATALA_UNITVAL);
   CATALA_DEC b;
   const CATALA_OPTION(CATALA_DEC) b__1;
   const CATALA_OPTION(CATALA_DEC) b__2;
@@ -50,24 +46,24 @@ static const Baz* baz (const Baz_in* baz_in)
   CATALA_ARRAY(CATALA_DEC) const c__2 = catala_malloc(sizeof(catala_array));
   const CATALA_OPTION(CATALA_ARRAY(CATALA_DEC)) c__1;
   Baz* const baz__1 = catala_malloc(sizeof(Baz));
-  if (a__3->code == catala_option_some) {
-    a__2 = catala_some(a__3->payload);
+  if (a->code == catala_option_some) {
+    a__2 = catala_some(a->payload);
   } else {
-    const Bar* a__4;
-    Bar* const a__6 = catala_malloc(sizeof(Bar));
-    const CATALA_OPTION(Bar*) a__5;
-    a__6->code = NO;
-    a__6->payload.NO = CATALA_UNITVAL;
-    a__5 = catala_some(a__6);
-    if (a__5->code == catala_option_some) {
-      a__4 = a__5->payload;
+    const Bar* a__3;
+    Bar* const a__5 = catala_malloc(sizeof(Bar));
+    const CATALA_OPTION(Bar*) a__4;
+    a__5->code = NO;
+    a__5->payload.NO = CATALA_UNITVAL;
+    a__4 = catala_some(a__5);
+    if (a__4->code == catala_option_some) {
+      a__3 = a__4->payload;
     } else {
       static const catala_code_position pos[1] =
         {{"tests/backends/simple.catala_en", 11, 11, 11, 12}};
       catala_error(catala_no_value, pos);
       abort();
     }
-    a__2 = catala_some(a__4);
+    a__2 = catala_some(a__3);
   }
   if (a__2->code == catala_option_some) {
     a__1 = a__2->payload;

--- a/tests/bool/good/test_bool.catala_en
+++ b/tests/bool/good/test_bool.catala_en
@@ -27,15 +27,14 @@ $ catala Typecheck --check-invariants
 $ catala Dcalc 
 let TestBool : TestBool_in → TestBool =
   λ (TestBool_in: TestBool_in) →
-  let foo : unit → ⟨bool⟩ = TestBool_in.foo_in in
-  let bar : unit → ⟨integer⟩ = TestBool_in.bar_in in
+  let foo : ⟨bool⟩ = TestBool_in.foo_in in
+  let bar : ⟨integer⟩ = TestBool_in.bar_in in
   let bar1 : integer =
-    error_empty
-      ⟨ bar () | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
+    error_empty ⟨ bar | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
   in
   let foo1 : bool =
     error_empty
-      ⟨ foo ()
+      ⟨ foo
       | true
         ⊢ ⟨error_empty
              ⟨ ⟨bar1 >= 0 ⊢ ⟨true⟩⟩, ⟨bar1 < 0 ⊢ ⟨false⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -70,7 +70,7 @@ type SubFoo2 = {
   x1: integer;
   y: ((closure_env, integer) → integer, closure_env);
 }
-type Foo_in = { b_in: ((closure_env, unit) → option bool, closure_env); }
+type Foo_in = { b_in: option bool; }
 type Foo = { z: integer; }
 
 let topval closure_y : (closure_env, integer) → integer =
@@ -123,18 +123,11 @@ let topval closure_r__1 : (closure_env, integer) → integer =
   in
   code_and_env.0 code_and_env.1 param0
 
-let scope foo
-  (foo_in: Foo_in {b_in: ((closure_env, unit) → option bool, closure_env)})
-  : Foo {z: integer}
-  =
-  let get b : ((closure_env, unit) → option bool, closure_env) =
-    foo_in.b_in
-  in
-  let set b__1 : bool =
-    match (b.0 b.1 ()) with
-    | ENone → true
-    | ESome x → x
-  in
+let scope foo (foo_in: Foo_in {b_in: option bool}): Foo {z: integer} =
+  let get b : option bool = foo_in.b_in in
+  let set b__1 : bool = match b with
+                        | ENone → true
+                        | ESome x → x in
   let set r :
       Result {
         r: ((closure_env, integer) → integer, closure_env);

--- a/tests/io/good/all_io.catala_en
+++ b/tests/io/good/all_io.catala_en
@@ -33,28 +33,22 @@ $ catala Typecheck --check-invariants
 $ catala Dcalc -s A
 let scope A
   (A_in:
-     A_in {
-       c_in: integer;
-       d_in: integer;
-       e_in: unit → ⟨integer⟩;
-       f_in: unit → ⟨integer⟩
-     })
+     A_in {c_in: integer; d_in: integer; e_in: ⟨integer⟩; f_in: ⟨integer⟩})
   : A {b: integer; d: integer; f: integer}
   =
   let get c : integer = A_in.c_in in
   let get d : integer = A_in.d_in in
-  let get e : unit → ⟨integer⟩ = A_in.e_in in
-  let get f : unit → ⟨integer⟩ = A_in.f_in in
+  let get e : ⟨integer⟩ = A_in.e_in in
+  let get f : ⟨integer⟩ = A_in.f_in in
   let set a : integer = error_empty ⟨ ⟨true ⊢ ⟨0⟩⟩ | false ⊢ ∅ ⟩ in
   let set b : integer = error_empty ⟨ ⟨true ⊢ ⟨a + 1⟩⟩ | false ⊢ ∅ ⟩ in
   let set e : integer =
     error_empty
-      ⟨ e ()
-      | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨b + c + d + 1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
+      ⟨ e | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨b + c + d + 1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
   in
   let set f : integer =
     error_empty
-      ⟨ f () | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨e + 1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
+      ⟨ f | true ⊢ ⟨error_empty ⟨ ⟨true ⊢ ⟨e + 1⟩⟩ | false ⊢ ∅ ⟩⟩ ⟩
   in
   return { A b = b; d = d; f = f; }
 ```

--- a/tests/io/good/subscope.catala_en
+++ b/tests/io/good/subscope.catala_en
@@ -39,7 +39,7 @@ let scope B (B_in: B_in): B =
     let result : A =
       A
         { A_in
-          a_in = λ () → ∅;
+          a_in = ∅;
           b_in = error_empty ⟨ ⟨true ⊢ ⟨2⟩⟩ | false ⊢ ∅ ⟩;
         }
     in

--- a/tests/monomorphisation/context_var.catala_en
+++ b/tests/monomorphisation/context_var.catala_en
@@ -12,20 +12,17 @@ scope TestXor:
 $ catala lcalc --monomorphize-types
 type option_1 = | None_1 of unit | Some_1 of bool
 
-type TestXor_in = { t_in: unit → option_1[None_1: unit | Some_1: bool]; }
+type TestXor_in = { t_in: option_1[None_1: unit | Some_1: bool]; }
 type TestXor = { t: bool; }
 
 let scope test_xor
-  (test_xor_in:
-     TestXor_in {t_in: unit → option_1[None_1: unit | Some_1: bool]})
+  (test_xor_in: TestXor_in {t_in: option_1[None_1: unit | Some_1: bool]})
   : TestXor {t: bool}
   =
-  let get t : unit → option_1[None_1: unit | Some_1: bool] =
-    test_xor_in.t_in
-  in
+  let get t : option_1[None_1: unit | Some_1: bool] = test_xor_in.t_in in
   let set t__1 : bool =
     match
-      (match (t ()) with
+      (match t with
        | None_1 →
          Some_1
            (match (Some_1 true) with
@@ -53,9 +50,7 @@ scope TestXor2:
 $ catala lcalc --monomorphize-types -s TestXor2
 let scope TestXor2 (test_xor2_in: TestXor2_in): TestXor2 {o: bool} =
   let set t : TestXor {t: bool} =
-    let result : TestXor =
-      test_xor { TestXor_in t_in = λ () → None_1 (); }
-    in
+    let result : TestXor = test_xor { TestXor_in t_in = None_1 (); } in
     let result__1 : TestXor = { TestXor t = result.t; } in
     if true then result__1 else result__1
   in

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -46,15 +46,15 @@ module S = struct
 end
 
 module S_in = struct
-  type t = {a_in: unit -> (bool) Eoption.t}
+  type t = {a_in: (bool) Eoption.t}
 end
 
 
 let s (s_in: S_in.t) : S.t =
-  let a: unit -> (bool) Eoption.t = s_in.S_in.a_in in
+  let a: (bool) Eoption.t = s_in.S_in.a_in in
   let a__1: bool =
     match
-      (match (a ())
+      (match a
        with
        | Eoption.ENone _ ->
            (Eoption.ESome


### PR DESCRIPTION
With the exceptions backend gone, there is no reason to turn context variables into functions of `unit` anymore: they can be handled directly as (`EPureDefault` | `EEmpty`) in dcalc, and options in lcalc.

This provides a big simplification on some programs, in particular when closure conversion is required.

Note that all complexity is not gone: it's now focused on the interesting case of context _functions_, which are not of type `default` but instead functions that _return_ a default type, allowing the possible exceptions to be delayed until the arguments of the functions are known. The behaviour here is unchanged.

I had to tweak the invariant check on default types (@adelaett could you have a look ?) :
- it now allows raw `default` types as fields of input structs

In the proof mode, unthunked `EPureDefault` had to be explicitely marked as safe with being empty (this check could probably be simplified now that we already get a lot of info by default typing; but I am not yet familiar with the code. @rmonat would you like to have a look ?)