### PR TITLE
Syntax: fix handling of spacing beside code fences

### DIFF
--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -375,7 +375,7 @@ let op_kind = function
 
 let check_fence_space =
   let trail_re =
-    Re.(compile @@ alt [ seq [bol; space]; seq [blank; eol] ])
+    Re.(compile @@ alt [ seq [bol; space]; seq [blank; opt (char '\r') ; eol] ])
   in
   fun lexbuf ->
   let txt = Utf8.lexeme lexbuf in

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -31,6 +31,9 @@ val context : lexing_context ref
 (** Reference, used by the lexer as the mutable state to distinguish whether it
     is lexing code or law. *)
 
+val context_start_pos : (Lexing.position * Lexing.position) ref
+(** The position of the opening token of the last opened [context] *)
+
 val update_acc : Sedlexing.lexbuf -> unit
 (** Updates the current code buffer with the current lexeme. The underlying
     buffer is used to accumulate the string representation of the body of code

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -269,8 +269,8 @@ module ParserAux (LocalisedLexer : Lexer_common.LocalisedLexer) = struct
       (* The encapsulating [Message.with_delayed_errors] will raise an
          exception: we are safe returning a dummy value. *)
       Message.delayed_error ~kind:Lexing [] ~pos
-        "Parsing error after token \"%s\": what comes after could not be \
-         recognised"
+        "Parsing error after token @{<yellow>%S@}: what comes after could not \
+         be recognised"
         token
 
   let commands_or_includes (lexbuf : lexbuf) : Ast.source_file =

--- a/tests/literate/bad/extra_space.catala_en
+++ b/tests/literate/bad/extra_space.catala_en
@@ -1,0 +1,140 @@
+# Title
+
+ ```catala
+declaration structure Individual:
+  data income content money
+  data number_of_children content integer
+
+ declaration scope IncomeTaxComputation:
+   input individual content Individual
+   internal fixed_percentage content decimal
+   output income_tax content money
+ ```
+
+ ## Article 1
+
+ The income tax for an individual is defined as a fixed percentage of the
+ individual's income over a year.
+
+```catala
+ scope IncomeTaxComputation:
+   definition income_tax equals
+     individual.income * fixed_percentage
+```
+
+```catala-test-inline
+$ catala typecheck
+┌─[WARNING]─
+│
+│  Extra leading or trailing space
+│
+├─➤ tests/literate/bad/extra_space.catala_en:3.1-4.1:
+│   │
+│ 3 │  ```catala
+│   │ ‾‾‾‾‾‾‾‾‾‾
+│ 4 │ declaration structure Individual:
+│   │ 
+└─
+┌─[WARNING]─
+│
+│  Extra leading or trailing space
+│
+├─➤ tests/literate/bad/extra_space.catala_en:12.1-13.1:
+│    │
+│ 12 │  ```
+│    │ ‾‾‾‾
+│ 13 │ 
+│    │ 
+└─
+┌─[WARNING]─
+│
+│  In scope "IncomeTaxComputation", the variable "fixed_percentage" is
+│  declared but never defined; did you forget something?
+│
+├─➤ tests/literate/bad/extra_space.catala_en:10.13-10.29:
+│    │
+│ 10 │    internal fixed_percentage content decimal
+│    │             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─ Title
+┌─[WARNING]─
+│
+│  The field "number_of_children" of struct "Individual" is never used;
+│  maybe it's unnecessary?
+│
+├─➤ tests/literate/bad/extra_space.catala_en:6.8-6.26:
+│   │
+│ 6 │   data number_of_children content integer
+│   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─ Title
+┌─[RESULT]─
+│ Typechecking successful!
+└─
+```
+
+# Title
+
+```catala
+declaration scope Foo:
+  output out condition
+ ```
+
+
+```catala-test-inline
+$ catala test-scope Foo
+┌─[WARNING]─
+│
+│  Extra leading or trailing space
+│
+├─➤ tests/literate/bad/extra_space.catala_en:3.1-4.1:
+│   │
+│ 3 │  ```catala
+│   │ ‾‾‾‾‾‾‾‾‾‾
+│ 4 │ declaration structure Individual:
+│   │ 
+└─
+┌─[WARNING]─
+│
+│  Extra leading or trailing space
+│
+├─➤ tests/literate/bad/extra_space.catala_en:12.1-13.1:
+│    │
+│ 12 │  ```
+│    │ ‾‾‾‾
+│ 13 │ 
+│    │ 
+└─
+┌─[WARNING]─
+│
+│  Extra leading or trailing space
+│
+├─➤ tests/literate/bad/extra_space.catala_en:79.1-80.1:
+│    │
+│ 79 │  ```
+│    │ ‾‾‾‾
+│ 80 │ 
+│    │ 
+└─
+┌─[WARNING]─
+│
+│  In scope "IncomeTaxComputation", the variable "fixed_percentage" is
+│  declared but never defined; did you forget something?
+│
+├─➤ tests/literate/bad/extra_space.catala_en:10.13-10.29:
+│    │
+│ 10 │    internal fixed_percentage content decimal
+│    │             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─ Title
+┌─[WARNING]─
+│
+│  The field "number_of_children" of struct "Individual" is never used;
+│  maybe it's unnecessary?
+│
+├─➤ tests/literate/bad/extra_space.catala_en:6.8-6.26:
+│   │
+│ 6 │   data number_of_children content integer
+│   │        ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+└─ Title
+┌─[RESULT]─
+│ out = false
+└─
+```


### PR DESCRIPTION
This prints a warning, but tolerates it, which should be much less surprising than treating the code as law text, which makes it look like it's ignored without errors.

Closes #777 