### PR TITLE
Whole program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,8 @@ tests: test
 TEST_FLAGS_LIST = ""\
 -O \
 --lcalc \
---lcalc,--closure-conversion,-O
+--lcalc,--closure-conversion,-O \
+--whole-program
 
 # Does not include running dune (to avoid duplication when run among bigger rules)
 testsuite-base: .FORCE

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -245,6 +245,14 @@ module Flags = struct
             "Instead of reporting an error on assertion failure, reports a \
              warning and carry on with the interpretation as usual."
 
+    let whole_program =
+      value
+      & flag
+      & info ["W"; "whole-program"]
+          ~doc:
+            "Compile the full chain of module dependencies without requiring a \
+             separate module compilation."
+
     let flags =
       let make
           language
@@ -258,7 +266,8 @@ module Flags = struct
           max_prec_digits
           directory
           stop_on_error
-          no_fail_on_assert : options =
+          no_fail_on_assert
+          whole_program : options =
         if debug then Printexc.record_backtrace true;
         let path_rewrite =
           match directory with
@@ -296,7 +305,7 @@ module Flags = struct
            returns the options record. *)
         Global.enforce_options ~language ~debug ~color ~message_format ~trace
           ~trace_format ~plugins_dirs ~disable_warnings ~max_prec_digits
-          ~path_rewrite ~stop_on_error ~no_fail_on_assert ()
+          ~path_rewrite ~stop_on_error ~no_fail_on_assert ~whole_program ()
       in
       Term.(
         const make
@@ -311,7 +320,8 @@ module Flags = struct
         $ max_prec_digits
         $ directory
         $ stop_on_error
-        $ no_fail_on_assert)
+        $ no_fail_on_assert
+        $ whole_program)
 
     let options =
       let make input_src name directory options : options =

--- a/compiler/catala_utils/global.ml
+++ b/compiler/catala_utils/global.ml
@@ -41,6 +41,7 @@ type options = {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
+  mutable whole_program : bool;
 }
 
 (* Note: we force that the global options (ie options common to all commands)
@@ -63,6 +64,7 @@ let options =
     path_rewrite = (fun _ -> assert false);
     stop_on_error = false;
     no_fail_on_assert = false;
+    whole_program = true;
   }
 
 let enforce_options
@@ -79,6 +81,7 @@ let enforce_options
     ?path_rewrite
     ?stop_on_error
     ?no_fail_on_assert
+    ?whole_program
     () =
   Option.iter (fun x -> options.input_src <- x) input_src;
   Option.iter (fun x -> options.language <- x) language;
@@ -93,6 +96,7 @@ let enforce_options
   Option.iter (fun x -> options.path_rewrite <- x) path_rewrite;
   Option.iter (fun x -> options.stop_on_error <- x) stop_on_error;
   Option.iter (fun x -> options.no_fail_on_assert <- x) no_fail_on_assert;
+  Option.iter (fun x -> options.whole_program <- x) whole_program;
   options
 
 let input_src_file = function FileName f | Contents (_, f) | Stdin f -> f

--- a/compiler/catala_utils/global.mli
+++ b/compiler/catala_utils/global.mli
@@ -61,6 +61,7 @@ type options = private {
   mutable path_rewrite : raw_file -> file;
   mutable stop_on_error : bool;
   mutable no_fail_on_assert : bool;
+  mutable whole_program : bool;
 }
 (** Global options, common to all subcommands (note: the fields are internally
     mutable only for purposes of the [globals] toplevel value defined below) *)
@@ -84,6 +85,7 @@ val enforce_options :
   ?path_rewrite:(raw_file -> file) ->
   ?stop_on_error:bool ->
   ?no_fail_on_assert:bool ->
