### PR TITLE
Add error handler hook in C runtime

### DIFF
--- a/runtimes/c/runtime-test.c
+++ b/runtimes/c/runtime-test.c
@@ -17,7 +17,7 @@ void test()
 
 int main()
 {
-  catala_init();
+  catala_init(NULL);
   test();
   catala_free_all();
   return 0;

--- a/runtimes/c/runtime.c
+++ b/runtimes/c/runtime.c
@@ -821,6 +821,13 @@ const CATALA_OPTION() handle_exceptions
   return excs[i];
 }
 
+
+void (*error_handler)(const struct catala_error *) = NULL;
+
+void register_error_handler(void (*f)(const struct catala_error *)){
+  error_handler = f;
+}
+
 void catala_init()
 {
   mp_set_memory_functions(&catala_malloc,&catala_realloc,&catala_free);
@@ -828,6 +835,10 @@ void catala_init()
   if (setjmp(catala_error_jump_buffer)) {
     char *error_kind;
     const catala_code_position pos = catala_error_raised.position;
+    if (error_handler != NULL) {
+      error_handler(&catala_error_raised);
+      return;
+    }
     switch (catala_error_raised.code) {
     case catala_assertion_failed:
       error_kind = "Assertion failure";

--- a/runtimes/c/runtime.h
+++ b/runtimes/c/runtime.h
@@ -329,6 +329,8 @@ const CATALA_OPTION() handle_exceptions
 
 /* --- Runtime initialisation --- */
 
+void register_error_handler(void (*f)(const struct catala_error *));
+
 void catala_init();
 /* This must be called once and before any use of the functions above: it
    performs necessary initialisations of GMP, as well as the setup for our error


### PR DESCRIPTION
This PR adds a naive mechanism to the C backend to allow the user to handle runtime errors  without crashing the program.