### PR TITLE
Test and fix bad positions in conflict message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build.ninja
 **/__pycache__/
 
 .catleg_secrets.toml
+*.tmp/

--- a/compiler/catala_utils/pos.ml
+++ b/compiler/catala_utils/pos.ml
@@ -24,6 +24,14 @@ let lex_pos_compare lp1 lp2 =
   | 0 -> Int.compare lp1.Lexing.pos_cnum lp2.Lexing.pos_cnum
   | n -> n
 
+let compare p1 p2 =
+  let p1beg, p1end = p1.code_pos and p2beg, p2end = p2.code_pos in
+  match lex_pos_compare p1beg p2beg with
+  | 0 -> lex_pos_compare p1end p2end
+  | n -> n
+
+let equal p1 p2 = p1.code_pos = p2.code_pos
+
 let join (p1 : t) (p2 : t) : t =
   if (fst p1.code_pos).Lexing.pos_fname <> (fst p2.code_pos).Lexing.pos_fname
   then invalid_arg "Pos.join";

--- a/compiler/catala_utils/pos.mli
+++ b/compiler/catala_utils/pos.mli
@@ -20,6 +20,9 @@ type t
 (** A position in the source code is a file, as well as begin and end location
     of the form col:line *)
 
+val compare : t -> t -> int
+val equal : t -> t -> bool
+
 (**{2 Constructor and getters}*)
 
 val from_lpos : Lexing.position * Lexing.position -> t

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -538,7 +538,7 @@ let rec translate_expr (ctx : 'm ctx) (e : 'm S.expr) : 'm Ast.expr boxed =
     Expr.eappop ~op:(Sub_dat_dur ctx.date_rounding, opos) ~args ~tys m
   | ( EVar _ | EAbs _ | ELit _ | EStruct _ | EStructAccess _ | ETuple _
     | ETupleAccess _ | EInj _ | EFatalError _ | EEmpty | EErrorOnEmpty _
-    | EArray _ | EIfThenElse _ | EAppOp _ ) as e ->
+    | EArray _ | EIfThenElse _ | EAppOp _ | EPos _ ) as e ->
     Expr.map ~f:(translate_expr ctx) ~op:Operator.translate (e, m)
 
 (** The result of a rule translation is a list of assignments, with variables

--- a/compiler/lcalc/closure_conversion.ml
+++ b/compiler/lcalc/closure_conversion.ml
@@ -147,7 +147,7 @@ let rec transform_closures_expr :
   let m = Mark.get e in
   match Mark.remove e with
   | EStruct _ | EStructAccess _ | ETuple _ | ETupleAccess _ | EInj _ | EArray _
-  | ELit _ | EAssert _ | EFatalError _ | EIfThenElse _ ->
+  | ELit _ | EAssert _ | EFatalError _ | EPos _ | EIfThenElse _ ->
     Expr.map_gather ~acc:Var.Map.empty ~join:join_vars
       ~f:(transform_closures_expr ctx)
       e
@@ -563,8 +563,8 @@ let rec hoist_closures_expr :
     ( { name = closure_var; ty; closure } :: collected_closures,
       Expr.make_var closure_var m )
   | EApp _ | EStruct _ | EStructAccess _ | ETuple _ | ETupleAccess _ | EInj _
-  | EArray _ | ELit _ | EAssert _ | EFatalError _ | EAppOp _ | EIfThenElse _
-  | EVar _ ->
+  | EArray _ | ELit _ | EAssert _ | EFatalError _ | EPos _ | EAppOp _
+  | EIfThenElse _ | EVar _ ->
     Expr.map_gather ~acc:[] ~join:( @ )
       ~f:(hoist_closures_expr flags name_context)
       e

--- a/compiler/lcalc/expand_op.ml
+++ b/compiler/lcalc/expand_op.ml
@@ -37,6 +37,7 @@ let rec resolve_eq ctx pos ty args m =
   | TLit TMoney -> Expr.eappop ~op:(Eq_mon_mon, pos) ~args ~tys:[ty; ty] m
   | TLit TDuration -> Expr.eappop ~op:(Eq_dur_dur, pos) ~args ~tys:[ty; ty] m
   | TLit TDate -> Expr.eappop ~op:(Eq_dat_dat, pos) ~args ~tys:[ty; ty] m
+  | TLit TPos -> assert false
   | TTuple tys ->
     let size = List.length tys in
     let eqs =

--- a/compiler/lcalc/from_dcalc.ml
+++ b/compiler/lcalc/from_dcalc.ml
@@ -170,7 +170,7 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
       (translate_mark m)
   | ( ( ELit _ | EArray _ | EVar _ | EApp _ | EAbs _ | EExternal _
       | EIfThenElse _ | ETuple _ | ETupleAccess _ | EInj _ | EAssert _
-      | EFatalError _ | EStruct _ | EStructAccess _ | EMatch _ ),
+      | EFatalError _ | EStruct _ | EStructAccess _ | EMatch _ | EPos _ ),
       _ ) as e ->
     Expr.map ~f:translate_expr ~typ:translate_typ e
   | _ -> .

--- a/compiler/lcalc/from_dcalc.ml
+++ b/compiler/lcalc/from_dcalc.ml
@@ -32,7 +32,8 @@ let rec translate_typ (tau : typ) : typ =
   Mark.copy tau
     begin
       match Mark.remove tau with
-      | TDefault t -> TOption (translate_typ t)
+      | TDefault ((_, pos) as t) ->
+        TOption (TTuple [translate_typ t; TLit TPos, pos], pos)
       | TLit l -> TLit l
       | TTuple ts -> TTuple (List.map translate_typ ts)
       | TStruct s -> TStruct s
@@ -57,7 +58,8 @@ let rec translate_default
     (just : 'm D.expr)
     (cons : 'm D.expr)
     (mark_default : 'm mark) : 'm A.expr boxed =
-  (* Since the program is well typed, all exceptions have as type [option 't] *)
+  (* Since the program is well typed, all exceptions have as type [option ('t *
+     pos)] *)
   let pos = Expr.mark_pos mark_default in
   let ty_option = Expr.maybe_ty mark_default in
   let ty_array = TArray ty_option, pos in
@@ -133,6 +135,9 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
   | EErrorOnEmpty arg, m ->
     let m = translate_mark m in
     let pos = Expr.mark_pos m in
+    let m_pos_pair =
+      Expr.map_ty (fun ty -> TTuple [ty; TLit TPos, pos], pos) m
+    in
     let cases =
       EnumConstructor.Map.of_list
         [
@@ -141,15 +146,23 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
             Expr.make_ghost_abs [x] (Expr.efatalerror NoValue m) [TAny, pos] pos
           );
           (* | None x -> raise NoValueProvided *)
-          Expr.some_constr, Expr.fun_id ~var_name:"arg" m (* | Some x -> x *);
+          ( Expr.some_constr,
+            let var = Var.make "arg" in
+            Expr.make_abs
+              [var, pos]
+              (Expr.make_tupleaccess (Expr.evar var m_pos_pair) 0 2 pos)
+              [Expr.maybe_ty m_pos_pair]
+              pos );
         ]
     in
     Expr.ematch ~e:(translate_expr arg) ~name:Expr.option_enum ~cases m
   | EDefault { excepts; just; cons }, m ->
     translate_default excepts just cons (translate_mark m)
   | EPureDefault e, m ->
-    Expr.einj ~e:(translate_expr e) ~cons:Expr.some_constr
-      ~name:Expr.option_enum (translate_mark m)
+    let pos = Expr.mark_pos m in
+    let e = Expr.make_tuple [translate_expr e; Expr.make_pos pos m] m in
+    Expr.einj ~e ~cons:Expr.some_constr ~name:Expr.option_enum
+      (translate_mark m)
   | EAppOp { op; tys; args }, m ->
     Expr.eappop ~op:(Operator.translate op)
       ~tys:(List.map translate_typ tys)

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -408,6 +408,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
   | EFatalError er ->
     Format.fprintf fmt "raise@ (Runtime_ocaml.Runtime.Error (%a, [%a]))"
       Print.runtime_error er format_pos (Expr.pos e)
+  | EPos p -> format_pos fmt p
   | _ -> .
 
 (* TODO: move [embed_foo] to [Foo.embed] to protect from name clashes *)

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -396,19 +396,8 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
         | Div_int_int | Div_rat_rat | Div_mon_mon | Div_mon_int | Div_mon_rat
         | Div_dur_dur ->
           Format.fprintf ppf "%a@ " format_pos (Expr.pos (List.nth args 1))
-        | HandleExceptions ->
-          let excs =
-            match args with [(EArray ex, _)] -> ex | _ -> assert false
-          in
-          Format.fprintf ppf "[|@[<hov>%a@]|]@ "
-            (Format.pp_print_list
-               ~pp_sep:(fun ppf () -> Format.fprintf ppf ";@ ")
-               format_pos)
-            (List.map Expr.pos excs)
         | _ -> ())
-      (Format.pp_print_list
-         ~pp_sep:(fun fmt () -> Format.fprintf fmt "@ ")
-         format_with_parens)
+      (Format.pp_print_list ~pp_sep:Format.pp_print_space format_with_parens)
       args
   | EAssert e' ->
     Format.fprintf fmt

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -59,7 +59,8 @@ module To_jsoo = struct
       | TRat | TMoney -> "Js.number Js.t"
       | TDuration -> "Runtime_jsoo.Runtime.duration Js.t"
       | TBool -> "bool Js.t"
-      | TDate -> "Js.js_string Js.t")
+      | TDate -> "Js.js_string Js.t"
+      | TPos -> assert false)
 
   let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
     let format_typ_with_parens (fmt : Format.formatter) (t : typ) =
@@ -96,6 +97,7 @@ module To_jsoo = struct
     | TLit TMoney -> Format.fprintf fmt "Js.number_of_float %@%@ money_to_float"
     | TLit TDuration -> Format.fprintf fmt "duration_to_js"
     | TLit TDate -> Format.fprintf fmt "date_to_js"
+    | TLit TPos -> assert false
     | TEnum ename -> Format.fprintf fmt "%a_to_js" format_enum_name ename
     | TStruct sname -> Format.fprintf fmt "%a_to_js" format_struct_name sname
     | TArray t ->
@@ -131,6 +133,7 @@ module To_jsoo = struct
         "money_of_decimal %@%@ decimal_of_float %@%@ Js.float_of_number"
     | TLit TDuration -> Format.fprintf fmt "duration_of_js"
     | TLit TDate -> Format.fprintf fmt "date_of_js"
+    | TLit TPos -> assert false
     | TEnum ename -> Format.fprintf fmt "%a_of_js" format_enum_name ename
     | TStruct sname -> Format.fprintf fmt "%a_of_js" format_struct_name sname
     | TArray t ->

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -60,7 +60,7 @@ module To_jsoo = struct
       | TDuration -> "Runtime_jsoo.Runtime.duration Js.t"
       | TBool -> "bool Js.t"
       | TDate -> "Js.js_string Js.t"
-      | TPos -> assert false)
+      | TPos -> "source_position Js.t")
 
   let rec format_typ (fmt : Format.formatter) (typ : typ) : unit =
     let format_typ_with_parens (fmt : Format.formatter) (t : typ) =
@@ -97,7 +97,7 @@ module To_jsoo = struct
     | TLit TMoney -> Format.fprintf fmt "Js.number_of_float %@%@ money_to_float"
     | TLit TDuration -> Format.fprintf fmt "duration_to_js"
     | TLit TDate -> Format.fprintf fmt "date_to_js"
-    | TLit TPos -> assert false
+    | TLit TPos -> Format.fprintf fmt "position_to_js"
     | TEnum ename -> Format.fprintf fmt "%a_to_js" format_enum_name ename
     | TStruct sname -> Format.fprintf fmt "%a_to_js" format_struct_name sname
     | TArray t ->
