### PR TITLE
Fix C runtime windows build

### DIFF
--- a/runtimes/c/discover.ml
+++ b/runtimes/c/discover.ml
@@ -1,0 +1,22 @@
+let () =
+  let open Re in
+  if Array.length Sys.argv <> 2 then
+    failwith "expected either ar or gmp_flags as argument"
+  else
+    match Sys.argv.(1) with
+    | "ar" ->
+      (* On mingw's opam windows install gcc is named: x86_64-w64-mingw32-gcc,
+         and, ar is named: x86_64-w64-mingw32-ar. We substitute gcc by ar from
+         the c compiler retrieved in the OCaml compiler's config to make the
+         build system handle it properly. *)
+      let r = compile (seq [str "gcc"; opt (str ".exe"); eol]) in
+      if (Sys.win32 || Sys.cygwin) && Re.execp r Config.c_compiler then
+        Config.c_compiler |> replace_string r ~by:"ar" |> print_string
+      else print_string "ar"
+    | "gmp_flags" ->
+      if Sys.win32 || Sys.cygwin then
+        (* On cygwin/windows, pkg-config is not aware of gmp but opam is aware
+           of the include dir. *)
+        ()
+      else exit @@ Sys.command "pkg-config --cflags gmp"
+    | s -> Format.ksprintf failwith "unknown command: %s" s

--- a/runtimes/c/dune
+++ b/runtimes/c/dune
@@ -1,7 +1,11 @@
+(executable
+ (name discover)
+ (modes native)
+ (libraries re compiler-libs.common))
+
 (rule
- (with-stdout-to
-  gmph
-  (run pkg-config --cflags gmp)))
+ (with-stdout-to gmph
+  (run ./discover.exe gmp_flags)))
 
 (rule
  (deps runtime.c runtime.h dates_calc.h)
@@ -11,12 +15,20 @@
    "%{cc} --std=c89 -Wall -Werror -pedantic -c runtime.c -I . %{read-strings:gmph} -o %{target}")))
 
 (rule
+ (with-stdout-to
+  ar_bin_name
+  (run ./discover.exe ar)))
+
+(rule
  (deps runtime.o)
  (target catala_runtime.a)
  (action
-  ; FIXME: ar is not portable, it makes the build fails on windows.
-  ; A workaround is to install a mingw toolchain that exposes ar.
-  (run ar rcs %{target} %{lib:dates_calc:c/dates_calc.o} %{deps})))
+  (run
+   %{read-strings:ar_bin_name}
+   rcs
+   %{target}
+   %{lib:dates_calc:c/dates_calc.o}
+   %{deps})))
 
 (rule
  (target dates_calc.h)

--- a/runtimes/c/dune
+++ b/runtimes/c/dune
@@ -4,7 +4,8 @@
  (libraries re compiler-libs.common))
 
 (rule
- (with-stdout-to gmph
+ (with-stdout-to
+  gmp_include_flags
   (run ./discover.exe gmp_flags)))
 
 (rule
@@ -12,7 +13,7 @@
  (target runtime.o)
  (action
   (system
-   "%{cc} --std=c89 -Wall -Werror -pedantic -c runtime.c -I . %{read-strings:gmph} -o %{target}")))
+   "%{cc} --std=c89 -Wall -Werror -pedantic -c runtime.c -I . %{read-strings:gmp_include_flags} -o %{target}")))
 
 (rule
  (with-stdout-to


### PR DESCRIPTION
This PR fixes the build on windows which failed due to an invocation to `ar` which wasn't named this way on windows.
It also fixes an issue introduced in #784 which made the failing build fails even more because windows's equivalent to pkg-config doesn't consider the cygwin folder.