### PR TITLE
Fix minted in syntax.pdf

### DIFF
--- a/doc/syntax/syntax_en.tex
+++ b/doc/syntax/syntax_en.tex
@@ -198,8 +198,8 @@
   \\
 \end{tabular}
 
-\newcommand*\FancyVerbStartString{\PYG{l+s}{```catala}}
-\newcommand*\FancyVerbStopString{\PYG{l+s}{```}}
+\newcommand*\FancyVerbStartString{```catala}
+\newcommand*\FancyVerbStopString{```}
 
 \section{Literals and types}
 

--- a/doc/syntax/syntax_fr.tex
+++ b/doc/syntax/syntax_fr.tex
@@ -200,8 +200,8 @@
   \\
 \end{tabular}
 
-\newcommand*\FancyVerbStartString{\PYG{l+s}{```catala}}
-\newcommand*\FancyVerbStopString{\PYG{l+s}{```}}
+\newcommand*\FancyVerbStartString{```catala}
+\newcommand*\FancyVerbStopString{```}
 
 \section{Littéraux et types}
 


### PR DESCRIPTION
Attempts to fix the bug introduced by #772 (reported in #773) that breaks the syntax.pdf file.