@@ -133,7 +133,7 @@ module To_jsoo = struct
         "money_of_decimal %@%@ decimal_of_float %@%@ Js.float_of_number"
     | TLit TDuration -> Format.fprintf fmt "duration_of_js"
     | TLit TDate -> Format.fprintf fmt "date_of_js"
-    | TLit TPos -> assert false
+    | TLit TPos -> Format.fprintf fmt "position_of_js"
     | TEnum ename -> Format.fprintf fmt "%a_of_js" format_enum_name ename
     | TStruct sname -> Format.fprintf fmt "%a_of_js" format_struct_name sname
     | TArray t ->

--- a/compiler/plugins/explain.ml
+++ b/compiler/plugins/explain.ml
@@ -418,7 +418,7 @@ let rec lazy_eval : decl_ctx -> Env.t -> laziness_level -> expr -> expr * Env.t
         let e, env = lazy_eval ctx env llevel body in
         e, env
       | e, _ -> error e "Invalid apply on %a" Expr.format e)
-  | (EAbs _ | ELit _ | EEmpty), _ -> e0, env (* these are values *)
+  | (EAbs _ | ELit _ | EEmpty | EPos _), _ -> e0, env (* these are values *)
   | (EStruct _ | ETuple _ | EInj _ | EArray _), _ ->
     if not llevel.eval_struct then e0, env
     else

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -48,6 +48,7 @@ module To_json = struct
     | TBool -> Format.fprintf fmt "\"type\": \"boolean\",@\n\"default\": false"
     | TDate -> Format.fprintf fmt "\"type\": \"string\",@\n\"format\": \"date\""
     | TDuration -> failwith "TODO: tlit duration"
+    | TPos -> assert false
     | TUnit ->
       (* NOTE(@EmileRolley): we previously used the "null" type for unit, but it
          is not working properly so we simply decided to remove it. *)

--- a/compiler/plugins/lazy_interp.ml
+++ b/compiler/plugins/lazy_interp.ml
@@ -142,7 +142,7 @@ let rec lazy_eval :
         log "@]}";
         e, env
       | e, _ -> error e "Invalid apply on %a" Expr.format e)
-  | (EAbs _ | ELit _ | EEmpty), _ -> e0, env (* these are values *)
+  | (EAbs _ | ELit _ | EEmpty | EPos _), _ -> e0, env (* these are values *)
   | (EStruct _ | ETuple _ | EInj _ | EArray _), _ ->
     if not llevel.eval_struct then e0, env
     else

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -299,6 +299,7 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
       (A.EApp { f = new_f; args = new_args }, Expr.pos expr),
       ren_ctx )
   | ELit l -> RevBlock.empty, (A.ELit l, Expr.pos expr), ctxt.ren_ctx
+  | EPos p -> RevBlock.empty, (A.EPosLit, p), ctxt.ren_ctx
   | EExternal { name } ->
     let path, name =
       match Mark.remove name with
@@ -501,8 +502,8 @@ and translate_assignment
              },
            Expr.pos block_expr ),
       ren_ctx )
-  | EArray _ | EStruct _ | EInj _ | ETuple _ | ELit _ | EAppOp _ | EVar _
-  | ETupleAccess _ | EStructAccess _ | EExternal _ | EApp _ ->
+  | EArray _ | EStruct _ | EInj _ | ETuple _ | ELit _ | EPos _ | EAppOp _
+  | EVar _ | ETupleAccess _ | EStructAccess _ | EExternal _ | EApp _ ->
     let stmts, expr, ren_ctx =
       match Mark.remove block_expr with
       | (EArray _ | EStruct _ | EInj _ | ETuple _) as e ->

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -196,58 +196,29 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
         tys = [t_arr];
         args = [(EArray exceptions, _)];
       } ->
-    let exceptions_stmts, new_exceptions, ren_ctx =
-      translate_expr_list ctxt exceptions
-    in
+    let stmts, new_exceptions, ren_ctx = translate_expr_list ctxt exceptions in
     let ctxt = { ctxt with ren_ctx } in
-    let eposl, vposdefs, ctxt =
-      List.fold_left
-        (fun (eposl, vposdefs, ctxt) exc ->
-          let epos, vposdef, ctxt = lift_pos ctxt (Expr.pos exc) in
-          epos :: eposl, RevBlock.append vposdefs vposdef, ctxt)
-        ([], RevBlock.empty, ctxt) exceptions
-    in
-    let stmts = exceptions_stmts ++ vposdefs in
-    let stmts, epos, excs, ctxt =
+    let stmts, excs, ctxt =
       if not ctxt.config.no_struct_literals then
-        ( stmts,
-          (A.EArray (List.rev eposl), pos),
-          (A.EArray new_exceptions, pos),
-          ctxt )
+        stmts, (A.EArray new_exceptions, pos), ctxt
       else
         let arr_var_name, ctxt =
           fresh_var ~pos ctxt ("exc_" ^ ctxt.context_name)
         in
-        let pos_arr_var_name, ctxt = fresh_var ~pos ctxt "pos_list" in
         let stmts =
           stmts
-          ++ RevBlock.make
-               [
-                 ( A.SLocalInit
-                     {
-                       name = arr_var_name, pos;
-                       typ = t_arr;
-                       expr = A.EArray new_exceptions, pos;
-                     },
-                   pos );
-                 ( A.SLocalInit
-                     {
-                       name = pos_arr_var_name, pos;
-                       typ = TArray (TLit TUnit, pos), pos;
-                       expr = A.EArray (List.rev eposl), pos;
-                     },
-                   pos );
-               ]
+          +> ( A.SLocalInit
+                 {
+                   name = arr_var_name, pos;
+                   typ = t_arr;
+                   expr = A.EArray new_exceptions, pos;
+                 },
+               pos )
         in
-        stmts, (A.EVar pos_arr_var_name, pos), (A.EVar arr_var_name, pos), ctxt
+        stmts, (A.EVar arr_var_name, pos), ctxt
     in
     ( stmts,
-      ( A.EAppOp
-          {
-            op = Op.HandleExceptions, pos;
-            args = [epos; excs];
-            tys = [TLit TUnit, pos; t_arr];
-          },
+      ( A.EAppOp { op = Op.HandleExceptions, pos; args = [excs]; tys = [t_arr] },
         pos ),
       ctxt.ren_ctx )
   | EAppOp { op; args; tys } ->
@@ -259,7 +230,7 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
         let epos, vposdef, ctxt = lift_pos ctxt pos in
         ( RevBlock.append stmts vposdef,
           epos :: args,
-          (TLit TUnit, pos) :: tys,
+          (TLit TPos, pos) :: tys,
           ctxt )
       else stmts, args, tys, ctxt
     in
@@ -299,7 +270,9 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
       (A.EApp { f = new_f; args = new_args }, Expr.pos expr),
       ren_ctx )
   | ELit l -> RevBlock.empty, (A.ELit l, Expr.pos expr), ctxt.ren_ctx
-  | EPos p -> RevBlock.empty, (A.EPosLit, p), ctxt.ren_ctx
+  | EPos p ->
+    let epos, vposdef, ctxt = lift_pos ctxt p in
+    RevBlock.empty +> vposdef, epos, ctxt.ren_ctx
   | EExternal { name } ->
     let path, name =
       match Mark.remove name with

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -119,6 +119,7 @@ let rec format_typ
   | TLit TDate -> Format.fprintf fmt "CATALA_DATE%t" element_name
   | TLit TDuration -> Format.fprintf fmt "CATALA_DURATION%t" element_name
   | TLit TBool -> Format.fprintf fmt "CATALA_BOOL%t" element_name
+  | TLit TPos -> Format.fprintf fmt "CATALA_POSITION%t" element_name
   | TTuple [_; (TClosureEnv, _)] ->
     Format.fprintf fmt "%scatala_closure*%t" sconst element_name
   | TTuple _ -> Format.fprintf fmt "%sCATALA_TUPLE%t" sconst element_name

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -122,7 +122,12 @@ let rec format_typ
   | TLit TPos -> Format.fprintf fmt "CATALA_POSITION%t" element_name
   | TTuple [_; (TClosureEnv, _)] ->
     Format.fprintf fmt "%scatala_closure*%t" sconst element_name
-  | TTuple _ -> Format.fprintf fmt "%sCATALA_TUPLE%t" sconst element_name
+  | TTuple ts ->
+    Format.fprintf fmt "%sCATALA_TUPLE(%a)%t" sconst
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.pp_print_char ppf ';')
+         (format_typ decl_ctx ~const:false ignore))
+      ts element_name
   | TStruct s ->
     Format.fprintf fmt "%s%s*%t" sconst (StructName.base s) element_name
   | TOption t ->
@@ -293,7 +298,7 @@ let rec format_expression
   | EAppOp { op = ToClosureEnv, _; args = [arg]; _ } ->
     Format.fprintf fmt "((catala_closure *)%a)" format_expression arg
   | EAppOp { op = FromClosureEnv, _; args = [arg]; _ } ->
-    Format.fprintf fmt "((CATALA_TUPLE)%a)" format_expression arg
+    Format.fprintf fmt "((CATALA_TUPLE(_))%a)" format_expression arg
   | EAppOp { op = ((Map | Filter), _) as op; args = [arg1; arg2]; _ } ->
     Format.fprintf fmt "%a(%a,@ %a)" format_op op format_expression arg1
       format_expression arg2
@@ -362,7 +367,13 @@ let rec format_expression
   | ETupleAccess { e1; index; typ } ->
     Format.fprintf fmt "(%a)(%a[%d].content)"
       (format_typ ctx.decl_ctx ignore)
-      typ format_expression e1 index
+      typ
+      (fun ppf -> function
+        | (EStructFieldAccess { name; _ }, _) as e
+          when name = Expr.option_struct ->
+          Format.fprintf ppf "((CATALA_TUPLE(_))%a)" format_expression e
+        | e -> format_expression ppf e)
+      e1 index
   | EExternal { name; _ } ->
     (* The name has already been properly qualified in [Renaming] *)
     Format.fprintf fmt "%s()" (Mark.remove name)
@@ -476,7 +487,7 @@ let rec format_statement
       } ->
     let cast =
       match op with
-      | FromClosureEnv -> "CATALA_TUPLE"
+      | FromClosureEnv -> "CATALA_TUPLE(_)"
       | ToClosureEnv -> "catala_closure *"
       | _ -> assert false
     in
@@ -502,7 +513,10 @@ let rec format_statement
       (format_expression ctx env)
       e
   | SFatalError { pos_expr; error } ->
-    Format.fprintf fmt "@,@[<hov 2>catala_error(catala_%s,@ %a);@]"
+    Format.fprintf fmt
+      "@,\
+       @[<hov 2>catala_error(catala_%s,@ (const catala_code_position **)&%a, \
+       1);@]"
       (String.to_snake_case (Runtime.error_to_string error))
       (format_expression ctx env)
       pos_expr
@@ -544,7 +558,8 @@ let rec format_statement
     Format.fprintf fmt
       "@,\
        @[<v 2>@[<hov 2>if (%a != CATALA_TRUE) {@]@,\
-       @[<hov 2>catala_error(catala_assertion_failed,@ %a);@]@;\
+       @[<hov 2>catala_error(catala_assertion_failed,@ (const \
+       catala_code_position **)&%a, 1);@]@;\
        <1 -2>}@]"
       (format_expression ctx env)
       expr
@@ -592,7 +607,7 @@ and format_ite (ctx : ctx) (env : env) (fmt : Format.formatter) (b : block) :
              {
                e1 = EVar switch_var, pos;
                field = StructField.fresh ("payload", pos);
-               name = StructName.fresh [] ("Dummy", pos);
+               name = Expr.option_struct;
              },
            pos )
          some_case.payload_var_typ pos some_case.case_block);

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -212,6 +212,7 @@ let rec format_typ ctx (fmt : Format.formatter) (typ : typ) : unit =
   | TLit TDate -> Format.fprintf fmt "Date"
   | TLit TDuration -> Format.fprintf fmt "Duration"
   | TLit TBool -> Format.fprintf fmt "bool"