+  ?whole_program:bool ->
   unit ->
   options
 (** Sets up the global options (side-effect); for specific use-cases only, this

--- a/compiler/desugared/ast.ml
+++ b/compiler/desugared/ast.ml
@@ -253,6 +253,7 @@ type topdef = {
   topdef_expr : expr option;
   topdef_type : typ;
   topdef_visibility : visibility;
+  topdef_external : bool;
 }
 
 type modul = {

--- a/compiler/desugared/ast.mli
+++ b/compiler/desugared/ast.mli
@@ -131,6 +131,7 @@ type topdef = {
   topdef_type : typ;
   topdef_visibility : visibility;
       (** Necessarily [Public] outside of the root module *)
+  topdef_external : bool;
 }
 
 type modul = {

--- a/compiler/desugared/from_surface.mli
+++ b/compiler/desugared/from_surface.mli
@@ -21,5 +21,8 @@
     - Separate code from legislation *)
 
 val translate_program :
-  Name_resolution.context -> Surface.Ast.program -> Ast.program
+  Name_resolution.context ->
+  Surface.Ast.module_content Shared_ast.ModuleName.Map.t ->
+  Surface.Ast.program ->
+  Ast.program
 (** Main function of this module *)

--- a/compiler/desugared/name_resolution.mli
+++ b/compiler/desugared/name_resolution.mli
@@ -185,6 +185,6 @@ val process_type : context -> Surface.Ast.typ -> typ
 
 val form_context :
   Surface.Ast.program * ModuleName.t Ident.Map.t ->
-  (Surface.Ast.interface * ModuleName.t Ident.Map.t) ModuleName.Map.t ->
+  (Surface.Ast.module_content * ModuleName.t Ident.Map.t) ModuleName.Map.t ->
   context
 (** Derive the context from metadata, in one pass over the declarations *)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -26,7 +26,7 @@ let modname_of_file f =
   (* Fixme: make this more robust *)
   String.capitalize_ascii Filename.(basename (remove_extension f))
 
-let load_module_interfaces
+let load_modules
     options
     includes
     ?(more_includes = [])
@@ -68,7 +68,8 @@ let load_module_interfaces
         ms
   in
   let rec aux req_chain seen uses :
-      (ModuleName.t * Surface.Ast.interface * ModuleName.t Ident.Map.t) option
+      (ModuleName.t * Surface.Ast.module_content * ModuleName.t Ident.Map.t)
+      option
       File.Map.t
       * ModuleName.t Ident.Map.t =
     List.fold_left
@@ -94,18 +95,25 @@ let load_module_interfaces
               Some Filename.(basename (remove_extension f))
             else None
           in
-          let intf =
-            Surface.Parser_driver.load_interface ?default_module_name
-              (Global.FileName f)
+          let module_content =
+            if options.Global.whole_program then
+              Surface.Parser_driver.load_interface_and_code ?default_module_name
+                (Global.FileName f)
+            else
+              Surface.Parser_driver.load_interface ?default_module_name
+                (Global.FileName f)
           in
-          let modname = ModuleName.fresh intf.intf_modname.module_name in
+          let modname =
+            ModuleName.fresh
+              module_content.Surface.Ast.module_modname.module_name
+          in
           let seen = File.Map.add f None seen in
           let seen, sub_use_map =
             aux
               (Mark.get use.Surface.Ast.mod_use_name :: req_chain)
-              seen intf.Surface.Ast.intf_submodules
+              seen module_content.Surface.Ast.module_submodules
           in
-          ( File.Map.add f (Some (modname, intf, sub_use_map)) seen,
+          ( File.Map.add f (Some (modname, module_content, sub_use_map)) seen,
             Ident.Map.add
               (Mark.remove use.Surface.Ast.mod_use_alias)
               modname use_map ))
@@ -150,7 +158,7 @@ module Passes = struct
   let desugared options ~includes :
       Desugared.Ast.program * Desugared.Name_resolution.context =
     let prg = surface options in
-    let mod_uses, modules = load_module_interfaces options includes prg in
+    let mod_uses, modules = load_modules options includes prg in
     debug_pass_name "desugared";
     Message.debug "Name resolution...";
     let ctx = Desugared.Name_resolution.form_context (prg, mod_uses) modules in
@@ -1101,8 +1109,7 @@ module Commands = struct
         }
     in
     let mod_uses, modules =
-      load_module_interfaces options includes ~more_includes
-        ~allow_notmodules:true prg
+      load_modules options includes ~more_includes ~allow_notmodules:true prg
     in
     let d_ctx =
       Desugared.Name_resolution.form_context (prg, mod_uses) modules

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -163,7 +163,8 @@ module Passes = struct
     Message.debug "Name resolution...";
     let ctx = Desugared.Name_resolution.form_context (prg, mod_uses) modules in
     Message.debug "Desugaring...";
-    let prg = Desugared.From_surface.translate_program ctx prg in
+    let modules = ModuleName.Map.map fst modules in
+    let prg = Desugared.From_surface.translate_program ctx modules prg in
     Message.debug "Disambiguating...";
     let prg = Desugared.Disambiguate.program prg in
     Message.debug "Linting...";
@@ -1114,7 +1115,8 @@ module Commands = struct
     let d_ctx =
       Desugared.Name_resolution.form_context (prg, mod_uses) modules
     in
-    let prg = Desugared.From_surface.translate_program d_ctx prg in
+    let modules = ModuleName.Map.map fst modules in
+    let prg = Desugared.From_surface.translate_program d_ctx modules prg in
     let modules_list_topo =
       Program.modules_to_list prg.program_ctx.ctx_modules
     in

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -64,13 +64,11 @@ type 'm scope_decl = {
 type 'm program = {
   program_module_name : (ModuleName.t * module_intf_id) option;
   program_ctx : decl_ctx;
-  program_modules : nil scope_decl Mark.pos ScopeName.Map.t ModuleName.Map.t;
-  (* Using [nil] here ensure that program interfaces don't contain any
-     expressions. They won't contain any rules or topdef implementations, but
-     will still have the scope signatures needed to respect the call
-     convention *)
+  program_modules : 'm scope_decl Mark.pos ScopeName.Map.t ModuleName.Map.t;
   program_scopes : 'm scope_decl Mark.pos ScopeName.Map.t;
-  program_topdefs : ('m expr * typ * visibility) TopdefName.Map.t;
+  program_topdefs :
+    ('m expr * typ * visibility * bool (* external if [true] *))
+    TopdefName.Map.t;
   program_lang : Global.backend_lang;
 }
 

--- a/compiler/scopelang/dependency.mli
+++ b/compiler/scopelang/dependency.mli
@@ -22,7 +22,9 @@ open Shared_ast
 
 (** {1 Scope dependencies} *)
 
-type vertex = Scope of ScopeName.t | Topdef of TopdefName.t
+type vertex =
+  | Scope of (ScopeName.t * ModuleName.t option) (* In whole-program, scopes *)
+  | Topdef of TopdefName.t
 
 (** On the edges, the label is the expression responsible for the use of the
     function *)

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -92,7 +92,7 @@ let scope ?debug ctx fmt (name, (decl, _pos)) =
              (Print.expr ?debug ()) e))
     decl.scope_decl_rules
 
