### PR TITLE
Carry over binders positions in EAbs

### DIFF
--- a/compiler/catala_utils/mark.ml
+++ b/compiler/catala_utils/mark.ml
@@ -21,6 +21,7 @@ type 'a pos = ('a, Pos.t) ed
 let add m e = e, m
 let remove (x, _) = x
 let get (_, m) = m
+let ghost x = x, Pos.no_pos
 let set m (x, _) = x, m
 let map f (x, m) = f x, m
 let map_mark f (a, m) = a, f m

--- a/compiler/catala_utils/mark.mli
+++ b/compiler/catala_utils/mark.mli
@@ -28,6 +28,7 @@ type 'a pos = ('a, Pos.t) ed
 val add : 'm -> 'a -> ('a, 'm) ed
 val remove : ('a, 'm) ed -> 'a
 val get : ('a, 'm) ed -> 'm
+val ghost : 'a -> 'a pos
 val set : 'm -> ('a, _) ed -> ('a, 'm) ed
 val map : ('a -> 'b) -> ('a, 'm) ed -> ('b, 'm) ed
 val map_mark : ('m1 -> 'm2) -> ('a, 'm1) ed -> ('a, 'm2) ed

--- a/compiler/lcalc/expand_op.ml
+++ b/compiler/lcalc/expand_op.ml
@@ -82,7 +82,7 @@ let rec resolve_eq ctx pos ty args m =
               (fun cstr2 ty ->
                 if EnumConstructor.equal cstr cstr2 then
                   let v2 = Var.make "v2" in
-                  Expr.make_abs [| v2 |]
+                  Expr.make_ghost_abs [v2]
                     (resolve_eq ctx pos ty
                        [
                          Expr.evar v1 (Expr.with_ty m ty);
@@ -91,13 +91,13 @@ let rec resolve_eq ctx pos ty args m =
                        m)
                     [ty] pos
                 else
-                  Expr.make_abs
-                    [| Var.make "_" |]
+                  Expr.make_ghost_abs
+                    [Var.make "_"]
                     (Expr.elit (LBool false) m)
                     [ty] pos)
               constrs
           in
-          Expr.make_abs [| v1 |] (Expr.ematch ~name ~e:arg2 ~cases m) [ty] pos)
+          Expr.make_ghost_abs [v1] (Expr.ematch ~name ~e:arg2 ~cases m) [ty] pos)
         constrs
     in
     Expr.ematch ~name ~e:arg1 ~cases m
@@ -106,7 +106,7 @@ let rec resolve_eq ctx pos ty args m =
     let map2_f =
       let x = Var.make "x" in
       let y = Var.make "y" in
-      Expr.make_abs [| x; y |]
+      Expr.make_ghost_abs [x; y]
         (resolve_eq ctx pos ty
            [Expr.evar x (Expr.with_ty m ty); Expr.evar y (Expr.with_ty m ty)]
            m)
@@ -115,7 +115,7 @@ let rec resolve_eq ctx pos ty args m =
     let fold_f =
       let acc = Var.make "acc" in
       let x = Var.make "x" in
-      Expr.make_abs [| acc; x |]
+      Expr.make_ghost_abs [acc; x]
         (conjunction [Expr.evar acc m; Expr.evar x m])
         [tbool; tbool] pos
     in

--- a/compiler/lcalc/from_dcalc.ml
+++ b/compiler/lcalc/from_dcalc.ml
@@ -96,7 +96,7 @@ let rec translate_default
                (* Some x -> Some x *)
                ( Expr.some_constr,
                  let x = Var.make "x" in
-                 Expr.make_abs [| x |]
+                 Expr.make_ghost_abs [x]
                    (Expr.einj ~name:Expr.option_enum ~cons:Expr.some_constr
                       ~e:(Expr.evar x mark_alpha) mark_default)
                    [ty_alpha] pos );
@@ -138,7 +138,7 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
         [
           ( Expr.none_constr,
             let x = Var.make "_" in
-            Expr.make_abs [| x |] (Expr.efatalerror NoValue m) [TAny, pos] pos
+            Expr.make_ghost_abs [x] (Expr.efatalerror NoValue m) [TAny, pos] pos
           );
           (* | None x -> raise NoValueProvided *)
           Expr.some_constr, Expr.fun_id ~var_name:"arg" m (* | Some x -> x *);

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -314,7 +314,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
              e))
       (EnumConstructor.Map.bindings cases)
   | ELit l -> Format.fprintf fmt "%a" format_lit (Mark.add (Expr.pos e) l)