+  | TLit TPos -> Format.fprintf fmt "SourcePosition"
   | TTuple ts ->
     Format.fprintf fmt "Tuple[%a]"
       (Format.pp_print_list

--- a/compiler/scopelang/from_desugared.ml
+++ b/compiler/scopelang/from_desugared.ml
@@ -206,7 +206,7 @@ let rec translate_expr (ctx : ctx) (e : D.expr) : untyped Ast.expr boxed =
           Expr.eappop ~op ~tys:(List.rev tys) ~args:(List.rev args) m)
   | ( EStruct _ | EStructAccess _ | ETuple _ | ETupleAccess _ | EInj _
     | EMatch _ | ELit _ | EDefault _ | EPureDefault _ | EFatalError _
-    | EIfThenElse _ | EArray _ | EEmpty | EErrorOnEmpty _ ) as e ->
+    | EIfThenElse _ | EArray _ | EEmpty | EErrorOnEmpty _ | EPos _ ) as e ->
     Expr.map ~f:(translate_expr ctx) (e, m)
 
 (** {1 Rule tree construction} *)

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -211,7 +211,7 @@ type ('d, 'c) interpr_kind =
 
 (** {2 Types} *)
 
-type typ_lit = TBool | TUnit | TInt | TRat | TMoney | TDate | TDuration
+type typ_lit = TBool | TUnit | TInt | TRat | TMoney | TDate | TDuration | TPos
 
 type typ = naked_typ Mark.pos
 
