### PR TITLE
Make the explain plugin compatible with vscode test-case extension

### DIFF
--- a/compiler/plugins/explain.ml
+++ b/compiler/plugins/explain.ml
@@ -26,6 +26,7 @@ type flags = {
   output : Global.raw_file option;
   base_src_url : string;
   line_format : string;
+  inline_module_usages : bool;
 }
 
 (* -- Definition of the lazy interpreter -- *)
@@ -1487,6 +1488,13 @@ let options =
              of characters 'NN' will be expanded using the actual positions. \
              The default value '#LNN' matches github-like positions")
   in
+  let inline_module_usages =
+    Arg.(
+      value
+      & flag
+      & info ["inline-mod-uses"]
+          ~doc:"Attempts to inline existing module usages using a heuristic.")
+  in
   let f
       with_conditions
       no_cleanup
@@ -1495,7 +1503,8 @@ let options =
       show
       output
       base_src_url
-      line_format =
+      line_format
+      inline_module_usages =
     {
       with_conditions;
       with_cleanup = not no_cleanup;
@@ -1505,6 +1514,7 @@ let options =
       output;
       base_src_url;
       line_format;
+      inline_module_usages;
     }
   in
   Term.(
@@ -1516,7 +1526,8 @@ let options =
     $ show
     $ Cli.Flags.output
     $ base_src_url
-    $ line_format)
+    $ line_format
+    $ inline_module_usages)
 
 let inline_used_modules global_options =
   let prg =
@@ -1604,7 +1615,10 @@ let run
     ex_scope
     explain_options
     global_options =
-  let () = inline_used_modules global_options in
+  let () =
+    if explain_options.inline_module_usages then
+      inline_used_modules global_options
+  in
   let prg, _ =
     Driver.Passes.dcalc global_options ~includes ~optimize
       ~check_invariants:false ~autotest:false ~typed:Expr.typed

--- a/compiler/surface/parser_driver.mli
+++ b/compiler/surface/parser_driver.mli
@@ -32,6 +32,12 @@ val load_interface :
     keeps type information. The list of submodules is initialised with names
     only and empty contents. *)
 
+val register_included_file_resolver :
+  filename:string -> new_content:string Global.input_src -> unit
+(** Register an included file dynamic resolver. When the surface's parser
+    encounters an inclusion that correspond to the [filename] argument, it will
+    dynamically replace it with the given [new_content]. *)
+
 val parse_top_level_file :
   ?resolve_included_file:(string -> string Global.input_src) ->
   File.t Global.input_src ->
@@ -39,4 +45,5 @@ val parse_top_level_file :
 (** Parses a catala file (handling file includes) and returns a program.
     Interfaces of the used modules are returned empty, use [load_interface] to
     fill them. When provided [resolve_included_file] replaces file includes with
-    an user provided input source. *)
+    an user provided input source. However, it will shadow any existing dynamic
+    resolver registered using [register_included_file_resolver]. *)


### PR DESCRIPTION
This PR adds an `--inline-mod-uses` option to the `explain` plugin so that it's able to handle tests files generated by the test-case plugin.

This option detects module usage in the given file and tries to inline them with the source file (that is currently supposed to be in the same directory in vscode). It also removes the `> Module` declaration which would prevent them from being inlined. This is a temporary workaround until the clerk build system gets mature enough to handle these kind of situations.

I also added a `--line-format` option to be able to output vscode-like links. E.g.,
```bash
$ catala explain ~/catala-language-server/test-case-parser/examples/test_case_apl.catala_en -s Exemple1_test\
                --html --url-base vscode://file --line-format ':NN:0' --inline-mod-uses > test.html
```
will output vscode links like : `vscode://file/path/to/file.catala_en:123:0` which will give the ability to jump to the position in vscode.