### PR TITLE
C backend: workaround bulk freeing of constants

### DIFF
--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -685,7 +685,8 @@ let translate_program ~(config : translation_config) (p : 'm L.program) :
               in
               let func_id = A.FuncName.fresh (func_name, pos) in
               (* The list is being built in reverse order *)
-              (* FIXME: find a better way than a function with no parameters... *)
+              (* Note: this pattern is matched in the C backend to make
+                 allocations permanent. *)
               ( A.SVar
                   {
                     var = var_id;

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -779,8 +779,14 @@ let format_program
                  Format.pp_print_space fmt ();
                  VarName.format fmt var))
             typ;
-          Format.fprintf ppc "@[<hov 2>return (%a ? %a : (%a = %a));@]"
-            VarName.format var VarName.format var VarName.format var
+          Format.fprintf ppc "@[<hov 2>return CATALA_GET_LAZY(%a, %a);@]"
+            (* This does (foo ? foo : foo = foo_init()), but enabling persistent
+               allocation around the init *)
+            (* FIXME: the proper solution would be to do a deep copy of the
+               allocated object from the Catala heap to the persistent heap
+               instead of switching allocation mode (which could persist
+               intermediate values) *)
+            VarName.format var
             (format_expression ctx env)
             expr;
           Format.fprintf ppc "@;<1 -2>}@]@,";

--- a/runtimes/c/runtime.h
+++ b/runtimes/c/runtime.h
@@ -60,6 +60,14 @@ void* catala_malloc (size_t sz);
 
 void catala_free_all();
 
+void catala_set_persistent_malloc();
+void catala_unset_persistent_malloc();
+/* These two functions can be used for switching an init section to persistent
+   malloc, then switching back to catala built-in malloc. In other words, any
+   calls to `catala_malloc` done between the two will not be affected by
+   `catala_free_all()`. Calls can be nested, but errors reset the context. */
+#define CATALA_GET_LAZY(X, X_INIT) (X ? X : (catala_set_persistent_malloc(), X = X_INIT, catala_unset_persistent_malloc(), X))
+
 /* --- Base types --- */
 
 #define CATALA_BOOL const int*


### PR DESCRIPTION
Constants may need initialisation and allocations, which we do lazily, but that
doesn't combine well with the way our allocator works, freeing everything in
bulk.

This patch adds a switch to the allocator that make it use raw `malloc`, which
is turned on within the initialisation functions of constants.