@@ -599,6 +599,8 @@ and ('a, 'b, 'm) base_gexpr =
       -> ('a, < explicitScopes : no ; .. >, 't) base_gexpr
   | EAssert : ('a, 'm) gexpr -> ('a, < assertions : yes ; .. >, 'm) base_gexpr
   | EFatalError : Runtime.error -> ('a, < .. >, 'm) base_gexpr
+  | EPos : Pos.t -> ('a, < defaultTerms : no ; .. >, 'm) base_gexpr
+      (** Position literal, used along returned exceptions *)
   (* Default terms *)
   | EDefault : {
       excepts : ('a, 'm) gexpr list;

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -452,8 +452,7 @@ type ('a, 'm) marked = ('a, 'm mark) Mark.ed
 
 (** Define a common base type for the expressions in most passes of the compiler *)
 
-(** Literals are the same throughout compilation except for the [LEmptyError]
-    case which is eliminated midway through. *)
+(** Literals are the same throughout compilation. *)
 type lit =
   | LBool of bool
   | LInt of Runtime.integer
@@ -599,8 +598,11 @@ and ('a, 'b, 'm) base_gexpr =
       -> ('a, < explicitScopes : no ; .. >, 't) base_gexpr
   | EAssert : ('a, 'm) gexpr -> ('a, < assertions : yes ; .. >, 'm) base_gexpr
   | EFatalError : Runtime.error -> ('a, < .. >, 'm) base_gexpr
-  | EPos : Pos.t -> ('a, < defaultTerms : no ; .. >, 'm) base_gexpr
-      (** Position literal, used along returned exceptions *)
+  | EPos : Pos.t -> ('a, < .. >, 'm) base_gexpr
+      (** Position literal, used along returned exceptions. Note that it's only
+          used in lcalc, so it could have [< defaultTerms: no; ..>], but since
+          the HandleExceptions operator isn't limited to that it would be
+          inconvenient *)
   (* Default terms *)
   | EDefault : {
       excepts : ('a, 'm) gexpr list;

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -263,6 +263,7 @@ let typed = Typed { pos = Pos.no_pos; ty = TLit TUnit, Pos.no_pos }
 (* - Predefined types (option) - *)
 
 let option_enum = EnumName.fresh [] ("Eoption", Pos.no_pos)
+let option_struct = StructName.fresh [] ("Soption", Pos.no_pos)
 
 (* Warning: order of these definitions is important, binary injection assumes
    that None is first *)
@@ -994,6 +995,8 @@ let make_puredefault e =
     map_mark (fun pos -> pos) (fun ty -> TDefault ty, Mark.get ty) (Mark.get e)
   in
   epuredefault e mark
+
+let make_pos p m0 = epos p (with_ty m0 ~pos:p (TLit TPos, p))
 
 let fun_id ?(var_name : string = "x") mark : ('a any, 'm) boxed_gexpr =
   let x = Var.make var_name in

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -818,7 +818,7 @@ let rec compare : type a. (a, _) gexpr -> (a, _) gexpr -> int =
   | EInj _, _ -> -1 | _, EInj _ -> 1
   | EAssert _, _ -> -1 | _, EAssert _ -> 1
   | EFatalError _, _ -> -1 | _, EFatalError _ -> 1
-  | EPos _, _ -> . | _, EPos _ -> .
+  | EPos _, _ -> -1 | _, EPos _ -> 1
   | EDefault _, _ -> -1 | _, EDefault _ -> 1
   | EPureDefault _, _ -> -1 | _, EPureDefault _ -> 1
   | EEmpty , _ -> -1 | _, EEmpty  -> 1

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -91,9 +91,7 @@ val eassert :
   ((< assertions : yes ; .. > as 'a), 'm) boxed_gexpr
 
 val efatalerror : Runtime.error -> 'm mark -> (< .. >, 'm) boxed_gexpr
-
-val epos :
-  Pos.t -> 'm mark -> ((< defaultTerms : no ; .. > as 'a), 'm) boxed_gexpr
+val epos : Pos.t -> 'm mark -> ('a any, 'm) boxed_gexpr
 
 val eappop :
   op:'a operator Mark.pos ->

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -92,6 +92,9 @@ val eassert :
 
 val efatalerror : Runtime.error -> 'm mark -> (< .. >, 'm) boxed_gexpr
 
+val epos :
+  Pos.t -> 'm mark -> ((< defaultTerms : no ; .. > as 'a), 'm) boxed_gexpr
+
 val eappop :
   op:'a operator Mark.pos ->
   args:('a, 'm) boxed_gexpr list ->

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -230,6 +230,10 @@ val typed : typed mark
 (** {2 Predefined types} *)
 
 val option_enum : EnumName.t
+
+val option_struct : StructName.t
+(** Only used in some backends where enums piggy-back on structs (e.g. C) *)
+
 val none_constr : EnumConstructor.t
 val some_constr : EnumConstructor.t
 val option_enum_config : typ EnumConstructor.Map.t
@@ -370,6 +374,10 @@ val make_app :
 
 val make_puredefault :
   ('a, 'm) boxed_gexpr -> ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr
+
+val make_pos :
+  Pos.t -> 'm mark -> ((< defaultTerms : no ; .. > as 'a), 'm) boxed_gexpr
+(** [m] is used as type witness, but both position and type are overriden *)
 
 val make_erroronempty :
   ('a, 'm) boxed_gexpr -> ((< defaultTerms : yes ; .. > as 'a), 'm) boxed_gexpr

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -494,6 +494,15 @@ let rec runtime_to_val :
   | TLit TMoney -> ELit (LMoney (Obj.obj o)), m
   | TLit TDate -> ELit (LDate (Obj.obj o)), m
   | TLit TDuration -> ELit (LDuration (Obj.obj o)), m
+  | TLit TPos ->
+    let rpos : Runtime.source_position = Obj.obj o in
+    let p =
+      Pos.from_info rpos.filename rpos.start_line rpos.start_column
+        rpos.end_line rpos.end_column
+    in
+    let p = Pos.overwrite_law_info p rpos.law_headings in
+    (* This is only allowed in lcalc, but the typer doesn't know *)
+    Obj.magic (EPos p), m
   | TTuple ts ->
     ( ETuple
         (List.map2
@@ -571,6 +580,18 @@ and val_to_runtime :
   | TLit TMoney, ELit (LMoney m) -> Obj.repr m
   | TLit TDate, ELit (LDate t) -> Obj.repr t
   | TLit TDuration, ELit (LDuration d) -> Obj.repr d
+  | TLit TPos, EPos p ->
+    let rpos : Runtime.source_position =
+      {
+        Runtime.filename = Pos.get_file p;
+        start_line = Pos.get_start_line p;
+        start_column = Pos.get_start_column p;
+        end_line = Pos.get_end_line p;
+        end_column = Pos.get_end_column p;
+        law_headings = Pos.get_law_info p;
+      }
+    in
+    Obj.repr rpos
   | TTuple ts, ETuple es ->
     List.map2 (val_to_runtime eval_expr ctx) ts es |> Array.of_list |> Obj.repr
   | TStruct name1, EStruct { name; fields } ->
@@ -724,7 +745,7 @@ let rec evaluate_expr :
   | EAppOp { op; args; _ } ->
     let args = List.map (evaluate_expr ctx lang) args in
     evaluate_operator (evaluate_expr ctx lang) op m lang args
-  | EAbs _ | ELit _ | ECustom _ | EEmpty -> e (* these are values *)
+  | EAbs _ | ELit _ | EPos _ | ECustom _ | EEmpty -> e (* these are values *)
   | EStruct { fields = es; name } ->
     let fields, es = List.split (StructField.Map.bindings es) in
     let es = List.map (evaluate_expr ctx lang) es in
@@ -982,6 +1003,7 @@ let addcustom e =
     | (EPureDefault _, _) as e -> Expr.map ~f e
     | (EEmpty, _) as e -> Expr.map ~f e
     | (EErrorOnEmpty _, _) as e -> Expr.map ~f e
+    | (EPos _, _) as e -> Expr.map ~f e
     | ( ( EAssert _ | EFatalError _ | ELit _ | EApp _ | EArray _ | EVar _
         | EExternal _ | EAbs _ | EIfThenElse _ | ETuple _ | ETupleAccess _
         | EInj _ | EStruct _ | EStructAccess _ | EMatch _ ),
@@ -1012,6 +1034,7 @@ let delcustom e =
     | (EPureDefault _, _) as e -> Expr.map ~f e
     | (EEmpty, _) as e -> Expr.map ~f e
     | (EErrorOnEmpty _, _) as e -> Expr.map ~f e
+    | (EPos _, _) as e -> Expr.map ~f e
     | ( ( EAssert _ | EFatalError _ | ELit _ | EApp _ | EArray _ | EVar _
         | EExternal _ | EAbs _ | EIfThenElse _ | ETuple _ | ETupleAccess _
         | EInj _ | EStruct _ | EStructAccess _ | EMatch _ ),

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -69,7 +69,7 @@ let tlit (fmt : Format.formatter) (l : typ_lit) : unit =
     | TMoney -> "money"
     | TDuration -> "duration"
     | TDate -> "date"
-    | TPos -> "position")
+    | TPos -> "source_position")
 
 let location (type a) (fmt : Format.formatter) (l : a glocation) : unit =
   match l with

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -68,7 +68,8 @@ let tlit (fmt : Format.formatter) (l : typ_lit) : unit =
     | TRat -> "decimal"
     | TMoney -> "money"
     | TDuration -> "duration"
-    | TDate -> "date")
+    | TDate -> "date"
+    | TPos -> "position")
 
 let location (type a) (fmt : Format.formatter) (l : a glocation) : unit =
   match l with
@@ -439,6 +440,7 @@ module Precedence = struct
     | EPureDefault _ -> Contained
     | EEmpty -> Contained
     | EErrorOnEmpty _ -> App
+    | EPos _ -> Contained
     | ECustom _ -> Contained
 
   let needs_parens ~context ?(rhs = false) e =
@@ -676,6 +678,7 @@ module ExprGen (C : EXPR_PARAM) = struct
       | EErrorOnEmpty e' ->
         Format.fprintf fmt "@[<hov 2>%a@ %a@]" op_style "error_empty"
           (rhs exprc) e'
+      | EPos p -> Format.fprintf fmt "<%s>" (Pos.to_string_shorter p)
       | EAssert e' ->
         Format.fprintf fmt "@[<hov 2>%a@ %a%a%a@]" keyword "assert" punctuation
           "(" (rhs exprc) e' punctuation ")"
@@ -1127,7 +1130,7 @@ module UserFacing = struct
     | EExternal _ -> Format.pp_print_string ppf "<external>"
     | EApp _ | EAppOp _ | EVar _ | EIfThenElse _ | EMatch _ | ETupleAccess _
     | EStructAccess _ | EAssert _ | EFatalError _ | EDefault _ | EPureDefault _
-    | EErrorOnEmpty _ | ELocation _ | EScopeCall _ | EDStructAmend _
+    | EErrorOnEmpty _ | EPos _ | ELocation _ | EScopeCall _ | EDStructAmend _
     | EDStructAccess _ ->
       fallback ppf e
 

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -993,6 +993,7 @@ and typecheck_expr_top_down :
     in
     Expr.eassert e1' mark
   | A.EFatalError err -> Expr.efatalerror err context_mark
+  | A.EPos p -> Expr.epos p (ty_mark (TLit TPos))
   | A.EEmpty ->
     Expr.eempty (ty_mark (TDefault (unionfind (TAny (Any.fresh ())))))
   | A.EErrorOnEmpty e1 ->

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -314,7 +314,13 @@ let polymorphic_op_type (op : Operator.polymorphic A.operator Mark.pos) :
     | Log (PosRecordIfTrueBool, _) -> [bt] @-> bt
     | Log _ -> [any] @-> any
     | Length -> [array any] @-> it
-    | HandleExceptions -> [array (option any)] @-> option any
+    | HandleExceptions ->
+      let pair a b =
+        lazy (UnionFind.make (TTuple [Lazy.force a; Lazy.force b], pos))
+      in
+      let tpos = lazy (UnionFind.make (TLit A.TPos, pos)) in
+      let texn = option (pair any tpos) in
+      [array texn] @-> texn
     | ToClosureEnv -> [any] @-> cet
     | FromClosureEnv -> [cet] @-> any
   in

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -167,6 +167,7 @@ let rec print_z3model_expr (ctx : context) (ty : typ) (e : Expr.expr) : string =
     (* TODO: Use differnt dates conventions depending on the language ? *)
     | TDate -> nb_days_to_date (int_of_string (Expr.to_string e))
     | TDuration -> Format.asprintf "%s days" (Expr.to_string e)
+    | TPos -> ""
   in
 
   match Mark.remove ty with
@@ -274,6 +275,7 @@ let translate_typ_lit (ctx : context) (t : typ_lit) : Sort.sort =
      Jan 1, 1900 *)
   | TDate -> Arithmetic.Integer.mk_sort ctx.ctx_z3
   | TDuration -> Arithmetic.Integer.mk_sort ctx.ctx_z3
+  | TPos -> fst ctx.ctx_z3unit
 
 (** [translate_typ] returns the Z3 sort correponding to the Catala type [t] **)
 let rec translate_typ (ctx : context) (t : naked_typ) : context * Sort.sort =

--- a/compiler/verification/z3backend.real.ml
+++ b/compiler/verification/z3backend.real.ml
@@ -766,6 +766,7 @@ and translate_expr (ctx : context) (vc : typed expr) : context * Expr.expr =
     ctx, Boolean.mk_ite ctx.ctx_z3 z3_if z3_then z3_else
   | EEmpty -> failwith "[Z3 encoding] 'Empty' literals not supported"
   | EErrorOnEmpty _ -> failwith "[Z3 encoding] ErrorOnEmpty unsupported"
+  | EPos _ -> failwith "[Z3 encoding] EPos unsupported"
   | _ -> .
 
 (** [create_z3unit] creates a Z3 sort and expression corresponding to the unit

--- a/runtimes/c/runtime.c
+++ b/runtimes/c/runtime.c
@@ -910,7 +910,7 @@ void catala_init(void)
     printf("\033[1;31m[ERROR]\033[m %s", error_kind);
     for (i = 0; i < catala_error_raised.nb_positions; i++) {
       if (pos[i]->filename)
-        printf("\n        in file %s:%d.%d-%d.%d\n",
+        printf("\n        in file %s:%d.%d-%d.%d",
              pos[i]->filename,
              pos[i]->start_line,
              pos[i]->start_column,

--- a/runtimes/c/runtime.c
+++ b/runtimes/c/runtime.c
@@ -34,15 +34,17 @@ __thread const catala_code_position catala_empty_position =
   { NULL, 0, 0, 0, 0 };
 
 __thread struct catala_error catala_error_raised =
-  { catala_empty_position, 0 };
+  { NULL, 0, 0 };
 
 __thread jmp_buf catala_error_jump_buffer;
 
 void catala_error(catala_error_code code,
-                  const catala_code_position * pos)
+                  const catala_code_position ** pos,
+                  const int npos)
 {
   catala_error_raised.code = code;
-  catala_error_raised.position = *pos;
+  catala_error_raised.position = pos;
+  catala_error_raised.nb_positions = npos;
   catala_persistent_malloc_mode_on = 0;
   longjmp(catala_error_jump_buffer, 1);
 }
@@ -421,7 +423,7 @@ CATALA_DATE o_add_dat_dur (dc_date_rounding mode,
 {
   dc_date *ret = catala_malloc(sizeof(dc_date));
   if (dc_add_dates(ret, mode, x1, x2) != dc_ok)
-    catala_error(catala_ambiguous_date_rounding, pos);
+    catala_error(catala_ambiguous_date_rounding, &pos, 1);
   return ret;
 }
 
@@ -468,7 +470,7 @@ CATALA_DATE o_sub_dat_dur (dc_date_rounding mode,
   dc_date *ret = catala_malloc(sizeof(dc_date));
   dc_neg_period(&dur, x2);
   if (dc_add_dates(ret, mode, x1, &dur) != dc_ok)
-    catala_error(catala_ambiguous_date_rounding, pos);
+    catala_error(catala_ambiguous_date_rounding, &pos, 1);
   return ret;
 }
 
@@ -522,7 +524,7 @@ CATALA_DEC o_div_int_int (const catala_code_position* pos,
 {
   CATALA_NEW_MPQ(ret);
   if (mpz_sgn(x2) == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   mpz_set(mpq_numref(ret), x1);
   mpz_set(mpq_denref(ret), x2);
   mpq_canonicalize(ret);
@@ -535,7 +537,7 @@ CATALA_DEC o_div_rat_rat (const catala_code_position* pos,
 {
   CATALA_NEW_MPQ(ret);
   if (mpq_sgn(x2) == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   mpq_div(ret, x1, x2);
   return ret;
 }
@@ -546,7 +548,7 @@ CATALA_DEC o_div_mon_mon (const catala_code_position* pos,
 {
   CATALA_NEW_MPQ(ret);
   if (mpz_sgn(x2) == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   mpz_set(mpq_numref(ret), x1);
   mpz_set(mpq_denref(ret), x2);
   mpq_canonicalize(ret);
@@ -559,7 +561,7 @@ CATALA_MONEY o_div_mon_int (const catala_code_position* pos,
 {
   CATALA_NEW_MPZ(ret);
   if (mpz_sgn(x2) == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   round_div(ret, x1, x2);
   return ret;
 }
@@ -570,7 +572,7 @@ CATALA_MONEY o_div_mon_rat (const catala_code_position* pos,
 {
   CATALA_NEW_MPZ(ret);
   if (mpq_sgn(x2) == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   mpz_mul(ret, x1, mpq_denref(x2));
   round_div(ret, ret, mpq_numref(x2));
   return ret;
@@ -584,9 +586,9 @@ CATALA_DEC o_div_dur_dur (const catala_code_position* pos,
   CATALA_NEW_MPQ(ret);
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   if (days2 == 0)
-    catala_error(catala_division_by_zero, pos);
+    catala_error(catala_division_by_zero, &pos, 1);
   mpz_set_si(mpq_numref(ret), days1);
   mpz_set_si(mpq_denref(ret), days2);
   mpq_canonicalize(ret);
@@ -622,7 +624,7 @@ CATALA_BOOL o_eq_dur_dur (const catala_code_position* pos,
     return CATALA_TRUE;
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   return CATALA_NEW_BOOL(days1 == days2);
 }
 
@@ -647,7 +649,7 @@ CATALA_BOOL o_lt_dur_dur (const catala_code_position* pos,
   long int days1, days2 = 0;
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   return CATALA_NEW_BOOL(days1 < days2);
 }
 
@@ -672,7 +674,7 @@ CATALA_BOOL o_lte_dur_dur (const catala_code_position* pos,
   long int days1, days2 = 0;
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   return CATALA_NEW_BOOL(days1 <= days2);
 }
 
@@ -697,7 +699,7 @@ CATALA_BOOL o_gt_dur_dur (const catala_code_position* pos,
   long int days1, days2 = 0;
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   return CATALA_NEW_BOOL(days1 > days2);
 }
 
@@ -722,7 +724,7 @@ CATALA_BOOL o_gte_dur_dur (const catala_code_position* pos,
   long int days1, days2 = 0;
   if (dc_period_to_days(&days1, x1) != dc_ok ||
       dc_period_to_days(&days2, x2) != dc_ok)
-    catala_error(catala_uncomparable_durations, pos);
+    catala_error(catala_uncomparable_durations, &pos, 1);
   return CATALA_NEW_BOOL(days1 >= days2);
 }
 
@@ -795,7 +797,7 @@ const CATALA_ARRAY(Z) o_map2 (const catala_code_position* pos,
     (void* (*)(const CLOSURE_ENV, const void*, const void*))cls->funcp;
   catala_array* ret = catala_malloc(sizeof(catala_array));
   if (x->size != y->size)
-    catala_error(catala_not_same_length, pos);
+    catala_error(catala_not_same_length, &pos, 1);
   ret->size = x->size;
   ret->elements = catala_malloc(ret->size * sizeof(void*));
   for (i=0; i < x->size; i++)
@@ -832,17 +834,25 @@ CATALA_BOOL catala_isnone (const CATALA_OPTION() opt)
   return CATALA_NEW_BOOL(opt->code == catala_option_none);
 }
 
-const CATALA_OPTION() handle_exceptions
-  (const CATALA_ARRAY(const catala_code_position*) pos,
-   const CATALA_ARRAY(const CATALA_OPTION()) e)
+const CATALA_EXN(_) handle_exceptions
+  (const CATALA_ARRAY(const CATALA_EXN) e)
 {
   int i, j;
   unsigned int size = e->size;
-  const CATALA_OPTION() * excs = (const CATALA_OPTION() *)e->elements;
+  const CATALA_EXN(_) * excs = (const CATALA_OPTION() *)e->elements;
   for (i = 0; i < size && excs[i]->code == catala_option_none; i++) {}
   if (i >= size) return CATALA_NONE;
   for(j = i + 1; j < size && excs[j]->code == catala_option_none; j++) {}
-  if (j < size) catala_error(catala_conflict, pos->elements[j]);
+  if (j < size) {
+    int k, count;
+    const catala_code_position ** pos =
+      catala_malloc (size * sizeof(catala_code_position *));
+    pos[0] = ((CATALA_TUPLE(_))(excs[i]->payload))[1].content;
+    for (k = j, count = 1; k < size; k++)
+      if (excs[k]->code == catala_option_some)
+        pos[count++] = ((CATALA_TUPLE(_))(excs[k]->payload))[1].content;
+    catala_error(catala_conflict, pos, count);
+  }
   return excs[i];
 }
 
@@ -859,7 +869,8 @@ void catala_init(void)
   mp_set_memory_functions(&catala_malloc,&catala_realloc,&catala_free);
   if (setjmp(catala_error_jump_buffer)) {
     char *error_kind;
-    const catala_code_position pos = catala_error_raised.position;
+    int i;
+    const catala_code_position ** pos = catala_error_raised.position;
     if (error_handler != NULL) {
       error_handler(&catala_error_raised);
       return;
@@ -896,16 +907,17 @@ void catala_init(void)
       error_kind = "Out of memory";
       break;
     }
-    if (pos.filename == NULL)
-      printf("\033[1;31m[ERROR]\033[m %s\n", error_kind);
-    else
-      printf("\033[1;31m[ERROR]\033[m %s in file %s:%d.%d-%d.%d\n",
-             error_kind,
-             pos.filename,
-             pos.start_line,
-             pos.start_column,
-             pos.end_line,
-             pos.end_column);
+    printf("\033[1;31m[ERROR]\033[m %s", error_kind);
+    for (i = 0; i < catala_error_raised.nb_positions; i++) {
+      if (pos[i]->filename)
+        printf("\n        in file %s:%d.%d-%d.%d\n",
+             pos[i]->filename,
+             pos[i]->start_line,
+             pos[i]->start_column,
+             pos[i]->end_line,
+             pos[i]->end_column);
+    }
+    printf("\n");
     catala_free_all();
     exit(10);
   }

--- a/runtimes/c/runtime.h
+++ b/runtimes/c/runtime.h
@@ -48,12 +48,14 @@ typedef struct catala_code_position
 
 struct catala_error
 {
-  catala_code_position position;
+  const catala_code_position ** position;
+  int nb_positions;
   catala_error_code code;
 };
 
 void catala_error(catala_error_code code,
-                  const catala_code_position * pos);
+                  const catala_code_position ** pos,
+                  const int nb_pos);
 
 /* --- Memory allocations --- */
 
@@ -79,12 +81,14 @@ void catala_unset_persistent_malloc(void);
 #define CATALA_DATE const dc_date*
 #define CATALA_DURATION const dc_period*
 #define CATALA_ARRAY(_) catala_array*
-#define CATALA_POSITOIN const catala_code_position*
+#define CATALA_POSITION const catala_code_position*
 
 typedef struct tuple_element {
   const void* content;
 } tuple_element;
-#define CATALA_TUPLE tuple_element*
+#define CATALA_TUPLE(_) tuple_element*
+
+#define CATALA_EXN(X) CATALA_OPTION(CATALA_TUPLE(X,CATALA_POSITION))
 
 #define CLOSURE_ENV void**
 
@@ -333,9 +337,8 @@ const CATALA_ARRAY(Z) o_map2 (const catala_code_position* pos,
 const CATALA_ARRAY(Z) o_concat (const CATALA_ARRAY(X) x,
                                 const CATALA_ARRAY(Y) y);
 
-const CATALA_OPTION() handle_exceptions
-  (const CATALA_ARRAY(const catala_code_position*) pos,
-   const CATALA_ARRAY(const CATALA_OPTION()) e);
+const CATALA_EXN(X) handle_exceptions
+  (const CATALA_ARRAY(const CATALA_EXN(X)) e);
 
 /* --- Runtime initialisation --- */
 

--- a/runtimes/c/runtime.h
+++ b/runtimes/c/runtime.h
@@ -79,6 +79,7 @@ void catala_unset_persistent_malloc(void);
 #define CATALA_DATE const dc_date*
 #define CATALA_DURATION const dc_period*
 #define CATALA_ARRAY(_) catala_array*
+#define CATALA_POSITOIN const catala_code_position*
 
 typedef struct tuple_element {
   const void* content;

--- a/runtimes/jsoo/runtime.ml
+++ b/runtimes/jsoo/runtime.ml
@@ -70,8 +70,29 @@ let date_of_js d =
   | _ -> fail ()
 
 let date_to_js d = Js.string @@ R_ocaml.date_to_string d
-let position_of_js _jpos = assert false (* TODO *)
-let position_to_js _pos = assert false (* TODO *)
+
+let position_of_js (jpos : source_position Js.t) : R_ocaml.source_position =
+  {
+    R_ocaml.filename = Js.to_string jpos##.fileName;
+    start_line = jpos##.startLine;
+    start_column = jpos##.startColumn;
+    end_line = jpos##.endLine;
+    end_column = jpos##.endColumn;
+    law_headings =
+      Js.to_array jpos##.lawHeadings |> Array.map Js.to_string |> Array.to_list;
+  }
+
+let position_to_js (pos : R_ocaml.source_position) : source_position Js.t =
+  object%js
+    val mutable fileName = Js.string pos.R_ocaml.filename
+    val mutable startLine = pos.R_ocaml.start_line
+    val mutable endLine = pos.R_ocaml.end_line
+    val mutable startColumn = pos.R_ocaml.start_column
+    val mutable endColumn = pos.R_ocaml.end_column
+
+    val mutable lawHeadings =
+      Array.of_list pos.law_headings |> Array.map Js.string |> Js.array
+  end
 
 class type event_manager = object
   method resetLog : unit Js.meth

--- a/runtimes/jsoo/runtime.ml
+++ b/runtimes/jsoo/runtime.ml
@@ -70,6 +70,8 @@ let date_of_js d =
   | _ -> fail ()
 
 let date_to_js d = Js.string @@ R_ocaml.date_to_string d
+let position_of_js _jpos = assert false (* TODO *)
+let position_to_js _pos = assert false (* TODO *)
 
 class type event_manager = object
   method resetLog : unit Js.meth

--- a/runtimes/jsoo/runtime.mli
+++ b/runtimes/jsoo/runtime.mli
@@ -108,6 +108,12 @@ val date_to_js : Runtime_ocaml.Runtime.date -> Js.js_string Js.t
 
 (** {1 Error management} *)
 
+val position_of_js :
+  source_position Js.t -> Runtime_ocaml.Runtime.source_position
+
+val position_to_js :
+  Runtime_ocaml.Runtime.source_position -> source_position Js.t
+
 val execute_or_throw_error : (unit -> 'a) -> 'a
 (** [execute_or_throw_error f] calls [f ()] and propagates the
     {!Runtime_ocaml.Runtime.NoValueProvided},

--- a/runtimes/ocaml/runtime.ml
+++ b/runtimes/ocaml/runtime.ml
@@ -777,21 +777,24 @@ module EventParser = struct
     ctx.events
 end
 
-let handle_exceptions
-    (pos : source_position array)
-    (exceptions : 'a Eoption.t array) : 'a Eoption.t =
+let handle_exceptions (exceptions : ('a * source_position) Eoption.t array) :
+    ('a * source_position) Eoption.t =
   let len = Array.length exceptions in
   let rec filt_except i =
     if i < len then
       match exceptions.(i) with
-      | Eoption.ESome _ as new_val -> (new_val, i) :: filt_except (i + 1)
+      | Eoption.ESome _ as new_val -> new_val :: filt_except (i + 1)
       | Eoption.ENone () -> filt_except (i + 1)
     else []
   in
   match filt_except 0 with
   | [] -> Eoption.ENone ()
-  | [(res, _)] -> res
-  | res -> error Conflict (List.map (fun (_, i) -> pos.(i)) res)
+  | [res] -> res
+  | res ->
+    error Conflict
+      (List.map
+         (function Eoption.ESome (_, pos) -> pos | _ -> assert false)
+         res)
 
 (* TODO: add a compare built-in to dates_calc. At the moment this fails on e.g.
    [3 months, 4 months] *)

--- a/runtimes/ocaml/runtime.mli
+++ b/runtimes/ocaml/runtime.mli
@@ -342,7 +342,7 @@ val duration_to_string : duration -> string
 (**{1 Defaults} *)
 
 val handle_exceptions :
-  source_position array -> 'a Eoption.t array -> 'a Eoption.t
+  ('a * source_position) Eoption.t array -> ('a * source_position) Eoption.t
 (** @raise Error Conflict *)
 
 (**{1 Operators} *)

--- a/tests/array/good/aggregation_4.catala_en
+++ b/tests/array/good/aggregation_4.catala_en
@@ -102,10 +102,10 @@ let topval closure_aggregate_periods_from_last_five_years__3 :
                in
                (aggregate_periods_from_last_five_years,
                  to_closure_env (date_of_sale_or_exchange)))
-            periods))
+            periods, <aggregation_4:25.5-32.29>))
   with
   | ENone → error NoValue
-  | ESome arg → arg
+  | ESome arg → arg.0
 
 let scope section121_single_person
   (section121_single_person_in:
@@ -142,14 +142,14 @@ let scope section121_single_person
             code_and_env.0 code_and_env.1 property_ownage)
            >= [0 years, 0 months, 730 days]
          then
-           ESome true
+           ESome (true, <aggregation_4:36.14-24>)
          else ENone ()
        with
-       | ENone → ESome false
+       | ENone → ESome (false, <aggregation_4:13.10-36>)
        | ESome x → ESome x)
     with
     | ENone → error NoValue
-    | ESome arg → arg
+    | ESome arg → arg.0
   in
   return { Section121SinglePerson
            requirements_ownership_met = requirements_ownership_met;

--- a/tests/backends/output/simple.c
+++ b/tests/backends/output/simple.c
@@ -30,47 +30,65 @@ typedef struct Bar {
 } Bar;
 
 typedef struct Baz_in {
-  const CATALA_OPTION(Bar*) a_in;
+  const CATALA_OPTION(CATALA_TUPLE(Bar*;CATALA_POSITION)) a_in;
 } Baz_in;
 
 static const Baz* baz (const Baz_in* baz_in)
 {
-  const CATALA_OPTION(Bar*) a = baz_in->a_in;
+  const CATALA_OPTION(CATALA_TUPLE(Bar*;CATALA_POSITION)) a = baz_in->a_in;
   const Bar* a__1;
-  const CATALA_OPTION(Bar*) a__2;
+  const CATALA_OPTION(CATALA_TUPLE(Bar*;CATALA_POSITION)) a__2;
   CATALA_DEC b;
-  const CATALA_OPTION(CATALA_DEC) b__1;
-  const CATALA_OPTION(CATALA_DEC) b__2;
+  const CATALA_OPTION(CATALA_TUPLE(CATALA_DEC;CATALA_POSITION)) b__1;
+  const CATALA_OPTION(CATALA_TUPLE(CATALA_DEC;CATALA_POSITION)) b__2;
   CATALA_BOOL b__3;
   const CATALA_ARRAY(CATALA_DEC) c;
-  CATALA_ARRAY(CATALA_DEC) const c__2 = catala_malloc(sizeof(catala_array));
-  const CATALA_OPTION(CATALA_ARRAY(CATALA_DEC)) c__1;
+  CATALA_ARRAY(CATALA_DEC) const c__3 = catala_malloc(sizeof(catala_array));
+  static const catala_code_position pos[1] =
+    {{"tests/backends/simple.catala_en", 27, 23, 27, 28}};
+  CATALA_TUPLE(CATALA_ARRAY(CATALA_DEC);CATALA_POSITION) const c__2 =
+    catala_malloc(2 * sizeof(tuple_element*));
+  const CATALA_OPTION(CATALA_TUPLE(CATALA_ARRAY(CATALA_DEC);CATALA_POSITION))
+    c__1;
   Baz* const baz__1 = catala_malloc(sizeof(Baz));
   if (a->code == catala_option_some) {
     a__2 = catala_some(a->payload);
   } else {
-    const Bar* a__3;
-    Bar* const a__5 = catala_malloc(sizeof(Bar));
-    const CATALA_OPTION(Bar*) a__4;
-    a__5->code = Bar__NO;
-    a__5->payload.Bar__NO = CATALA_UNITVAL;
-    a__4 = catala_some(a__5);
-    if (a__4->code == catala_option_some) {
-      a__3 = a__4->payload;
+    const Bar* a__4;
+    Bar* const a__7 = catala_malloc(sizeof(Bar));
+    static const catala_code_position pos[1] =
+      {{"tests/backends/simple.catala_en", 16, 23, 16, 25}};
+    CATALA_TUPLE(Bar*;CATALA_POSITION) const a__6 =
+      catala_malloc(2 * sizeof(tuple_element*));
+    const CATALA_OPTION(CATALA_TUPLE(Bar*;CATALA_POSITION)) a__5;
+    static const catala_code_position pos__1[1] =
+      {{"tests/backends/simple.catala_en", 11, 11, 11, 12}};
+    CATALA_TUPLE(Bar*;CATALA_POSITION) const a__3 =
+      catala_malloc(2 * sizeof(tuple_element*));
+    a__7->code = Bar__NO;
+    a__7->payload.Bar__NO = CATALA_UNITVAL;
+    a__6[0].content = a__7;
+    a__6[1].content = pos;
+    a__5 = catala_some(a__6);
+    if (a__5->code == catala_option_some) {
+      a__4 = (Bar*)(((CATALA_TUPLE(_))a__5->payload)[0].content);
     } else {
-      static const catala_code_position pos[1] =
+      static const catala_code_position pos__1[1] =
         {{"tests/backends/simple.catala_en", 11, 11, 11, 12}};
-      catala_error(catala_no_value, pos);
+      catala_error(catala_no_value,
+        (const catala_code_position **)&pos__1, 1);
       abort();
     }
+    a__3[0].content = a__4;
+    a__3[1].content = pos__1;
     a__2 = catala_some(a__3);
   }
   if (a__2->code == catala_option_some) {
-    a__1 = a__2->payload;
+    a__1 = (Bar*)(((CATALA_TUPLE(_))a__2->payload)[0].content);
   } else {
     static const catala_code_position pos[1] =
       {{"tests/backends/simple.catala_en", 11, 11, 11, 12}};
-    catala_error(catala_no_value, pos);
+    catala_error(catala_no_value, (const catala_code_position **)&pos, 1);
     abort();
   }
   switch (a__1->code) {
@@ -86,54 +104,68 @@ static const Baz* baz (const Baz_in* baz_in)
       abort();
   }
   if (b__3 == CATALA_TRUE) {
-    b__2 = catala_some(catala_new_dec_str("42"));
+    static const catala_code_position pos[1] =
+      {{"tests/backends/simple.catala_en", 25, 22, 25, 26}};
+    CATALA_TUPLE(CATALA_DEC;CATALA_POSITION) const b__4 =
+      catala_malloc(2 * sizeof(tuple_element*));
+    b__4[0].content = catala_new_dec_str("42");
+    b__4[1].content = pos;
+    b__2 = catala_some(b__4);
   } else {
     b__2 = CATALA_NONE;
   }
   if (b__2->code == catala_option_some) {
     b__1 = catala_some(b__2->payload);
   } else {
-    CATALA_DEC b__4;
+    CATALA_DEC b__5;
+    static const catala_code_position pos[1] =
+      {{"tests/backends/simple.catala_en", 19, 5, 21, 54}};
+    CATALA_TUPLE(CATALA_DEC;CATALA_POSITION) const b__4 =
+      catala_malloc(2 * sizeof(tuple_element*));
     switch (a__1->code) {
       case Bar__NO: {
-        b__4 = catala_new_dec_str("0");
+        b__5 = catala_new_dec_str("0");
         break;
       }
       case Bar__YES: {
         const Foo* foo = a__1->payload.Bar__YES;
-        CATALA_DEC b__5;
+        CATALA_DEC b__6;
         if (foo->x == CATALA_TRUE) {
-          b__5 = catala_new_dec_str("1");
+          b__6 = catala_new_dec_str("1");
         } else {
-          b__5 = catala_new_dec_str("0");
+          b__6 = catala_new_dec_str("0");
         }
-        b__4 = o_add_rat_rat(foo->y, b__5);
+        b__5 = o_add_rat_rat(foo->y, b__6);
         break;
       }
       default:
         abort();
     }
+    b__4[0].content = b__5;
+    b__4[1].content = pos;
     b__1 = catala_some(b__4);
   }
   if (b__1->code == catala_option_some) {
-    b = b__1->payload;
+    b = (CATALA_DEC)(((CATALA_TUPLE(_))b__1->payload)[0].content);
   } else {
     static const catala_code_position pos[1] =
       {{"tests/backends/simple.catala_en", 12, 10, 12, 11}};
-    catala_error(catala_no_value, pos);
+    catala_error(catala_no_value, (const catala_code_position **)&pos, 1);
     abort();
   }
-  c__2->size = 2;
-  c__2->elements = catala_malloc(2 * sizeof(void*));
-  c__2->elements[0] = b;
-  c__2->elements[1] = b;
+  c__3->size = 2;
+  c__3->elements = catala_malloc(2 * sizeof(void*));
+  c__3->elements[0] = b;
+  c__3->elements[1] = b;
+  c__2[0].content = c__3;
+  c__2[1].content = pos;
   c__1 = catala_some(c__2);
   if (c__1->code == catala_option_some) {
-    c = c__1->payload;
+    c = (CATALA_ARRAY(CATALA_DEC))(((CATALA_TUPLE(_))c__1->payload)[0].content);
   } else {
-    static const catala_code_position pos[1] =
+    static const catala_code_position pos__1[1] =
       {{"tests/backends/simple.catala_en", 13, 10, 13, 11}};
-    catala_error(catala_no_value, pos);
+    catala_error(catala_no_value, (const catala_code_position **)&pos__1, 1);
     abort();
   }
   baz__1->b = b;

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -91,27 +91,35 @@ class BIn:
 
 def some_name(some_name_in:SomeNameIn):
     i = (some_name_in.i_in)
-    o__1 = ((i + integer_of_string("1")))
+    pos = (SourcePosition(
+               filename="tests/backends/python_name_clash.catala_en",
+               start_line=10, start_column=23, end_line=10, end_column=28,
+               law_headings=[]))
+    o__1 = (((i + integer_of_string("1")), pos))
     if o__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/backends/python_name_clash.catala_en",
-                   start_line=7, start_column=10, end_line=7, end_column=11,
-                   law_headings=[]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/backends/python_name_clash.catala_en",
+                      start_line=7, start_column=10,
+                      end_line=7, end_column=11, law_headings=[]))
+        raise NoValue(pos__1)
     else:
-        o = (o__1)
+        o = (o__1[0])
     return SomeName(o = o)
 
 def b(b_in:BIn):
-    result__2 = (integer_of_string("1"))
+    pos = (SourcePosition(
+               filename="tests/backends/python_name_clash.catala_en",
+               start_line=16, start_column=33, end_line=16, end_column=34,
+               law_headings=[]))
+    result__2 = ((integer_of_string("1"), pos))
     if result__2 is None:
-        pos = (SourcePosition(
-                   filename="tests/backends/python_name_clash.catala_en",
-                   start_line=16, start_column=14,
-                   end_line=16, end_column=25, law_headings=[]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/backends/python_name_clash.catala_en",
+                      start_line=16, start_column=14,
+                      end_line=16, end_column=25, law_headings=[]))
+        raise NoValue(pos__1)
     else:
-        result__1 = (result__2)
+        result__1 = (result__2[0])
     result = (some_name(SomeNameIn(i_in = result__1)))
     result__3 = (SomeName(o = result.o))
     if True:

--- a/tests/exception/bad/multi_same_result.catala_en
+++ b/tests/exception/bad/multi_same_result.catala_en
@@ -1,0 +1,116 @@
+
+```catala
+declaration scope A:
+  input case content integer
+  output taux content decimal
+
+scope A:
+  definition taux
+  under condition case = 1
+  consequence equals 50%
+
+  definition taux
+  under condition case = 2
+  consequence equals 30% # <- no conflict expected here
+
+  definition taux
+  under condition case = 3
+  consequence equals 40% # <- no conflict expected here
+
+  definition taux
+  under condition case = 4
+  consequence equals 50%
+
+  definition taux
+  under condition case = 5
+  consequence equals 30%
+
+  definition taux
+  under condition case = 6
+  consequence equals 30% # <- this line
+
+  definition taux
+  under condition case > 5
+  consequence equals 40% # <- and this one conflict when case = 6
+
+declaration scope Test:
+  output a scope A
+
+scope Test:
+  definition a.case equals 6
+```
+
+```catala-test-inline
+$ catala dcalc -s A
+let scope A (A_in: A_in {case_in: integer}): A {taux: decimal} =
+  let get case : integer = A_in.case_in in
+  let set taux : decimal =
+    error_empty
+      ⟨ ⟨ ⟨case = 4 ⊢ ⟨0.5⟩⟩ | case = 1 ⊢ ⟨0.5⟩ ⟩,
+        ⟨ ⟨ ⟨case = 6 ⊢ ⟨0.3⟩⟩ | case = 5 ⊢ ⟨0.3⟩ ⟩ | case = 2 ⊢ ⟨0.3⟩ ⟩,
+        ⟨ ⟨case > 5 ⊢ ⟨0.4⟩⟩ | case = 3 ⊢ ⟨0.4⟩ ⟩
+      | false ⊢ ∅ ⟩
+  in
+  return { A taux = taux; }
+```
+
+
+```catala-test-inline
+$ catala interpret -s Test
+┌─[ERROR]─
+│
+│  During evaluation: conflict between multiple valid consequences for
+│  assigning the same variable.
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:30.22-30.25:
+│    │
+│ 30 │   consequence equals 30% # <- this line
+│    │                      ‾‾‾
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:34.22-34.25:
+│    │
+│ 34 │   consequence equals 40% # <- and this one conflict when case = 6
+│    │                      ‾‾‾
+└─
+#return code 123#
+```
+
+```catala-test-inline
+$ catala interpret --lcalc -s Test
+┌─[ERROR]─
+│
+│  During evaluation: conflict between multiple valid consequences for
+│  assigning the same variable.
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:30.22-30.25:
+│    │
+│ 30 │   consequence equals 30% # <- this line
+│    │                      ‾‾‾
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:34.22-34.25:
+│    │
+│ 34 │   consequence equals 40% # <- and this one conflict when case = 6
+│    │                      ‾‾‾
+└─
+#return code 123#
+```
+
+```catala-test-inline
+$ catala interpret --lcalc -s Test -O
+┌─[ERROR]─
+│
+│  During evaluation: conflict between multiple valid consequences for
+│  assigning the same variable.
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:30.22-30.25:
+│    │
+│ 30 │   consequence equals 30% # <- this line
+│    │                      ‾‾‾
+│
+├─➤ tests/exception/bad/multi_same_result.catala_en:34.22-34.25:
+│    │
+│ 34 │   consequence equals 40% # <- and this one conflict when case = 6
+│    │                      ‾‾‾
+└─
+#return code 123#
+```

--- a/tests/func/good/closure_conversion_reduce.catala_en
+++ b/tests/func/good/closure_conversion_reduce.catala_en
@@ -60,28 +60,28 @@ let scope S (s_in: S_in {x_in: list of integer}): S {y: integer} =
   let set y : integer =
     match
       (ESome
-         (let weights : list of (integer, integer) =
-            map (let y__1 : (closure_env, integer) → (integer, integer) =
-                   closure_y
-                 in
-                 (y__1, to_closure_env ()))
-              x
-          in
-          reduce
-            let y__1 :
-                (closure_env, (integer, integer), (integer, integer)) →
-                  (integer, integer) =
-              closure_y__2
-            in
-            (y__1, to_closure_env ())
-            let y__1 : (closure_env, unit) → (integer, integer) =
-              closure_y__1
-            in
-            (y__1, to_closure_env ())
-            weights).0)
+         ((let weights : list of (integer, integer) =
+             map (let y__1 : (closure_env, integer) → (integer, integer) =
+                    closure_y
+                  in
+                  (y__1, to_closure_env ()))
+               x
+           in
+           reduce
+             let y__1 :
+                 (closure_env, (integer, integer), (integer, integer)) →
+                   (integer, integer) =
+               closure_y__2
+             in
+             (y__1, to_closure_env ())
+             let y__1 : (closure_env, unit) → (integer, integer) =
+               closure_y__1
+             in
+             (y__1, to_closure_env ())
+             weights).0, <closure_conversion_reduce:11.5-97>))
     with
     | ENone → error NoValue
-    | ESome arg → arg
+    | ESome arg → arg.0
   in
   return { S y = y; }
 ```

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -70,7 +70,7 @@ type SubFoo2 = {
   x1: integer;
   y: ((closure_env, integer) → integer, closure_env);
 }
-type Foo_in = { b_in: option bool; }
+type Foo_in = { b_in: option (bool, source_position); }
 type Foo = { z: integer; }
 
 let topval closure_y : (closure_env, integer) → integer =
@@ -123,11 +123,16 @@ let topval closure_r__1 : (closure_env, integer) → integer =
   in
   code_and_env.0 code_and_env.1 param0
 
-let scope foo (foo_in: Foo_in {b_in: option bool}): Foo {z: integer} =
-  let get b : option bool = foo_in.b_in in
-  let set b__1 : bool = match b with
-                        | ENone → true
-                        | ESome x → x in
+let scope foo
+  (foo_in: Foo_in {b_in: option (bool, source_position)})
+  : Foo {z: integer}
+  =
+  let get b : option (bool, source_position) = foo_in.b_in in
+  let set b__1 : bool =
+    match b with
+    | ENone → (true, <scope_call_func_struct_closure:17.11-12>).0
+    | ESome x → x.0
+  in
   let set r :
       Result {
         r: ((closure_env, integer) → integer, closure_env);

--- a/tests/modules/good/output/mod_def.ml
+++ b/tests/modules/good/output/mod_def.ml
@@ -26,23 +26,33 @@ end
 
 let s (_: S_in.t) : S.t =
   let sr: money =
-    match (Eoption.ESome (money_of_cents_string "100000"))
+    match
+      (Eoption.ESome
+         ((money_of_cents_string "100000"),
+           ({filename="tests/modules/good/mod_def.catala_en";
+             start_line=29; start_column=24; end_line=29; end_column=30;
+             law_headings=["Test modules + inclusions 1"]})))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
                                                  start_line=16; start_column=10;
                                                  end_line=16; end_column=12;
                                                  law_headings=["Test modules + inclusions 1"]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   let e1: Enum1.t =
-    match (Eoption.ESome (Enum1.Maybe ()))
+    match
+      (Eoption.ESome
+         ((Enum1.Maybe ()),
+           ({filename="tests/modules/good/mod_def.catala_en";
+             start_line=30; start_column=24; end_line=30; end_column=29;
+             law_headings=["Test modules + inclusions 1"]})))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
                                                  start_line=17; start_column=10;
                                                  end_line=17; end_column=12;
                                                  law_headings=["Test modules + inclusions 1"]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   {S.sr = sr; S.e1 = e1}
 
 let half : integer -> decimal =

--- a/tests/monomorphisation/good/context_var.catala_en
+++ b/tests/monomorphisation/good/context_var.catala_en
@@ -10,28 +10,51 @@ scope TestXor:
 
 ```catala-test-inline
 $ catala lcalc --monomorphize-types
-type option_1 = | None_1 of unit | Some_1 of bool
+type option_1 = | None_1 of unit | Some_1 of tuple_1 {
+                                               elt_0: bool;
+                                               elt_1: source_position
+                                             }
 
-type TestXor_in = { t_in: option_1[None_1: unit | Some_1: bool]; }
+type TestXor_in = {
+  t_in: option_1[None_1: unit | Some_1:
+          tuple_1 {elt_0: bool; elt_1: source_position}];
+}
 type TestXor = { t: bool; }
+type tuple_1 = { elt_0: bool; elt_1: source_position; }
 
 let scope test_xor
-  (test_xor_in: TestXor_in {t_in: option_1[None_1: unit | Some_1: bool]})
+  (test_xor_in:
+     TestXor_in {
+       t_in:
+         option_1[None_1: unit | Some_1:
+           tuple_1 {elt_0: bool; elt_1: source_position}]
+     })
   : TestXor {t: bool}
   =
-  let get t : option_1[None_1: unit | Some_1: bool] = test_xor_in.t_in in
+  let get t :
+      option_1[None_1: unit | Some_1:
+        tuple_1 {elt_0: bool; elt_1: source_position}] =
+    test_xor_in.t_in
+  in
   let set t__1 : bool =
     match
       (match t with
        | None_1 →
          Some_1
-           (match (Some_1 true) with
-            | None_1 → error NoValue
-            | Some_1 arg → arg)
+           { tuple_1
+             elt_0 =
+               match
+                 (Some_1
+                    { tuple_1 elt_0 = true; elt_1 = <context_var:8.23-27>; })
+               with
+               | None_1 → error NoValue
+               | Some_1 arg → arg.elt_0;
+             elt_1 = <context_var:5.18-19>;
+           }
        | Some_1 x → Some_1 x)
     with
     | None_1 → error NoValue
-    | Some_1 arg → arg
+    | Some_1 arg → arg.elt_0
   in
   return { TestXor t = t__1; }
 
@@ -55,9 +78,11 @@ let scope TestXor2 (test_xor2_in: TestXor2_in): TestXor2 {o: bool} =
     if true then result__1 else result__1
   in
   let set o : bool =
-    match (Some_1 t.t) with
+    match
+      (Some_1 { tuple_1 elt_0 = t.t; elt_1 = <context_var:69.23-26>; })
+    with
     | None_1 → error NoValue
-    | Some_1 arg → arg
+    | Some_1 arg → arg.elt_0
   in
   return { TestXor2 o = o; }
 ```

--- a/tests/name_resolution/good/conflicts-module.catala_en
+++ b/tests/name_resolution/good/conflicts-module.catala_en
@@ -98,9 +98,20 @@ let closure_scoppe__2 : Obj.t -> bool -> integer -> bool =
 
 let closure_scoppe (_: Closure_scoppe_in.t) : Closure_scoppe.t =
   let scoppe: bool =
-    o_fold (closure_scoppe__2, (o_toclosureenv ())) true
-      ([|(integer_of_string "5"); (integer_of_string "6"); (integer_of_string
-         "7")|]) in
+     if
+      (o_fold (closure_scoppe__2, (o_toclosureenv ())) true
+         ([|(integer_of_string "5"); (integer_of_string "6");
+            (integer_of_string "7")|])) then
+      (let x, _
+        = (true,
+            ({filename="tests/name_resolution/good/conflicts-module.catala_en";
+              start_line=56; start_column=14; end_line=56; end_column=24;
+              law_headings=[]})) in x) else
+      (let x, _
+        = (false,
+            ({filename="tests/name_resolution/good/conflicts-module.catala_en";
+              start_line=5; start_column=10; end_line=5; end_column=16;
+              law_headings=[]})) in x) in
   {Closure_scoppe.scoppe = scoppe}
 
 let closure_scoppe__1 (_: Closure_scoppe__1_in.t) : Closure_scoppe__1.t =

--- a/tests/name_resolution/good/conflicts.catala_en
+++ b/tests/name_resolution/good/conflicts.catala_en
@@ -83,13 +83,13 @@ let scope assert (assert_in: Assert_in__1): Assert__2 {assert: bool} =
                     (assert__2, to_closure_env ()))
                  [0]
              in
-             false))
+             false, <conflicts:23.3-51>))
        with
-       | ENone → ESome false
+       | ENone → ESome (false, <conflicts:19.10-16>)
        | ESome x → ESome x)
     with
     | ENone → error NoValue
-    | ESome arg → arg
+    | ESome arg → arg.0
   in
   return { Assert__2 assert = assert; }
 
@@ -140,15 +140,23 @@ let assert__1 (_: Assert_in__1.t) : Assert__2.t =
     match
       (match
          (Eoption.ESome
-            (let _ : integer array =
-               (o_map
-                  (let assert__2 : Obj.t -> integer -> integer =
-                     closure_assert in
-                  (assert__2, (o_toclosureenv ())))
-                  ([|(integer_of_string "0")|])) in
-            false))
+            ((let _ : integer array =
+                (o_map
+                   (let assert__2 : Obj.t -> integer -> integer =
+                      closure_assert in
+                   (assert__2, (o_toclosureenv ())))
+                   ([|(integer_of_string "0")|])) in
+              false),
+              ({filename="tests/name_resolution/good/conflicts.catala_en";
+                start_line=23; start_column=3; end_line=23; end_column=51;
+                law_headings=[]})))
        with
-       | Eoption.ENone _ -> (Eoption.ESome false)
+       | Eoption.ENone _ ->
+           (Eoption.ESome
+              (false,
+                ({filename="tests/name_resolution/good/conflicts.catala_en";
+                  start_line=19; start_column=10; end_line=19; end_column=16;
+                  law_headings=[]})))
        | Eoption.ESome x -> (Eoption.ESome x))
     with
     | Eoption.ENone _ -> (raise
@@ -156,7 +164,7 @@ let assert__1 (_: Assert_in__1.t) : Assert__2.t =
                                                  start_line=19; start_column=10;
                                                  end_line=19; end_column=16;
                                                  law_headings=[]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   {Assert__2.assert__1 = assert__1}
 
 let assert__2 : integer -> integer =

--- a/tests/name_resolution/good/keywords.catala_en
+++ b/tests/name_resolution/good/keywords.catala_en
@@ -57,18 +57,21 @@ let stdlib (stdlib_in: Stdlib_in.t) : Stdlib__1.t =
   let when__1: date =
     match
       (Eoption.ESome
-         (o_add_dat_dur AbortOnRound
-            {filename="tests/name_resolution/good/keywords.catala_en";
-             start_line=11; start_column=38; end_line=11; end_column=39;
-             law_headings=[]} (date_of_numbers (1970) (1) (1))
-            (o_mult_dur_int (duration_of_numbers (0) (0) (1)) val__1)))
+         ((o_add_dat_dur AbortOnRound
+             {filename="tests/name_resolution/good/keywords.catala_en";
+              start_line=11; start_column=38; end_line=11; end_column=39;
+              law_headings=[]} (date_of_numbers (1970) (1) (1))
+             (o_mult_dur_int (duration_of_numbers (0) (0) (1)) val__1)),
+           ({filename="tests/name_resolution/good/keywords.catala_en";
+             start_line=11; start_column=26; end_line=11; end_column=52;
+             law_headings=[]})))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
                                                  start_line=5; start_column=10;
                                                  end_line=5; end_column=14;
                                                  law_headings=[]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   {Stdlib__1.when__1 = when__1}
 
 let test (_: Test_in.t) : Test.t =
@@ -76,7 +79,12 @@ let test (_: Test_in.t) : Test.t =
     (let result : Stdlib__1.t =
        (stdlib
           ({Stdlib_in.val_in =
-              (match (Eoption.ESome (integer_of_string "99"))
+              (match
+                 (Eoption.ESome
+                    ((integer_of_string "99"),
+                      ({filename="tests/name_resolution/good/keywords.catala_en";
+                        start_line=18; start_column=27;
+                        end_line=18; end_column=29; law_headings=[]})))
                with
                | Eoption.ENone _ -> (raise
                    (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
@@ -84,21 +92,26 @@ let test (_: Test_in.t) : Test.t =
                                                             end_line=18; end_column=19;
                                                             law_headings=
                                                             []}])))
-               | Eoption.ESome arg -> arg)}))
+               | Eoption.ESome arg -> (let x, _ = arg in x))}))
     in
     (let result__1 : Stdlib__1.t =
        ({Stdlib__1.when__1 = (result.Stdlib__1.when__1)})
     in
     ( if true then result__1 else result__1))) in
   let val__1: date =
-    match (Eoption.ESome (a.Stdlib__1.when__1))
+    match
+      (Eoption.ESome
+         ((a.Stdlib__1.when__1),
+           ({filename="tests/name_resolution/good/keywords.catala_en";
+             start_line=19; start_column=25; end_line=19; end_column=31;
+             law_headings=[]})))
     with
     | Eoption.ENone _ -> (raise
         (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
                                                  start_line=15; start_column=10;
                                                  end_line=15; end_column=13;
                                                  law_headings=[]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   {Test.val__1 = val__1}
 
 

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -46,31 +46,38 @@ module S = struct
 end
 
 module S_in = struct
-  type t = {a_in: (bool) Eoption.t}
+  type t = {a_in: ((bool * source_position)) Eoption.t}
 end
 
 
 let s (s_in: S_in.t) : S.t =
-  let a: (bool) Eoption.t = s_in.S_in.a_in in
+  let a: ((bool * source_position)) Eoption.t = s_in.S_in.a_in in
   let a__1: bool =
     match
       (match a
        with
        | Eoption.ENone _ ->
            (Eoption.ESome
-              (match
-                 (Eoption.ESome (let a__2 : bool = false
-                    in
-                    (let a__3 : bool = (a__2 || true) in
-                    a__3)))
-               with
-               | Eoption.ENone _ -> (raise
-                   (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
-                                                            start_line=7; start_column=18;
-                                                            end_line=7; end_column=19;
-                                                            law_headings=
-                                                            ["Article"]}])))
-               | Eoption.ESome arg -> arg))
+              ((match
+                  (Eoption.ESome
+                     ((let a__2 : bool = false
+                       in
+                       (let a__3 : bool = (a__2 || true) in
+                       a__3)),
+                       ({filename="tests/name_resolution/good/let_in2.catala_en";
+                         start_line=11; start_column=5;
+                         end_line=13; end_column=6; law_headings=["Article"]})))
+                with
+                | Eoption.ENone _ -> (raise
+                    (Runtime_ocaml.Runtime.Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
+                                                             start_line=7; start_column=18;
+                                                             end_line=7; end_column=19;
+                                                             law_headings=
+                                                             ["Article"]}])))
+                | Eoption.ESome arg -> (let x, _ = arg in x)),
+                ({filename="tests/name_resolution/good/let_in2.catala_en";
+                  start_line=7; start_column=18; end_line=7; end_column=19;
+                  law_headings=["Article"]})))
        | Eoption.ESome x -> (Eoption.ESome x))
     with
     | Eoption.ENone _ -> (raise
@@ -78,7 +85,7 @@ let s (s_in: S_in.t) : S.t =
                                                  start_line=7; start_column=18;
                                                  end_line=7; end_column=19;
                                                  law_headings=["Article"]}])))
-    | Eoption.ESome arg -> arg in
+    | Eoption.ESome arg -> (let x, _ = arg in x) in
   {S.a = a__1}
 
 let () =

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -126,54 +126,62 @@ let glob2 = A {"y": glob1 >= 30., "z": 123. * 17.}
 
 let s2 (s2_in: S2_in) =
   decl a : decimal;
-  init a__1 : option decimal = ESome glob3 ¤44.00 + 100.;
+  init pos : SourcePosition = <toplevel_defs:53.24-43>;
+  init a__1 : option (decimal, source_position) =
+    ESome (glob3 ¤44.00 + 100., pos);
   switch a__1:
   | ENone _ →
-    init pos : SourcePosition = <toplevel_defs:50.10-11>;
+    init pos__1 : SourcePosition = <toplevel_defs:50.10-11>;
     fatal NoValue
   | ESome arg →
-    a = arg;
+    a = arg."0";
   return S2 {"a": a}
 
 let s3 (s3_in: S3_in) =
   decl a : decimal;
-  init a__1 : option decimal = ESome 50. + glob4 ¤44.00 55.;
+  init pos : SourcePosition = <toplevel_defs:74.24-47>;
+  init a__1 : option (decimal, source_position) =
+    ESome (50. + glob4 ¤44.00 55., pos);
   switch a__1:
   | ENone _ →
-    init pos : SourcePosition = <toplevel_defs:71.10-11>;
+    init pos__1 : SourcePosition = <toplevel_defs:71.10-11>;
     fatal NoValue
   | ESome arg →
-    a = arg;
+    a = arg."0";
   return S3 {"a": a}
 
 let s4 (s4_in: S4_in) =
   decl a : decimal;
-  init a__1 : option decimal = ESome glob5 + 1.;
+  init pos : SourcePosition = <toplevel_defs:98.24-34>;
+  init a__1 : option (decimal, source_position) = ESome (glob5 + 1., pos);
   switch a__1:
   | ENone _ →
-    init pos : SourcePosition = <toplevel_defs:95.10-11>;
+    init pos__1 : SourcePosition = <toplevel_defs:95.10-11>;
     fatal NoValue
   | ESome arg →
-    a = arg;
+    a = arg."0";
   return S4 {"a": a}
 
 let s (s_in: S_in) =
   decl a : decimal;
-  init a__1 : option decimal = ESome glob1 * glob1;
+  init pos : SourcePosition = <toplevel_defs:18.24-37>;
+  init a__1 : option (decimal, source_position) = ESome (glob1 * glob1, pos);
   switch a__1:
   | ENone _ →
-    init pos : SourcePosition = <toplevel_defs:7.10-11>;
+    init pos__1 : SourcePosition = <toplevel_defs:7.10-11>;
     fatal NoValue
   | ESome arg →
-    a = arg;
+    a = arg."0";
   decl b : A {y: bool; z: decimal};
-  init b__1 : option A {y: bool; z: decimal} = ESome glob2;
+  init pos__1 : SourcePosition = <toplevel_defs:19.24-29>;
+  init b__1 : option (A {y: bool; z: decimal}, source_position) =
+    ESome (glob2, pos__1);
   switch b__1:
   | ENone _ →
-    init pos : SourcePosition = <toplevel_defs:8.10-11>;
+    init pos__2 : SourcePosition = <toplevel_defs:8.10-11>;
     fatal NoValue
   | ESome arg →
-    b = arg;
+    b = arg."0";
   return S {"a": a, "b": b}
 ```
 
@@ -356,65 +364,89 @@ glob2 = (
 )
 
 def s2(s2_in:S2In):
-    a__1 = ((glob3(money_of_cents_string("4400")) +
-        decimal_of_string("100")))
+    pos = (SourcePosition(
+               filename="tests/name_resolution/good/toplevel_defs.catala_en",
+               start_line=53, start_column=24, end_line=53, end_column=43,
+               law_headings=["Test toplevel function defs"]))
+    a__1 = (((glob3(money_of_cents_string("4400")) +
+        decimal_of_string("100")),
+        pos))
     if a__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=50, start_column=10,
-                   end_line=50, end_column=11,
-                   law_headings=["Test toplevel function defs"]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                      start_line=50, start_column=10,
+                      end_line=50, end_column=11,
+                      law_headings=["Test toplevel function defs"]))
+        raise NoValue(pos__1)
     else:
-        a = (a__1)
+        a = (a__1[0])
     return S2(a = a)
 
 def s3(s3_in:S3In):
-    a__1 = ((decimal_of_string("50") +
-        glob4(money_of_cents_string("4400"), decimal_of_string("55"))))
+    pos = (SourcePosition(
+               filename="tests/name_resolution/good/toplevel_defs.catala_en",
+               start_line=74, start_column=24, end_line=74, end_column=47,
+               law_headings=["Test function def with two args"]))
+    a__1 = (((decimal_of_string("50") +
+        glob4(money_of_cents_string("4400"), decimal_of_string("55"))),
+        pos))
     if a__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=71, start_column=10,
-                   end_line=71, end_column=11,
-                   law_headings=["Test function def with two args"]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                      start_line=71, start_column=10,
+                      end_line=71, end_column=11,
+                      law_headings=["Test function def with two args"]))
+        raise NoValue(pos__1)
     else:
-        a = (a__1)
+        a = (a__1[0])
     return S3(a = a)
 
 def s4(s4_in:S4In):
-    a__1 = ((glob5 + decimal_of_string("1")))
+    pos = (SourcePosition(
+               filename="tests/name_resolution/good/toplevel_defs.catala_en",
+               start_line=98, start_column=24, end_line=98, end_column=34,
+               law_headings=["Test inline defs in toplevel defs"]))
+    a__1 = (((glob5 + decimal_of_string("1")), pos))
     if a__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=95, start_column=10,
-                   end_line=95, end_column=11,
-                   law_headings=["Test inline defs in toplevel defs"]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                      start_line=95, start_column=10,
+                      end_line=95, end_column=11,
+                      law_headings=["Test inline defs in toplevel defs"]))
+        raise NoValue(pos__1)
     else:
-        a = (a__1)
+        a = (a__1[0])
     return S4(a = a)
 
 def s(s_in:SIn):
-    a__1 = ((glob1 * glob1))
+    pos = (SourcePosition(
+               filename="tests/name_resolution/good/toplevel_defs.catala_en",
+               start_line=18, start_column=24, end_line=18, end_column=37,
+               law_headings=["Test basic toplevel values defs"]))
+    a__1 = (((glob1 * glob1), pos))
     if a__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=7, start_column=10, end_line=7, end_column=11,
-                   law_headings=["Test basic toplevel values defs"]))
-        raise NoValue(pos)
+        pos__1 = (SourcePosition(
+                      filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                      start_line=7, start_column=10,
+                      end_line=7, end_column=11,
+                      law_headings=["Test basic toplevel values defs"]))
+        raise NoValue(pos__1)
     else:
-        a = (a__1)
-    b__1 = (glob2)
+        a = (a__1[0])
+    pos__1 = (SourcePosition(
+                  filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                  start_line=19, start_column=24, end_line=19, end_column=29,
+                  law_headings=["Test basic toplevel values defs"]))
+    b__1 = ((glob2, pos__1))
     if b__1 is None:
-        pos = (SourcePosition(
-                   filename="tests/name_resolution/good/toplevel_defs.catala_en",
-                   start_line=8, start_column=10, end_line=8, end_column=11,
-                   law_headings=["Test basic toplevel values defs"]))
-        raise NoValue(pos)
+        pos__2 = (SourcePosition(
+                      filename="tests/name_resolution/good/toplevel_defs.catala_en",
+                      start_line=8, start_column=10,
+                      end_line=8, end_column=11,
+                      law_headings=["Test basic toplevel values defs"]))
+        raise NoValue(pos__2)
     else:
-        b = (b__1)
+        b = (b__1[0])
     return S(a = a, b = b)
 
 # Automatic Catala tests

--- a/tests/scope/good/simple.catala_en
+++ b/tests/scope/good/simple.catala_en
@@ -24,9 +24,9 @@ $ catala Typecheck --check-invariants
 $ catala Lcalc -s Foo
 let scope Foo (foo_in: Foo_in): Foo {bar: integer} =
   let set bar : integer =
-    match (ESome 0) with
+    match (ESome (0, <simple:8.25-26>)) with
     | ENone → error NoValue
-    | ESome arg → arg
+    | ESome arg → arg.0
   in
   return { Foo bar = bar; }
 ```


### PR DESCRIPTION
Related to #755, which this fixes *for the lcalc interpreter* ;
however, the real issue is the OCaml (and other) backends, where it's much harder.

Indeed, for those, the positions are passed as a flat list to the top-level default term, which has no information anymore about nested exceptions. The only reliable way I see to fix that is to switch evaluated default terms from `'a option` to `('a * pos) option`, and remove the the flat list of positions. It requires a change in the type of the `handle_exceptions` primitive, but it shouldn't be too difficult now that positions can be reified.