### PR TITLE
Fix and refactor emit_n

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -344,17 +344,18 @@ module Content = struct
     | GNU -> gnu_msg ~pp_marker ppf target content
     | Lsp -> lsp_msg ppf content
 
-  let emit_n ?ppf (target : level) = function
-    | [content] -> emit content target
+  let emit_n ?ppf (errs : t list) (target : level) =
+    match errs with
+    | [content] -> emit ?ppf content target
     | contents ->
       let ppf = Option.value ~default:(get_ppf target) ppf in
       let len = List.length contents in
       List.iteri
         (fun i c ->
-          if i > 0 then Format.pp_print_newline ppf ();
+          if i > 0 then Format.pp_print_space ppf ();
           let extra_label = Printf.sprintf "(%d/%d)" (succ i) len in
           let pp_marker ?extra_label:_ = pp_marker ~extra_label in
-          emit ~pp_marker c target)
+          emit ~ppf ~pp_marker c target)
         contents
 
   let emit ?ppf (content : t) (target : level) = emit ?ppf content target

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -54,7 +54,7 @@ module Content : sig
 
   (** {2 Content emission}*)
 
-  val emit_n : ?ppf:Format.formatter -> level -> t list -> unit
+  val emit_n : ?ppf:Format.formatter -> t list -> level -> unit
   val emit : ?ppf:Format.formatter -> t -> level -> unit
 end
 

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1260,7 +1260,7 @@ let main () =
     exit_with_error Cmd.Exit.some_error @@ fun () -> content
   | exception Message.CompilerErrors contents ->
     let bt = Printexc.get_raw_backtrace () in
-    Message.Content.emit_n Error contents;
+    Message.Content.emit_n contents Error;
     if Global.options.debug then Printexc.print_raw_backtrace stderr bt;
     exit Cmd.Exit.some_error
   | exception Failure msg ->


### PR DESCRIPTION
This PR fixes the `emit_n` behavior where it would ignore the given formatter. It also harmonize the signature of `emit_n` with regards to `emit`.