### PR TITLE
Fix confusing disambiguation errors appearing instead of type errors

### DIFF
--- a/tests/array/bad/type_error_in_filter.catala_en
+++ b/tests/array/bad/type_error_in_filter.catala_en
@@ -1,0 +1,90 @@
+
+```catala
+declaration structure St:
+  data x content integer
+
+declaration scope S:
+  input ll content list of St
+  output out content list of St
+
+scope S:
+  definition out equals
+    combine acc initially []
+    with (acc ++ list of x among in_n such that x.x > 2)
+      # acc ++ filter (x -> x.x > 2) in_n
+    for in_n among ll
+
+declaration scope Test:
+  output s scope S
+
+declaration st content St
+  depends on x content integer
+  equals St { -- x: x }
+
+scope Test:
+  definition s.ll equals [
+    [st of 1; st of 2; st of 3];
+    [st of 2; st of 3; st of 4];
+    [st of 3; st of 4; st of 5]
+  ]
+```
+
+
+```catala-test-inline
+$ catala dcalc
+┌─[ERROR]─
+│
+│  Error during typechecking, incompatible types:
+│  ─➤ St
+│  ─➤ list of any
+│
+│ While typechecking the following expression:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:13.34-13.38:
+│    │
+│ 13 │     with (acc ++ list of x among in_n such that x.x > 2)
+│    │                                  ‾‾‾‾
+│
+│ Type St is coming from:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:7.28-7.30:
+│   │
+│ 7 │   input ll content list of St
+│   │                            ‾‾
+│
+│ Type list of any is coming from:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:13.18-13.56:
+│    │
+│ 13 │     with (acc ++ list of x among in_n such that x.x > 2)
+│    │                  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─
+#return code 123#
+```
+
+
+```catala-test-inline
+$ catala test-scope Test
+┌─[ERROR]─
+│
+│  Error during typechecking, incompatible types:
+│  ─➤ St
+│  ─➤ list of any
+│
+│ While typechecking the following expression:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:13.34-13.38:
+│    │
+│ 13 │     with (acc ++ list of x among in_n such that x.x > 2)
+│    │                                  ‾‾‾‾
+│
+│ Type St is coming from:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:7.28-7.30:
+│   │
+│ 7 │   input ll content list of St
+│   │                            ‾‾
+│
+│ Type list of any is coming from:
+├─➤ tests/array/bad/type_error_in_filter.catala_en:13.18-13.56:
+│    │
+│ 13 │     with (acc ++ list of x among in_n such that x.x > 2)
+│    │                  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─
+#return code 123#
+```

--- a/tests/array/good/broken-message.catala_en
+++ b/tests/array/good/broken-message.catala_en
@@ -26,33 +26,38 @@ scope B:
       (acc1 ++ [x + acc2], acc2 + x) for x among a.x
 ```
 
-The positions in this error message are completely wrong and misleading.
-Investigation needed...
+There was an error -- now fixed -- where the issue was pointed on `x+acc2` with
+a confusing message.
+
+This was diagnosed to be due to delayed error messages that got skipped.
 
 ```catala-test-inline
 $ catala Typecheck --check-invariants
 ┌─[ERROR]─
 │
-│  I don't know how to apply operator + on types list of money and money
+│  Error during typechecking, incompatible types:
+│  ─➤ money
+│  ─➤ list of money
 │
-├─➤ tests/array/good/broken-message.catala_en:26.17-26.25:
+│ While typechecking the following expression:
+├─➤ tests/array/good/broken-message.catala_en:21.8-21.9:
 │    │
-│ 26 │       (acc1 ++ [x + acc2], acc2 + x) for x among a.x
-│    │                 ‾‾‾‾‾‾‾‾
+│ 21 │       (x ++ acc) for x among a.x
+│    │        ‾
 ├─ Article
 │
-│ Type list of money coming from expression:
+│ Type money is coming from:
+├─➤ tests/array/good/broken-message.catala_en:5.28-5.33:
+│   │
+│ 5 │   output x content list of money
+│   │                            ‾‾‾‾‾
+├─ Article
+│
+│ Type list of money is coming from:
 ├─➤ tests/array/good/broken-message.catala_en:21.10-21.12:
 │    │
 │ 21 │       (x ++ acc) for x among a.x
 │    │          ‾‾
-├─ Article
-│
-│ Type money coming from expression:
-├─➤ tests/array/good/broken-message.catala_en:25.41-25.43:
-│    │
-│ 25 │     combine (acc1, acc2) initially ([], $1) with
-│    │                                         ‾‾
 └─ Article
 #return code 123#
 ```

--- a/tests/struct/bad/wrong_qualified_field.catala_en
+++ b/tests/struct/bad/wrong_qualified_field.catala_en
@@ -21,8 +21,8 @@ scope A:
 $ catala test-scope A
 ┌─[ERROR]─
 │
-│  Field "g" does not belong to structure "Foo" (however, structure "Bar"
-│  defines it).
+│  Field g does not belong to structure Foo (however, structure Bar defines
+│  it).
 ├─➤ tests/struct/bad/wrong_qualified_field.catala_en:17.23-17.30:
 │   │
 │17 │   definition y equals x.Foo.g


### PR DESCRIPTION
Closes #749 ;
the PR also has a patch that greatly improves real disambiguation errors when they happen.

The issue was actually with the way we attempt to gather multiple typing errors: this can get us in an inconsistent state after the first error, and any non-delayed exception raised at that point (including `internal inconsistency` compiler errors) would break out... and hide all delayed exceptions.

This is visible in test  `array/bad/type_error_in_filter.catala_en` which would raise a `Cannot resolve typing` error because assumptions of the typer are no longer guaranteed.

The behaviour implemented here is to print the errors that have been delayed, and actually hide the non-delayed error instead (it seems safer to assume, in general, that it is a consequence of an inconsistent state, rather than the opposite. We could put it back when in debug mode if we ever find cases where it would have been useful).