-let print_topdef ctx ppf name (e, ty, _vis) =
+let print_topdef ctx ppf name (e, ty, _vis, _is_external) =
   Format.pp_open_vbox ppf 2;
   let () =
     Format.pp_open_hovbox ppf 2;

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -482,6 +482,7 @@ type 'a glocation =
       -> < scopeVarSimpl : yes ; .. > glocation
   | ToplevelVar : {
       name : TopdefName.t Mark.pos;
+      is_external : bool;
     }
       -> < explicitScopes : yes ; .. > glocation
 

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -591,7 +591,7 @@ let compare_location
     | n -> n)
   | ScopelangScopeVar { name = vx, _ }, ScopelangScopeVar { name = vy, _ } ->
     ScopeVar.compare vx vy
-  | ToplevelVar { name = vx, _ }, ToplevelVar { name = vy, _ } ->
+  | ToplevelVar { name = vx, _; _ }, ToplevelVar { name = vy, _; _ } ->
     TopdefName.compare vx vy
   | DesugaredScopeVar _, _ -> -1
   | _, DesugaredScopeVar _ -> 1

--- a/compiler/shared_ast/interpreter.mli
+++ b/compiler/shared_ast/interpreter.mli
@@ -64,4 +64,5 @@ val delcustom :
 
 val load_runtime_modules : hashf:(Hash.t -> Hash.full) -> _ program -> unit
 (** Dynlink the runtime modules required by the given program, in order to make
-    them callable by the interpreter. *)
+    them callable by the interpreter. Note: in whole-program, we will only try
+    loading external modules. *)

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -74,7 +74,7 @@ let location (type a) (fmt : Format.formatter) (l : a glocation) : unit =
   match l with
   | DesugaredScopeVar { name; _ } -> ScopeVar.format fmt (Mark.remove name)
   | ScopelangScopeVar { name; _ } -> ScopeVar.format fmt (Mark.remove name)
