### PR TITLE
Format trace to JSON format

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,0 @@
-# shellcheck shell=bash
-# For use with direnv.
-# Installing nix-direnv will ensure a smoother experience.
-use flake

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -155,6 +155,14 @@ module Flags = struct
             "Displays a trace of the interpreter's computation or generates \
              logging instructions in translate programs."
 
+    let trace_output =
+      value
+      & opt (some string) None
+      & info ["trace-output"] ~docv:"FILE"
+          ~doc:
+            "Output trace logs to the specified file instead of stdout. Works \
+             with both human-readable and JSON formats."
+
     let trace_format =
       value
       & opt (enum trace_format_opt) Human
@@ -235,6 +243,7 @@ module Flags = struct
           message_format
           trace
           trace_format
+          trace_output
           plugins_dirs
           disable_warnings
           max_prec_digits
@@ -254,7 +263,7 @@ module Flags = struct
         (* This sets some global refs for convenience, but most importantly
            returns the options record. *)
         Global.enforce_options ~language ~debug ~color ~message_format ~trace
-          ~trace_format ~plugins_dirs ~disable_warnings ~max_prec_digits
+          ~trace_format ~trace_output ~plugins_dirs ~disable_warnings ~max_prec_digits
           ~path_rewrite ~stop_on_error ~no_fail_on_assert ()
       in
       Term.(
@@ -265,6 +274,7 @@ module Flags = struct
         $ message_format
         $ trace
         $ trace_format
+        $ trace_output
         $ plugins_dirs
         $ disable_warnings
         $ max_prec_digits

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -150,7 +150,12 @@ module Flags = struct
       let converter =
         conv ~docv:"FILE"
           ( (fun s ->
-              if s = "-" then Ok `Stdout else Ok (`FileName (Global.raw_file s))),
+              if s = "-" then Ok `Stdout
+              else if
+                Filename.extension s |> String.starts_with ~prefix:".catala"
+              then
+                Error (`Msg "Output trace file cannot have a .catala extension")
+              else Ok (`FileName (Global.raw_file s))),
             fun ppf -> function
               | `Stdout -> Format.pp_print_string ppf "-"
               | `FileName f -> Format.pp_print_string ppf (f :> string) )
@@ -165,7 +170,8 @@ module Flags = struct
              outputs\n\
             \             trace to stdout. If $(docv) is defined, outputs the \
              trace to a file while interpreting.\n\
-            \             Defining a filename does not affect code generation."
+            \             Defining a filename does not affect code generation. \
+             Cannot use .catala extension."
 
     let trace_format =
       value

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -26,7 +26,8 @@ let language_code =
   let rl = List.map (fun (a, b) -> b, a) languages in
   fun l -> List.assoc l rl
 
-let message_format_opt = ["human", Human; "gnu", GNU]
+let message_format_opt = ["human", (Human : message_format_enum); "gnu", GNU]
+let trace_format_opt = ["human", (Human : trace_format_enum); "json", JSON]
 
 open Cmdliner
 
@@ -154,6 +155,16 @@ module Flags = struct
             "Displays a trace of the interpreter's computation or generates \
              logging instructions in translate programs."
 
+    let trace_format =
+      value
+      & opt (enum trace_format_opt) Human
+      & info ["trace-format"]
+          ~doc:
+            "Selects the format of trace logs emitted by the interpreter. If \
+             set to $(i,human), the messages will be nicely displayed and \
+             meant to be read by a human. If set to $(i, json), the messages \
+             will be emitted as a JSON structured object."
+
     let plugins_dirs =
       let doc = "Set the given directory to be searched for backend plugins." in
       let env = Cmd.Env.info "CATALA_PLUGINS" in
@@ -223,6 +234,7 @@ module Flags = struct
           color
           message_format
           trace
+          trace_format
           plugins_dirs
           disable_warnings
           max_prec_digits
@@ -242,8 +254,8 @@ module Flags = struct
         (* This sets some global refs for convenience, but most importantly
            returns the options record. *)
         Global.enforce_options ~language ~debug ~color ~message_format ~trace
-          ~plugins_dirs ~disable_warnings ~max_prec_digits ~path_rewrite
-          ~stop_on_error ~no_fail_on_assert ()
+          ~trace_format ~plugins_dirs ~disable_warnings ~max_prec_digits
+          ~path_rewrite ~stop_on_error ~no_fail_on_assert ()
       in
       Term.(
         const make
@@ -252,6 +264,7 @@ module Flags = struct
         $ color
         $ message_format
         $ trace
+        $ trace_format
         $ plugins_dirs
         $ disable_warnings
         $ max_prec_digits

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -157,7 +157,7 @@ module Flags = struct
 
     let trace_output =
       value
-      & opt (some string) None
+      & opt (some raw_file) None
       & info ["trace-output"] ~docv:"FILE"
           ~doc:
             "Output trace logs to the specified file instead of stdout. Works \
@@ -260,11 +260,12 @@ module Flags = struct
               | "-" -> "-"
               | f -> File.reverse_path ~to_dir f)
         in
+        let trace_output = Option.map path_rewrite trace_output in
         (* This sets some global refs for convenience, but most importantly
            returns the options record. *)
         Global.enforce_options ~language ~debug ~color ~message_format ~trace
-          ~trace_format ~trace_output ~plugins_dirs ~disable_warnings ~max_prec_digits
-          ~path_rewrite ~stop_on_error ~no_fail_on_assert ()
+          ~trace_format ~trace_output ~plugins_dirs ~disable_warnings
+          ~max_prec_digits ~path_rewrite ~stop_on_error ~no_fail_on_assert ()
       in
       Term.(
         const make

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -41,7 +41,7 @@ type options = {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
-  mutable trace_output : string option;
+  mutable trace_output : file option;
 }
 
 (* Note: we force that the global options (ie options common to all commands)

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -33,7 +33,7 @@ type options = {
   mutable debug : bool;
   mutable color : when_enum;
   mutable message_format : message_format_enum;
-  mutable trace : bool;
+  mutable trace : Format.formatter Lazy.t option;
   mutable trace_format : trace_format_enum;
   mutable plugins_dirs : file list;
   mutable disable_warnings : bool;
@@ -41,7 +41,6 @@ type options = {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
-  mutable trace_output : file option;
 }
 
 (* Note: we force that the global options (ie options common to all commands)
@@ -56,7 +55,7 @@ let options =
     debug = false;
     color = Auto;
     message_format = Human;
-    trace = false;
+    trace = None;
     trace_format = Human;
     plugins_dirs = [];
     disable_warnings = false;
@@ -64,7 +63,6 @@ let options =
     path_rewrite = (fun _ -> assert false);
     stop_on_error = false;
     no_fail_on_assert = false;
-    trace_output = None;
   }
 
 let enforce_options
@@ -81,7 +79,6 @@ let enforce_options
     ?path_rewrite
     ?stop_on_error
     ?no_fail_on_assert
-    ?trace_output
     () =
   Option.iter (fun x -> options.input_src <- x) input_src;
   Option.iter (fun x -> options.language <- x) language;
@@ -96,7 +93,6 @@ let enforce_options
   Option.iter (fun x -> options.path_rewrite <- x) path_rewrite;
   Option.iter (fun x -> options.stop_on_error <- x) stop_on_error;
   Option.iter (fun x -> options.no_fail_on_assert <- x) no_fail_on_assert;
-  Option.iter (fun x -> options.trace_output <- x) trace_output;
   options
 
 let input_src_file = function FileName f | Contents (_, f) | Stdin f -> f

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -19,6 +19,7 @@ type raw_file = file
 type backend_lang = En | Fr | Pl
 type when_enum = Auto | Always | Never
 type message_format_enum = Human | GNU | Lsp
+type trace_format_enum = Human | JSON
 
 type 'file input_src =
   | FileName of 'file
@@ -33,6 +34,7 @@ type options = {
   mutable color : when_enum;
   mutable message_format : message_format_enum;
   mutable trace : bool;
+  mutable trace_format : trace_format_enum;
   mutable plugins_dirs : file list;
   mutable disable_warnings : bool;
   mutable max_prec_digits : int;
@@ -54,6 +56,7 @@ let options =
     color = Auto;
     message_format = Human;
     trace = false;
+    trace_format = Human;
     plugins_dirs = [];
     disable_warnings = false;
     max_prec_digits = 20;
@@ -69,6 +72,7 @@ let enforce_options
     ?color
     ?message_format
     ?trace
+    ?trace_format
     ?plugins_dirs
     ?disable_warnings
     ?max_prec_digits
@@ -82,6 +86,7 @@ let enforce_options
   Option.iter (fun x -> options.color <- x) color;
   Option.iter (fun x -> options.message_format <- x) message_format;
   Option.iter (fun x -> options.trace <- x) trace;
+  Option.iter (fun x -> options.trace_format <- x) trace_format;
   Option.iter (fun x -> options.plugins_dirs <- x) plugins_dirs;
   Option.iter (fun x -> options.disable_warnings <- x) disable_warnings;
   Option.iter (fun x -> options.max_prec_digits <- x) max_prec_digits;

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -41,6 +41,7 @@ type options = {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
+  mutable trace_output : string option;
 }
 
 (* Note: we force that the global options (ie options common to all commands)
@@ -63,6 +64,7 @@ let options =
     path_rewrite = (fun _ -> assert false);
     stop_on_error = false;
     no_fail_on_assert = false;
+    trace_output = None;
   }
 
 let enforce_options
@@ -79,6 +81,7 @@ let enforce_options
     ?path_rewrite
     ?stop_on_error
     ?no_fail_on_assert
+    ?trace_output
     () =
   Option.iter (fun x -> options.input_src <- x) input_src;
   Option.iter (fun x -> options.language <- x) language;
@@ -93,6 +96,7 @@ let enforce_options
   Option.iter (fun x -> options.path_rewrite <- x) path_rewrite;
   Option.iter (fun x -> options.stop_on_error <- x) stop_on_error;
   Option.iter (fun x -> options.no_fail_on_assert <- x) no_fail_on_assert;
+  Option.iter (fun x -> options.trace_output <- x) trace_output;
   options
 
 let input_src_file = function FileName f | Contents (_, f) | Stdin f -> f

--- a/compiler/catala_utils/global.mli
+++ b/compiler/catala_utils/global.mli
@@ -32,6 +32,9 @@ type when_enum = Auto | Always | Never
 (** Format of error and warning messages output by the compiler. *)
 type message_format_enum = Human | GNU | Lsp
 
+(** Format of trace logs *)
+type trace_format_enum = Human | JSON
+
 (** Sources for program input *)
 type 'file input_src =
   | FileName of 'file  (** A file path to read from disk *)
@@ -51,6 +54,7 @@ type options = private {
   mutable color : when_enum;
   mutable message_format : message_format_enum;
   mutable trace : bool;
+  mutable trace_format : trace_format_enum;
   mutable plugins_dirs : file list;
   mutable disable_warnings : bool;
   mutable max_prec_digits : int;
@@ -73,6 +77,7 @@ val enforce_options :
   ?color:when_enum ->
   ?message_format:message_format_enum ->
   ?trace:bool ->
+  ?trace_format:trace_format_enum ->
   ?plugins_dirs:file list ->
   ?disable_warnings:bool ->
   ?max_prec_digits:int ->

--- a/compiler/catala_utils/global.mli
+++ b/compiler/catala_utils/global.mli
@@ -53,7 +53,7 @@ type options = private {
   mutable debug : bool;
   mutable color : when_enum;
   mutable message_format : message_format_enum;
-  mutable trace : bool;
+  mutable trace : Format.formatter Lazy.t option;
   mutable trace_format : trace_format_enum;
   mutable plugins_dirs : file list;
   mutable disable_warnings : bool;
@@ -61,7 +61,6 @@ type options = private {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
-  mutable trace_output : string option;
 }
 (** Global options, common to all subcommands (note: the fields are internally
     mutable only for purposes of the [globals] toplevel value defined below) *)
@@ -77,7 +76,7 @@ val enforce_options :
   ?debug:bool ->
   ?color:when_enum ->
   ?message_format:message_format_enum ->
-  ?trace:bool ->
+  ?trace:Format.formatter Lazy.t option ->
   ?trace_format:trace_format_enum ->
   ?plugins_dirs:file list ->
   ?disable_warnings:bool ->
@@ -85,7 +84,6 @@ val enforce_options :
   ?path_rewrite:(raw_file -> file) ->
   ?stop_on_error:bool ->
   ?no_fail_on_assert:bool ->
-  ?trace_output:string option ->
   unit ->
   options
 (** Sets up the global options (side-effect); for specific use-cases only, this

--- a/compiler/catala_utils/global.mli
+++ b/compiler/catala_utils/global.mli
@@ -61,6 +61,7 @@ type options = private {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
+  mutable trace_output : string option;
 }
 (** Global options, common to all subcommands (note: the fields are internally
     mutable only for purposes of the [globals] toplevel value defined below) *)
@@ -84,6 +85,7 @@ val enforce_options :
   ?path_rewrite:(raw_file -> file) ->
   ?stop_on_error:bool ->
   ?no_fail_on_assert:bool ->
+  ?trace_output:string option ->
   unit ->
   options
 (** Sets up the global options (side-effect); for specific use-cases only, this

--- a/compiler/catala_utils/hash.ml
+++ b/compiler/catala_utils/hash.ml
@@ -49,7 +49,7 @@ end = struct
     % !(monomorphize_types : bool)
     % (* The following may not affect the call convention, but we want it set in
          an homogeneous way *)
-    !(Global.options.trace : bool)
+    !(Global.options.trace <> None: bool)
     % !(Global.options.max_prec_digits : int)
     |> k
 

--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -66,8 +66,13 @@ let formatter_of_out_channel oc =
     if Lazy.force tty then Format.pp_set_margin ppf (terminal_columns ());
     ppf
 
-let std_ppf = formatter_of_out_channel stdout
-let err_ppf = formatter_of_out_channel stderr
+let std_ppf =
+  let ppf = lazy (formatter_of_out_channel stdout ()) in
+  fun () -> Lazy.force ppf
+
+let err_ppf =
+  let ppf = lazy (formatter_of_out_channel stderr ()) in
+  fun () -> Lazy.force ppf
 
 let ignore_ppf =
   let ppf = lazy (Format.make_formatter (fun _ _ _ -> ()) (fun () -> ())) in

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -94,6 +94,7 @@ val pad : int -> string -> Format.formatter -> unit
 (* {1 More general color-enabled formatting helpers}*)
 
 val std_ppf : unit -> Format.formatter
+val err_ppf : unit -> Format.formatter
 val formatter_of_out_channel : out_channel -> unit -> Format.formatter
 (** Creates a new formatter from the given out channel, with correct handling of
     the ocolor tags. Actual use of escape codes in the output depends on

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -93,6 +93,7 @@ val pad : int -> string -> Format.formatter -> unit
 
 (* {1 More general color-enabled formatting helpers}*)
 
+val std_ppf : unit -> Format.formatter
 val formatter_of_out_channel : out_channel -> unit -> Format.formatter
 (** Creates a new formatter from the given out channel, with correct handling of
     the ocolor tags. Actual use of escape codes in the output depends on

--- a/compiler/catala_web_interpreter.ml
+++ b/compiler/catala_web_interpreter.ml
@@ -21,7 +21,7 @@ let () =
          let options =
            Global.enforce_options
              ~input_src:(Contents (contents, "-inline-"))
-             ~language:(Some language) ~debug:false ~color:Never ~trace ()
+             ~language:(Some language) ~debug:false ~color:Never ~trace: (if trace then Some (lazy Format.std_formatter) else None) ()
          in
          let prg, _type_order =
            Passes.dcalc options ~includes:[] ~optimize:false

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -127,7 +127,7 @@ let tag_with_log_entry
     (markings : Uid.MarkedString.info list) : 'm Ast.expr boxed =
   let m = mark_tany (Mark.get e) (Expr.pos e) in
 
-  if Global.options.trace then
+  if Global.options.trace <> None then
     let pos = Expr.pos e in
     Expr.eappop ~op:(Log (l, markings), pos) ~tys:[TAny, pos] ~args:[e] m
   else e

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -340,11 +340,11 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
         args = [arg];
         _;
       }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt "(log_begin_call@ %a@ %a)@ %a" format_uid_list info
       format_with_parens f format_with_parens arg
   | EAppOp { op = Log (VarDef var_def_info, info), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt
       "(log_variable_definition@ %a@ {io_input=%s;@ io_output=%b}@ (%a)@ %a)"
       format_uid_list info
@@ -356,7 +356,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       (var_def_info.log_typ, Pos.no_pos)
       format_with_parens arg1
   | EAppOp { op = Log (PosRecordIfTrueBool, _), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     let pos = Expr.pos e in
     Format.fprintf fmt
       "(log_decision_taken@ @[<hov 2>{filename = \"%s\";@ start_line=%d;@ \
@@ -365,7 +365,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos) format_with_parens arg1
   | EAppOp { op = Log (EndCall, info), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt "(log_end_call@ %a@ %a)" format_uid_list info
       format_with_parens arg1
   | EAppOp { op = Log _, _; args = [arg1]; _ } ->
@@ -482,7 +482,7 @@ let format_ctx
              Format.fprintf fmt "@[<hov 2>%a:@ %a@]" format_struct_field_name
                (None, struct_field) format_typ struct_field_type))
         (StructField.Map.bindings struct_fields);
-    if Global.options.trace then
+    if Global.options.trace <> None then
       format_struct_embedding fmt (struct_name, struct_fields)
   in
   let format_enum_decl fmt (enum_name, enum_cons) =
@@ -495,7 +495,7 @@ let format_ctx
            Format.fprintf fmt "@[<hov 2>| %a@ of@ %a@]" format_enum_cons_name
              enum_cons format_typ enum_cons_type))
       (EnumConstructor.Map.bindings enum_cons);
-    if Global.options.trace then format_enum_embedding fmt (enum_name, enum_cons)
+    if Global.options.trace <> None then format_enum_embedding fmt (enum_name, enum_cons)
   in
   let is_in_type_ordering s =
     List.exists

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -475,7 +475,7 @@ let run
     keep_special_ops
     monomorphize_types
     _options =
-  let options = Global.enforce_options ~trace:true () in
+  let options = Global.enforce_options ~trace:(Some (lazy Format.std_formatter)) () in
   let prg, type_ordering, _ =
     Driver.Passes.lcalc options ~includes ~optimize ~check_invariants
       ~autotest:false ~closure_conversion ~keep_special_ops ~typed:Expr.typed

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -297,11 +297,11 @@ let rec format_expression ctx (fmt : Format.formatter) (e : expr) : unit =
         f = EAppOp { op = Log (BeginCall, info), _; args = [f]; _ }, _;
         args = [arg];
       }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt "log_begin_call(%a,@ %a,@ %a)" format_uid_list info
       (format_expression ctx) f (format_expression ctx) arg
   | EAppOp { op = Log (VarDef var_def_info, info), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt
       "log_variable_definition(%a,@ LogIO(input_io=InputIO.%s,@ \
        output_io=%s),@ %a)"
@@ -313,7 +313,7 @@ let rec format_expression ctx (fmt : Format.formatter) (e : expr) : unit =
       (if var_def_info.log_io_output then "True" else "False")
       (format_expression ctx) arg1
   | EAppOp { op = Log (PosRecordIfTrueBool, _), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     let pos = Mark.get e in
     Format.fprintf fmt
       "log_decision_taken(SourcePosition(filename=\"%s\",@ start_line=%d,@ \
@@ -322,7 +322,7 @@ let rec format_expression ctx (fmt : Format.formatter) (e : expr) : unit =
       (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
       (Pos.get_law_info pos) (format_expression ctx) arg1
   | EAppOp { op = Log (EndCall, info), _; args = [arg1]; _ }
-    when Global.options.trace ->
+    when Global.options.trace <> None ->
     Format.fprintf fmt "log_end_call(%a,@ %a)" format_uid_list info
       (format_expression ctx) arg1
   | EAppOp { op = Log _, _; args = [arg1]; _ } ->

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -37,7 +37,7 @@ let tag_with_log_entry
     (e : untyped Ast.expr boxed)
     (l : log_entry)
     (markings : Uid.MarkedString.info list) : untyped Ast.expr boxed =
-  if Global.options.trace then
+  if Global.options.trace <> None then
     Expr.eappop
       ~op:(Log (l, markings), Expr.pos e)
       ~tys:[TAny, Expr.pos e]

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -936,8 +936,7 @@ let evaluate_expr_trace :
           let fmt = Format.formatter_of_out_channel oc in
           Fun.protect
             (fun () -> output_trace fmt)
-            ~finally:(fun () ->
-              close_out oc)
+            ~finally:(fun () -> close_out oc)
         )
 
 let evaluate_expr_safe :

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -936,8 +936,7 @@ let evaluate_expr_trace :
           let fmt = Format.formatter_of_out_channel oc in
           Fun.protect
             (fun () -> output_trace fmt)
-            ~finally:(fun () -> close_out oc)
-        )
+            ~finally:(fun () -> close_out oc))
 
 let evaluate_expr_safe :
     type d.

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -73,34 +73,34 @@ let print_log ppf lang level entry =
         ~pp_sep:(fun ppf () -> fprintf ppf ".@,")
         pp_print_string)
   in
-  let logprintf entry fmt =
-    if ppf == Message.std_ppf () then Format.fprintf ppf "[@{<bold;black>LOG@}] ";
-    Format.fprintf ppf ("%s@[<hov>%a " ^^ fmt ^^ "@]@,") (String.make (level * 2) ' ') Print.log_entry entry
+  let logprintf level entry fmt =
+    if ppf == Message.std_ppf () then Format.fprintf ppf "[@{<bold;grey>LOG@}] ";
+    Format.fprintf ppf ("@[<hov>%*s%a" ^^ fmt ^^ "@]@,") (level * 2) "" Print.log_entry entry
   in
   match entry with
   | Runtime.BeginCall infos ->
-    logprintf BeginCall "%a" pp_infos infos;
+    logprintf level BeginCall " %a" pp_infos infos;
     level + 1
   | Runtime.EndCall infos ->
     let level = max 0 (level - 1) in
-    logprintf EndCall "%a" pp_infos infos;
+    logprintf level EndCall " %a" pp_infos infos;
     level
   | Runtime.VariableDefinition (infos, io, value) ->
-    logprintf
+    logprintf level
       (VarDef
          {
            log_typ = TAny;
            log_io_input = io.Runtime.io_input;
            log_io_output = io.Runtime.io_output;
          })
-      "%a: @{<green>%s@}"
+      " %a: @{<green>%s@}"
       pp_infos infos
       (Message.unformat (fun ppf -> format_runtime_value lang ppf value));
     level
   | Runtime.DecisionTaken rtpos ->
     let pos = Expr.runtime_to_pos rtpos in
-    logprintf PosRecordIfTrueBool
-      "@[<v>@{<green>Definition applied@}:@,%a@]@,"
+    logprintf level PosRecordIfTrueBool
+      "@[<v -2>@{<green>Definition applied@}:@,%a@]@,"
       Pos.format_loc_text pos;
     level
 

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -924,10 +924,13 @@ let evaluate_expr_trace :
              (Runtime.EventParser.parse_raw_events trace)] fais here, check
              why *)
         | JSON ->
-          List.iter
-            (fun raw_event ->
-              Format.printf "%s" (Runtime.Json.raw_event raw_event))
-            trace)
+          Format.printf "[";
+          Format.pp_print_list
+            ~pp_sep:(fun fmt () -> Format.fprintf fmt ",")
+            (fun fmt -> Format.fprintf fmt "%s")
+            Format.std_formatter
+            (List.map Runtime.Json.raw_event trace);
+          Format.printf "]\n")
 
 let evaluate_expr_safe :
     type d.

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -80,7 +80,7 @@ let print_log ppf lang entry =
     Format.fprintf ppf "%s%a %a" !indent_str Print.log_entry BeginCall pp_infos infos;
     indent_str := !indent_str ^ "  "
   | Runtime.EndCall infos ->
-    indent_str := String.sub !indent_str 0 (String.length !indent_str - 2);
+    indent_str := if String.length !indent_str >= 2 then String.sub !indent_str 0 (String.length !indent_str - 2) else !indent_str;
     Format.fprintf ppf "%s%a %a" !indent_str Print.log_entry EndCall pp_infos infos
   | Runtime.VariableDefinition (infos, io, value) ->
     Format.fprintf ppf "%s%a %a: @{<green>%s@}" !indent_str Print.log_entry

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -937,8 +937,7 @@ let evaluate_expr_trace :
           Fun.protect
             (fun () -> output_trace fmt)
             ~finally:(fun () ->
-              close_out oc;
-              Format.pp_print_flush fmt ())
+              close_out oc)
         )
 
 let evaluate_expr_safe :

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -923,7 +923,11 @@ let evaluate_expr_trace :
           (* TODO: [Runtime.pp_events ~is_first_call:true Format.err_formatter
              (Runtime.EventParser.parse_raw_events trace)] fais here, check
              why *)
-        | JSON -> assert false (*TODO*))
+        | JSON ->
+          List.iter
+            (fun raw_event ->
+              Format.printf "%s" (Runtime.Json.raw_event raw_event))
+            trace)
 
 let evaluate_expr_safe :
     type d.

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -917,9 +917,13 @@ let evaluate_expr_trace :
     ~finally:(fun () ->
       if Global.options.trace then
         let trace = Runtime.retrieve_log () in
-        List.iter (print_log lang) trace
-        (* TODO: [Runtime.pp_events ~is_first_call:true Format.err_formatter
-           (Runtime.EventParser.parse_raw_events trace)] fais here, check why *))
+        match Global.options.trace_format with
+        | Human ->
+          List.iter (print_log lang) trace
+          (* TODO: [Runtime.pp_events ~is_first_call:true Format.err_formatter
+             (Runtime.EventParser.parse_raw_events trace)] fais here, check
+             why *)
+        | JSON -> assert false (*TODO*))
 
 let evaluate_expr_safe :
     type d.

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -380,6 +380,17 @@ module BufferedJson = struct
     Printf.bprintf buf {|,"fun_inputs":[%a]|} (list var_def) fc.fun_inputs;
     Printf.bprintf buf {|,"body":[%a]|} (list event) fc.body;
     Printf.bprintf buf {|,"output":%a}|} var_def fc.output
+
+  and raw_event buf = function
+   | BeginCall name -> Printf.bprintf buf {|{"event": "BeginCall", "name": "%s"}|} (String.concat "." name)
+   | EndCall name -> Printf.bprintf buf {|{"event": "EndCall", "name": "%s"}|} (String.concat "." name)
+   | VariableDefinition (name, _io, _value) ->
+       Printf.bprintf buf {|{
+         "event": "VariableDefinition",
+         "name": "%s",
+         "value": "TODO"
+         }|} (String.concat "." name) 
+   | DecisionTaken _dectaken -> Printf.bprintf buf {|DecisionTaken|}
 end
 
 module Json = struct

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -338,7 +338,7 @@ module BufferedJson = struct
   (* Note: the output format is made for transition with what Yojson gave us,
      but we could change it to something nicer (e.g. objects for structures) *)
   let rec runtime_value buf = function
-    | Unit -> Buffer.add_string buf {|{}|}
+    | Unit -> Buffer.add_string buf "{}"
     | Bool b -> Buffer.add_string buf (string_of_bool b)
     | Money m -> Buffer.add_string buf (money_to_string m)
     | Integer i -> Buffer.add_string buf (integer_to_string i)

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -366,6 +366,12 @@ module BufferedJson = struct
       Printf.bprintf buf {|{"name":%a,"inputs":[%a],"body":[%a]}|} information
         name (list var_def) inputs (list event) body
 
+  and raw_event buf = function
+  | BeginCall _bcall -> Printf.bprintf buf {|BeginCall|}
+  | EndCall _ecall -> Printf.bprintf buf {|EndCall|}
+  | VariableDefinition (_infos, _io, _value) -> Printf.bprintf buf {|VariableDefinition|}
+  | DecisionTaken _dectaken -> Printf.bprintf buf {|DecisionTaken|}
+
   and var_def buf def =
     Option.iter (Printf.bprintf buf {|{"pos":%a|} source_position) def.pos;
     Printf.bprintf buf {|,"name":%a|} information def.name;
@@ -404,6 +410,7 @@ module Json = struct
   let runtime_value = str runtime_value
   let io_log = str io_log
   let event = str event
+  let raw_event = str raw_event
 end
 
 let log_ref : raw_event list ref = ref []

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -366,12 +366,6 @@ module BufferedJson = struct
       Printf.bprintf buf {|{"name":%a,"inputs":[%a],"body":[%a]}|} information
         name (list var_def) inputs (list event) body
 
-  and raw_event buf = function
-  | BeginCall _bcall -> Printf.bprintf buf {|BeginCall|}
-  | EndCall _ecall -> Printf.bprintf buf {|EndCall|}
-  | VariableDefinition (_infos, _io, _value) -> Printf.bprintf buf {|VariableDefinition|}
-  | DecisionTaken _dectaken -> Printf.bprintf buf {|DecisionTaken|}
-
   and var_def buf def =
     Option.iter (Printf.bprintf buf {|{"pos":%a|} source_position) def.pos;
     Printf.bprintf buf {|,"name":%a|} information def.name;
@@ -388,15 +382,22 @@ module BufferedJson = struct
     Printf.bprintf buf {|,"output":%a}|} var_def fc.output
 
   and raw_event buf = function
-   | BeginCall name -> Printf.bprintf buf {|{"event": "BeginCall", "name": "%s"}|} (String.concat "." name)
-   | EndCall name -> Printf.bprintf buf {|{"event": "EndCall", "name": "%s"}|} (String.concat "." name)
-   | VariableDefinition (name, _io, _value) ->
-       Printf.bprintf buf {|{
+    | BeginCall name ->
+      Printf.bprintf buf {|{"event": "BeginCall", "name": "%s"}|}
+        (String.concat "." name)
+    | EndCall name ->
+      Printf.bprintf buf {|{"event": "EndCall", "name": "%s"}|}
+        (String.concat "." name)
+    | VariableDefinition (name, io, value) ->
+      Printf.bprintf buf
+        {|{
          "event": "VariableDefinition",
          "name": "%s",
-         "value": "TODO"
-         }|} (String.concat "." name) 
-   | DecisionTaken _dectaken -> Printf.bprintf buf {|DecisionTaken|}
+         "io": %a,
+         "value": "%a"
+         }|}
+        (String.concat "." name) io_log io runtime_value value
+    | DecisionTaken _dectaken -> Printf.bprintf buf {|DecisionTaken|}
 end
 
 module Json = struct

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -252,6 +252,7 @@ module Json : sig
 
   (* val information: information -> string *)
   val event : event -> string
+  val raw_event : raw_event -> string
 end
 
 val pp_events : ?is_first_call:bool -> Format.formatter -> event list -> unit

--- a/tests/scope/good/scope_call3.catala_en
+++ b/tests/scope/good/scope_call3.catala_en
@@ -67,7 +67,7 @@ $ catala Interpret -t -s HousingComputation --debug
           7 │   definition f of x equals (output of RentComputation).f of x
             │                             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 [LOG]     ≔  RentComputation.direct.
-  output: RentComputation { -- f: <object> }
+      output: RentComputation { -- f: <object> }
 [LOG]   ←  RentComputation.direct
 [LOG]   →  RentComputation.f
 [LOG]     ≔  RentComputation.f.input0: 1


### PR DESCRIPTION
Based on @rprimet's, excellent suggestion, we want to print the trace by the interpreter in a JSON format that could be exploitable by debug tools. However, the parsing of raw events to events is broken now and needs to be fixed. In the meantime, this PR prints the list of raw events on the standard output in JSON format.