-  | EApp { f = EAbs { binder; tys }, _; args; _ } ->
+  | EApp { f = EAbs { binder; pos = _; tys }, _; args; _ } ->
     let xs, body = Bindlib.unmbind binder in
     let xs_tau = List.map2 (fun x tau -> x, tau) (Array.to_list xs) tys in
     let xs_tau_arg = List.map2 (fun (x, tau) arg -> x, tau, arg) xs_tau args in
@@ -325,7 +325,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
            Format.fprintf fmt "@[<hov 2>let@ %a@ :@ %a@ =@ %a@]@ in@\n"
              format_var x format_typ tau format_with_parens arg))
       xs_tau_arg format_with_parens body
-  | EAbs { binder; tys } ->
+  | EAbs { binder; pos = _; tys } ->
     let xs, body = Bindlib.unmbind binder in
     let xs_tau = List.map2 (fun x tau -> x, tau) (Array.to_list xs) tys in
     Format.fprintf fmt "@[<hov 2>fun@ %a ->@ %a@]"

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -251,8 +251,8 @@ let interpret_program (prg : ('dcalc, 'm) gexpr program) (scope : ScopeName.t) :
         (StructField.Map.map
            (function
              | TArrow (ty_in, ty_out), _ ->
-               Expr.make_abs
-                 [| Var.make "_" |]
+               Expr.make_ghost_abs
+                 [Var.make "_"]
                  (Bindlib.box EEmpty, Expr.with_ty m ty_out)
                  ty_in (Expr.mark_pos m)
              | ty -> Expr.evar (Var.make "undefined_input") (Expr.with_ty m ty))

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -265,7 +265,7 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
     in
     (* FIXME: what happens if [arg] is not a tuple but reduces to one ? *)
     stmts, (A.EAppOp { op; args; tys }, Expr.pos expr), ctxt.ren_ctx
-  | EApp { f = EAbs { binder; tys }, binder_mark; args; tys = _ } ->
+  | EApp { f = EAbs { binder; pos = _; tys }, binder_mark; args; tys = _ } ->
     (* This defines multiple local variables at the time *)
     let binder_pos = Expr.mark_pos binder_mark in
     let vars, body, ctxt = unmbind ctxt binder in
@@ -369,7 +369,7 @@ and translate_assignment
   | EFatalError error ->
     let pos_expr, vposdef, ctxt = lift_pos ctxt pos in
     RevBlock.make [vposdef; SFatalError { pos_expr; error }, pos], ctxt.ren_ctx
-  | EApp { f = EAbs { binder; tys }, binder_mark; args; _ } ->
+  | EApp { f = EAbs { binder; pos = _; tys }, binder_mark; args; _ } ->
     (* This defines multiple local variables at the time *)
     let binder_pos = Expr.mark_pos binder_mark in
     let vars, body, ctxt = unmbind ctxt binder in
@@ -405,7 +405,7 @@ and translate_assignment
       translate_assignment { ctxt with ren_ctx } assign_to body
     in
     local_decls ++ def_blocks ++ rest_of_block, ren_ctx
-  | EAbs { binder; tys } ->
+  | EAbs { binder; pos = _; tys } ->
     let vars, body, ctxt = unmbind ctxt binder in
     let binder_pos = Expr.pos block_expr in
     let vars_tau = List.combine (Array.to_list vars) tys in
@@ -460,7 +460,7 @@ and translate_assignment
       EnumConstructor.Map.fold
         (fun _ arg new_args ->
           match Mark.remove arg with
-          | EAbs { binder; tys = typ :: _ } ->
+          | EAbs { binder; pos = _; tys = typ :: _ } ->
             let vars, body, ctxt = unmbind ctxt binder in
             assert (Array.length vars = 1);
             let var = vars.(0) in

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -525,6 +525,7 @@ and ('a, 'b, 'm) base_gexpr =
   | EVar : ('a, 'm) naked_gexpr Bindlib.var -> ('a, _, 'm) base_gexpr
   | EAbs : {
       binder : (('a, 'a, 'm) base_gexpr, ('a, 'm) gexpr) Bindlib.mbinder;
+      pos : Pos.t list;
       tys : typ list;
     }
       -> ('a, < .. >, 'm) base_gexpr

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -66,9 +66,17 @@ val elit : lit -> 'm mark -> ('a any, 'm) boxed_gexpr
 
 val eabs :
   (('a, 'm) naked_gexpr, ('a, 'm) gexpr) Bindlib.mbinder Bindlib.box ->
+  Pos.t list ->
   typ list ->
   'm mark ->
   ('a any, 'm) boxed_gexpr
+
+val eabs_ghost :
+  (('a, 'm) naked_gexpr, ('a, 'm) gexpr) Bindlib.mbinder Bindlib.box ->
+  typ list ->
+  'm mark ->
+  ('a any, 'm) boxed_gexpr
+(** Same as [eabs] but without binders' positions *)
 
 val eapp :
   f:('a, 'm) boxed_gexpr ->
@@ -336,11 +344,19 @@ val map_gather :
 val make_var : ('a, 'm) gexpr Var.t -> 'm mark -> ('a, 'm) boxed_gexpr
 
 val make_abs :
-  ('a, 'm) gexpr Var.vars ->
+  ('a, 'm) gexpr Var.var Mark.pos list ->
   ('a, 'm) boxed_gexpr ->
   typ list ->
   Pos.t ->
   ('a any, 'm) boxed_gexpr
+
+val make_ghost_abs :
+  ('a, 'm) gexpr Var.var list ->
+  ('a, 'm) boxed_gexpr ->
+  typ list ->
+  Pos.t ->
+  ('a any, 'm) boxed_gexpr
+(** Same as [make_abs] without binders' positions *)
 
 val make_app :
   ('a any, 'm) boxed_gexpr ->
@@ -365,7 +381,7 @@ val unthunk_term_nobox : ('a any, 'm) gexpr -> ('a, 'm) gexpr
     raises Invalid_argument otherwise) *)
 
 val make_let_in :
-  ('a, 'm) gexpr Var.t ->
+  ('a, 'm) gexpr Var.t Mark.pos ->
   typ ->
   ('a, 'm) boxed_gexpr ->
   ('a, 'm) boxed_gexpr ->
@@ -373,7 +389,7 @@ val make_let_in :
   ('a any, 'm) boxed_gexpr
 
 val make_multiple_let_in :
-  ('a, 'm) gexpr Var.vars ->
+  ('a, 'm) gexpr Var.var Mark.pos list ->
   typ list ->
   ('a, 'm) boxed_gexpr list ->
   ('a, 'm) boxed_gexpr ->

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -991,7 +991,7 @@ let interpret_program_lcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
           | TArrow (ty_in, (TOption _, _)) ->
             (* Context args should return an option *)
             Expr.make_abs
-              (Array.of_list @@ List.map (fun _ -> Var.make "_") ty_in)
+              (List.map (fun _ -> Mark.ghost (Var.make "_")) ty_in)
               (Expr.einj ~e:(Expr.elit LUnit mark_e) ~cons:Expr.none_constr
                  ~name:Expr.option_enum mark_e
                 : (_, _) boxed_gexpr)
@@ -1001,7 +1001,7 @@ let interpret_program_lcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
             Expr.make_tuple
               [
                 Expr.make_abs
-                  (Array.of_list @@ List.map (fun _ -> Var.make "_") ty_in)
+                  (List.map (fun _ -> Mark.ghost (Var.make "_")) ty_in)
                   (Expr.einj ~e:(Expr.elit LUnit mark_e) ~cons:Expr.none_constr
                      ~name:Expr.option_enum mark_e)
                   ty_in (Expr.mark_pos mark_e);
@@ -1078,7 +1078,7 @@ let interpret_program_dcalc p s : (Uid.MarkedString.info * ('a, 'm) gexpr) list
           match Mark.remove ty0 with
           | TArrow (ty_in, ty_out) ->
             Expr.make_abs
-              (Array.of_list @@ List.map (fun _ -> Var.make "_") ty_in)
+              (List.map (fun _ -> Mark.ghost (Var.make "_")) ty_in)
               (Bindlib.box EEmpty, Expr.with_ty mark_e ty_out)
               ty_in (Expr.mark_pos mark_e)
           | TDefault _ -> Bindlib.box EEmpty, Expr.with_ty mark_e ty0

--- a/compiler/shared_ast/optimizations.ml
+++ b/compiler/shared_ast/optimizations.ml
@@ -253,7 +253,7 @@ let rec optimize_expr :
           Expr.map_ty (function TArray ty, _ -> ty | _, pos -> TAny, pos) m
         in
         let x = Expr.evar v (mty (Mark.get ls)) in
-        Expr.make_abs [| v |]
+        Expr.make_ghost_abs [v]
           (Expr.eapp ~f:(Expr.box f1)
              ~args:[Expr.eapp ~f:(Expr.box f2) ~args:[x] ~tys:[xty] (mty m2)]
              ~tys:[yty] (mty mark))
@@ -302,7 +302,7 @@ let rec optimize_expr :
         in
         let x1 = Expr.evar v1 (mty (Mark.get ls1)) in
         let x2 = Expr.evar v2 (mty (Mark.get ls2)) in
-        Expr.make_abs [| v1; v2 |]
+        Expr.make_ghost_abs [v1; v2]
           (Expr.eapp ~f:(Expr.box f1)
              ~args:
                [
@@ -366,8 +366,9 @@ let test_iota_reduction_1 () =
   let cases : ('a, 't) boxed_gexpr EnumConstructor.Map.t =
     EnumConstructor.Map.of_list
       [
-        consA, Expr.eabs (Expr.bind [| x |] injC) [TAny, Pos.no_pos] nomark;
-        consB, Expr.eabs (Expr.bind [| x |] injD) [TAny, Pos.no_pos] nomark;
+        consA, Expr.eabs_ghost (Expr.bind [| x |] injC) [TAny, Pos.no_pos] nomark;
+        ( consB,
+          Expr.eabs_ghost (Expr.bind [| x |] injD) [TAny, Pos.no_pos] nomark );
       ]
   in
   let matchA = Expr.ematch ~e:injA ~name:enumT ~cases nomark in
@@ -388,7 +389,7 @@ let cases_of_list l : ('a, 't) boxed_gexpr EnumConstructor.Map.t =
   @@ ListLabels.map l ~f:(fun (cons, f) ->
          let var = Var.make "x" in
          ( cons,
-           Expr.eabs
+           Expr.eabs_ghost
              (Expr.bind [| var |] (f var))
              [TAny, Pos.no_pos]
              (Untyped { pos = Pos.no_pos }) ))

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -532,7 +532,7 @@ module ExprGen (C : EXPR_PARAM) = struct
       | ELit l -> C.lit fmt l
       | EApp { f = EAbs _, _; _ } ->
         let rec pr bnd_ctx colors fmt = function
-          | EApp { f = EAbs { binder; tys }, _; args; _ }, _ ->
+          | EApp { f = EAbs { binder; pos = _; tys }, _; args; _ }, _ ->
             let xs, body, bnd_ctx = Bindlib.unmbind_in bnd_ctx binder in
             let xs_tau = List.mapi (fun i tau -> xs.(i), tau) tys in
             let xs_tau_arg =
@@ -552,7 +552,7 @@ module ExprGen (C : EXPR_PARAM) = struct
         Format.pp_open_vbox fmt 0;
         pr bnd_ctx colors fmt e;
         Format.pp_close_box fmt ()
-      | EAbs { binder; tys } ->
+      | EAbs { binder; pos = _; tys } ->
         let xs, body, bnd_ctx = Bindlib.unmbind_in bnd_ctx binder in
         let expr = exprb bnd_ctx in
         let xs_tau = List.mapi (fun i tau -> xs.(i), tau) tys in

--- a/compiler/shared_ast/program.ml
+++ b/compiler/shared_ast/program.ml
@@ -51,7 +51,7 @@ let map_scopes_env ~f prg =
         let body1 = f env name body in
         let env child =
           env
-          @@ Expr.make_let_in var
+          @@ Expr.make_let_in (Mark.add pos var)
                ( TArrow
                    ( [TStruct body.scope_body_input_struct, pos],
                      (TStruct body.scope_body_output_struct, pos) ),
@@ -64,7 +64,8 @@ let map_scopes_env ~f prg =
       | Topdef (name, ty, vis, expr) ->
         let pos = Mark.get (TopdefName.get_info name) in
         let env child =
-          env @@ Expr.make_let_in var ty (Expr.rebox expr) child pos
+          env
+          @@ Expr.make_let_in (Mark.add pos var) ty (Expr.rebox expr) child pos
         in
         let def =
           Bindlib.box_apply

--- a/compiler/shared_ast/renaming.ml
+++ b/compiler/shared_ast/renaming.ml
@@ -187,18 +187,19 @@ let rec expr : type k. context -> (k, 'm) gexpr -> (k, 'm) gexpr boxed =
     Expr.eexternal ~name:(External_scope (ctx.scopes s), pos) (fm m)
   | EExternal { name = External_value d, pos }, m ->
     Expr.eexternal ~name:(External_value (ctx.topdefs d), pos) (fm m)
-  | EAbs { binder; tys }, m ->
+  | EAbs { binder; tys; pos }, m ->
     let vars, body, ctx = unmbind_in ctx binder in
     let body = expr ctx body in
     let binder = Expr.bind vars body in
-    Expr.eabs binder (List.map (typ ctx) tys) (fm m)
-  | EApp { f = EAbs { binder; tys = tyabs }, mabs; args; tys = tyapp }, mapp ->
+    Expr.eabs binder pos (List.map (typ ctx) tys) (fm m)
+  | ( EApp { f = EAbs { binder; pos; tys = tyabs }, mabs; args; tys = tyapp },
+      mapp ) ->
     (* let-in: forward the context to not reuse the name being defined *)
     let vars, body, ctx = unmbind_in ctx binder in
     let body = expr ctx body in
     let binder = Expr.bind vars body in
     Expr.eapp
-      ~f:(Expr.eabs binder (List.map (typ ctx) tyabs) (fm mabs))
+      ~f:(Expr.eabs binder pos (List.map (typ ctx) tyabs) (fm mabs))
       ~args:(List.map (expr ctx) args)
       ~tys:(List.map (typ ctx) tyapp)
       (fm mapp)

--- a/compiler/shared_ast/scope.ml
+++ b/compiler/shared_ast/scope.ml
@@ -95,7 +95,7 @@ let get_body_mark scope_body =
 
 let unfold_body_expr (_ctx : decl_ctx) (scope_let : 'e scope_body_expr) =
   BoundList.fold_right scope_let ~init:Expr.rebox ~f:(fun sl var acc ->
-      Expr.make_let_in var sl.scope_let_typ
+      Expr.make_let_in (Mark.add Pos.no_pos var) sl.scope_let_typ
         (Expr.rebox sl.scope_let_expr)
         acc sl.scope_let_pos)
 
@@ -110,7 +110,7 @@ let to_expr (ctx : decl_ctx) (body : 'e scope_body) : 'e boxed =
   let var, body_expr = Bindlib.unbind body.scope_body_expr in
   let body_expr = unfold_body_expr ctx body_expr in
   let pos = Expr.pos body_expr in
-  Expr.make_abs [| var |] body_expr
+  Expr.make_ghost_abs [var] body_expr
     [TStruct body.scope_body_input_struct, pos]
     pos
 
@@ -129,7 +129,7 @@ let unfold (ctx : decl_ctx) (s : 'e code_item_list) (main_scope : ScopeName.t) :
         | ScopeDef (_, body) -> to_expr ctx body, typ body
         | Topdef (_, typ, _vis, expr) -> Expr.rebox expr, typ
       in
-      Expr.make_let_in var typ e next (Expr.pos e))
+      Expr.make_let_in (Mark.add Pos.no_pos var) typ e next (Expr.pos e))
 
 let free_vars_body_expr scope_lets =
   BoundList.fold_right scope_lets ~init:Expr.free_vars ~f:(fun sl v acc ->

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -836,7 +836,7 @@ and typecheck_expr_top_down :
             (Print.typ ctx) ty
     in
     Expr.etupleaccess ~e:e1' ~index ~size mark
-  | A.EAbs { binder; tys = t_args } ->
+  | A.EAbs { binder; pos; tys = t_args } ->
     if Bindlib.mbinder_arity binder <> List.length t_args then
       Message.error ~pos:(Expr.pos e)
         "function has %d variables but was supplied %d types\n%a"
@@ -856,7 +856,7 @@ and typecheck_expr_top_down :
       in
       let body' = typecheck_expr_top_down ctx env t_ret body in
       let binder' = Bindlib.bind_mvar xs' (Expr.Box.lift body') in
-      Expr.eabs binder' (List.map (typ_to_ast ~flags) tau_args) mark
+      Expr.eabs binder' pos (List.map (typ_to_ast ~flags) tau_args) mark
   | A.EApp { f = e1; args; tys } ->
     (* Here we type the arguments first (in order), to ensure we know the types
        of the arguments if [f] is [EAbs] before disambiguation. This is also the

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -111,7 +111,7 @@ let match_and_ignore_outer_reentrant_default (ctx : ctx) (e : typed expr) :
     when List.exists (fun x' -> Var.equal x x') ctx.input_vars ->
     (* scope variables*)
     cons
-  | EAbs { binder; tys = [(TLit TUnit, _)] } ->
+  | EAbs { binder; pos = _; tys = [(TLit TUnit, _)] } ->
     (* context sub-scope variables *)
     let _, body = Bindlib.unmbind binder in
     body
@@ -198,7 +198,7 @@ let rec generate_vc_must_not_return_empty (ctx : ctx) (e : typed expr) :
                   List.map
                     (fun field ->
                       match Mark.remove field with
-                      | EAbs { binder; tys = [(TLit TUnit, _)] } -> (
+                      | EAbs { binder; pos = _; tys = [(TLit TUnit, _)] } -> (
                         (* Invariant: when calling a function with a thunked
                            emptyerror, this means we're in a direct scope call
                            with a context argument. In that case, we don't apply


### PR DESCRIPTION
This PR augments the EAbs's node with the position of binded variables. This allows the LSP server to handle such variables and references them for the user which was not previously possible.