-  | ToplevelVar { name } -> TopdefName.format fmt (Mark.remove name)
+  | ToplevelVar { name; _ } -> TopdefName.format fmt (Mark.remove name)
 
 let external_ref fmt er =
   match Mark.remove er with

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -503,7 +503,7 @@ and typecheck_expr_top_down :
       match loc with
       | DesugaredScopeVar { name; _ } | ScopelangScopeVar { name } ->
         Env.get_scope_var env (Mark.remove name)
-      | ToplevelVar { name } -> Env.get_toplevel_var env (Mark.remove name)
+      | ToplevelVar { name; _ } -> Env.get_toplevel_var env (Mark.remove name)
     in
     let ty =
       match ty_opt with

--- a/compiler/surface/ast.ml
+++ b/compiler/surface/ast.ml
@@ -322,14 +322,6 @@ and law_structure =
   | LawText of (string[@opaque])
   | CodeBlock of code_block * source_repr * bool (* Metadata if true *)
 
-and interface = {
-  intf_modname : program_module;
-  intf_code : code_block;
-      (** Invariant: an interface shall only contain [*Decl] elements, or
-          [Topdef] elements with [topdef_expr = None] *)
-  intf_submodules : module_use list;
-}
-
 and module_use = {
   mod_use_name : uident Mark.pos;
   mod_use_alias : uident Mark.pos;
@@ -347,6 +339,19 @@ and program = {
 
 and source_file = law_structure list
 [@@deriving visitors { variety = "map"; ancestors = ["Mark.pos_map"] }]
+
+type module_items =
+  | Code of law_structure list
+      (** Used in whole-program to gather all module code *)
+  | Interface of code_block
+      (** Invariant: an interface shall only contain [*Decl] elements, or
+          [Topdef] elements with [topdef_expr = None] (metadata only) *)
+
+type module_content = {
+  module_modname : program_module;
+  module_items : module_items;
+  module_submodules : module_use list;
+}
 
 (** {1 Helpers}*)
 

--- a/compiler/surface/parser_driver.mli
+++ b/compiler/surface/parser_driver.mli
@@ -27,10 +27,16 @@ val lines :
     structure as is *)
 
 val load_interface :
-  ?default_module_name:string -> File.t Global.input_src -> Ast.interface
+  ?default_module_name:string -> File.t Global.input_src -> Ast.module_content
 (** Reads only declarations in metadata in the supplied input file, and only
     keeps type information. The list of submodules is initialised with names
     only and empty contents. *)
+
+val load_interface_and_code :
+  ?default_module_name:string -> File.t Global.input_src -> Ast.module_content
+(** Reads the supplied input file and returns its interface that contains type
+    information as well as scope and topdef definitions. The list of submodules
+    is initialised with names only and empty contents. *)
 
 val register_included_file_resolver :
   filename:string -> new_content:string Global.input_src -> unit


### PR DESCRIPTION
This PR adds a new feature that can be activated using the global flag : `--whole-program` (short: `-W`).
In whole-program, every (non-external) module will also be compiled on top of the main file. Hence, running `clerk` beforehand is not mandatory anymore (but the compilation is sequentialized). This is useful when clerk is not an option or for punctual scripting/prototyping/testing.

To achieve that, we relax some existing invariants and process the modules code (instead of their minimal interface) throughout the compiler passes.