### PR TITLE
Compatibility with LSP server build on different platforms

### DIFF
--- a/runtimes/c/dune
+++ b/runtimes/c/dune
@@ -1,14 +1,16 @@
 (rule
- (deps runtime.c runtime.h)
+ (deps runtime.c runtime.h dates_calc.h)
  (target runtime.o)
  (action
   (system
-   "%{cc} --std=c89 -Wall -Werror -pedantic -c runtime.c -I $(ocamlfind query dates_calc)/c -o %{target}")))
+   "%{cc} --std=c89 -Wall -Werror -pedantic -c runtime.c -I . -o %{target}")))
 
 (rule
  (deps runtime.o)
  (target catala_runtime.a)
  (action
+  ; FIXME: ar is not portable, it makes the build fails on windows.
+  ; A workaround is to install a mingw toolchain that exposes ar.
   (run ar rcs %{target} %{lib:dates_calc:c/dates_calc.o} %{deps})))
 
 (rule


### PR DESCRIPTION
Windows doesn't like rogue shell invocations. This change fixes this.