### PR TITLE
Add warning notification and add utility function to passes

### DIFF
--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -66,7 +66,7 @@ end
 exception CompilerError of Content.t
 exception CompilerErrors of Content.t list
 
-type lsp_error_kind = Lexing | Parsing | Typing | Generic
+type lsp_error_kind = Lexing | Parsing | Typing | Generic | Warning
 
 type lsp_error = {
   kind : lsp_error_kind;


### PR DESCRIPTION
This PR plugs warnings notification mechanism that's currently used for errors messages.

~It also refactors the driver's passes so that it offers more control which is needed in LSP.~

~We also add a global option to handle include resolving introduced by #688~
Edit: I don't need this rework as of right now and I'm still not sure that it's sufficient for what I want to achieve so I removed it from the PR.