### PR TITLE
Support attachment of attributes to declaration items

### DIFF
--- a/compiler/catala_utils/map.ml
+++ b/compiler/catala_utils/map.ml
@@ -61,6 +61,15 @@ module type S = sig
       provided with a formatter for keys (can be used with ["%t"]) and the
       corresponding value. *)
 
+  val format_bindings_i :
+    ?pp_sep:(Format.formatter -> unit -> unit) ->
+    (Format.formatter -> (Format.formatter -> unit) -> key -> 'a -> unit) ->
+    Format.formatter ->
+    'a t ->
+    unit
+  (** Like [format_bindings], but the key is also supplied to the printing
+      function *)
+
   val format :
     ?pp_sep:(Format.formatter -> unit -> unit) ->
     ?pp_bind:(Format.formatter -> unit -> unit) ->
@@ -105,6 +114,11 @@ module Make (Ord : OrderedType) : S with type key = Ord.t = struct
   let format_bindings ?pp_sep pp_bnd ppf t =
     Format.pp_print_list ?pp_sep
       (fun ppf (k, v) -> pp_bnd ppf (fun ppf -> Ord.format ppf k) v)
+      ppf (bindings t)
+
+  let format_bindings_i ?pp_sep pp_bnd ppf t =
+    Format.pp_print_list ?pp_sep
+      (fun ppf (k, v) -> pp_bnd ppf (fun ppf -> Ord.format ppf k) k v)
       ppf (bindings t)
 
   let format

--- a/compiler/catala_utils/pos.ml
+++ b/compiler/catala_utils/pos.ml
@@ -36,6 +36,7 @@ let equal p1 p2 = p1.code_pos = p2.code_pos
 let attrs t = t.attr
 let set_attrs t attr = { t with attr }
 let add_attr t attr = { t with attr = attr :: t.attr }
+let add_attrs t attrs = List.fold_left add_attr t attrs
 let get_attrs t f = List.filter_map f t.attr
 
 let get_attr t f =

--- a/compiler/catala_utils/pos.mli
+++ b/compiler/catala_utils/pos.mli
@@ -40,6 +40,7 @@ val get_file : t -> string
 val attrs : t -> attr list
 val set_attrs : t -> attr list -> t
 val add_attr : t -> attr -> t
+val add_attrs : t -> attr list -> t
 
 val get_attr : t -> (attr -> 'a option) -> 'a option
 (** Raises [Invalid_argument] if the attribute appears multiple times *)

--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -54,7 +54,8 @@ type 'm ctx = {
   date_rounding : date_rounding;
 }
 
-let mark_tany m pos = Expr.with_ty m (Mark.add pos TAny) ~pos
+let mark_tany m pos =
+  Expr.with_ty m (Mark.add pos TAny) ~pos:(Expr.no_attrs_pos pos)
 
 (* Expression argument is used as a type witness, its type and positions aren't
    used *)
@@ -558,7 +559,7 @@ let translate_rule
   | S.ScopeVarDefinition { var; typ; e; _ }
   | S.SubScopeVarDefinition { var; typ; e; _ } ->
     let scope_var = Mark.remove var in
-    let decl_pos = Mark.get (ScopeVar.get_info scope_var) in
+    let decl_pos = Expr.no_attrs_pos (Mark.get (ScopeVar.get_info scope_var)) in
     let pos_mark, _ = pos_mark_mk e in
     let scope_let_kind, io =
       match rule with
@@ -720,7 +721,7 @@ let translate_scope_decl
   let scope_input_var = Var.make (ScopeName.base scope_name ^ "_in") in
   let scope_input_struct_name = scope_sig.scope_sig_input_struct in
   let scope_return_struct_name = scope_sig.scope_sig_output_struct in
-  let pos_sigma = Mark.get sigma_info in
+  let pos_sigma = Expr.no_attrs_pos (Mark.get sigma_info) in
   let scope_mark =
     (* Find a witness of a mark in the definitions *)
     match sigma.scope_decl_rules with
@@ -832,9 +833,10 @@ let translate_program (prgm : 'm S.program) : 'm Ast.program =
             | OnlyInput | Reentrant ->
               let info = ScopeVar.get_info dvar in
               let s = Mark.remove info ^ "_in" in
+              let pos = Expr.no_attrs_pos (Mark.get info) in
               Some
                 {
-                  scope_input_name = StructField.fresh (s, Mark.get info);
+                  scope_input_name = StructField.fresh (s, pos);
                   scope_input_io = svar.S.svar_io.Desugared.Ast.io_input;
                   scope_input_typ =
                     Mark.remove

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -735,7 +735,9 @@ let rec translate_expr
         let e_uid, c_uid = EnumName.Map.choose possible_c_uids in
         let c_uid =
           (* Retain the correct position *)
-          EnumConstructor.map_info (fun (v, _) -> v, pos_constructor) c_uid
+          EnumConstructor.map_info
+            (fun (v, p) -> v, Pos.add_attrs pos_constructor (Pos.attrs p))
+            c_uid
         in
         let payload = Option.map rec_helper payload in
         Expr.einj
@@ -766,7 +768,8 @@ let rec translate_expr
         let c_uid =
           EnumName.Map.find e_uid possible_c_uids
           |> (* Retain the correct position *)
-          EnumConstructor.map_info (fun (v, _) -> v, pos_constructor)
+          EnumConstructor.map_info (fun (v, p) ->
+              v, Pos.add_attrs pos_constructor (Pos.attrs p))
         in
         let payload = Option.map rec_helper payload in
         Expr.einj
@@ -1542,7 +1545,6 @@ let process_scope_use_item
       ScopeName.Map.add scope_uid new_scope modul.module_scopes
     in
     { modul with module_scopes }
-  | _ -> modul
 
 (** {1 Translating top-level items} *)
 

--- a/compiler/desugared/name_resolution.ml
+++ b/compiler/desugared/name_resolution.ml
@@ -535,7 +535,7 @@ let process_enum_decl
     (ctxt : context)
     (edecl : Surface.Ast.enum_decl) : context =
   let e_uid = get_enum ctxt edecl.enum_decl_name in
-  if List.length edecl.enum_decl_cases = 0 then
+  if edecl.enum_decl_cases = [] then
     Message.error
       ~pos:(Mark.get edecl.enum_decl_name)
       "The enum@ %s@ does@ not@ have@ any@ cases;@ give it some for Catala to \

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -224,15 +224,11 @@ let set_attrs e attrs =
   let attrs = List.map (fun (k, (v, pos)) -> Src (k, v, pos)) attrs in
   Mark.map_mark (map_mark (fun pos -> Pos.set_attrs pos attrs) (fun ty -> ty)) e
 
-let no_attrs m =
-  map_mark
-    (fun pos ->
-      Pos.set_attrs pos
-        (Pos.get_attrs pos (function
-          | Pos.Law_pos _ as p -> Some p
-          | _ -> None)))
-    (fun ty -> ty)
-    m
+let no_attrs_pos pos =
+  Pos.set_attrs pos
+    (Pos.get_attrs pos (function Pos.Law_pos _ as p -> Some p | _ -> None))
+
+let no_attrs m = map_mark no_attrs_pos (fun ty -> ty) m
 
 let map_mark2
     (type m)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -196,6 +196,9 @@ val set_attrs :
 val take_attr :
   ('a, 'm) gexpr -> (Pos.attr -> 'b option) -> 'b option * ('a, 'm) gexpr
 
+val no_attrs_pos : Pos.t -> Pos.t
+(** Discards the attributes: useful when copying a mark around. *)
+
 val no_attrs : 'm mark -> 'm mark
 (** Discards the attributes: useful when copying a mark around. *)
 

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -50,6 +50,7 @@ val log_entry : Format.formatter -> log_entry -> unit
 val runtime_error : Format.formatter -> Runtime.error -> unit
 val var : Format.formatter -> 'e Var.t -> unit
 val var_debug : Format.formatter -> 'e Var.t -> unit
+val attrs : Format.formatter -> Pos.t -> unit
 
 val expr : ?debug:bool -> unit -> Format.formatter -> ('a, 'm) gexpr -> unit
 (** Expression printer.
@@ -84,6 +85,7 @@ module ExprDebugParam : EXPR_PARAM
 (** {1 Debugging versions that don't require a context} *)
 
 val typ_debug : Format.formatter -> typ -> unit
+val decl_ctx : ?debug:bool -> Format.formatter -> decl_ctx -> unit
 
 val scope :
   ?debug:bool ->

--- a/compiler/surface/ast.mli
+++ b/compiler/surface/ast.mli
@@ -227,7 +227,6 @@ type scope_use_item =
   | Rule of rule
   | Definition of definition
   | Assertion of assertion
-  | MetaAssertion of meta_assertion
   | DateRounding of variation_typ Mark.pos
 
 type scope_use = {

--- a/compiler/surface/parser.messages
+++ b/compiler/surface/parser.messages
@@ -1,20 +1,22 @@
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT CONTENT TEXT YEAR
 ##
-## Ends in an error in state: 693.
+## Ends in an error in state: 754.
 ##
-## list_with_attr(enum_decl_line) -> list(addpos(attribute)) enum_decl_line . list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION ENUM UIDENT COLON rev_list_with_attr(enum_decl_line) . [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(enum_decl_line) -> rev_list_with_attr(enum_decl_line) . attribute [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
+## rev_list_with_attr(enum_decl_line) -> rev_list_with_attr(enum_decl_line) . enum_decl_line [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## list(addpos(attribute)) enum_decl_line
+## DECLARATION ENUM UIDENT COLON rev_list_with_attr(enum_decl_line)
 ##
 
 expected another enum case, or a new declaration or scope use
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 690.
+## Ends in an error in state: 757.
 ##
-## option(preceded(CONTENT,addpos(typ))) -> CONTENT . typ_data [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
+## option(preceded(CONTENT,posattr(typ))) -> CONTENT . list(attribute) typ_data [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTENT
@@ -24,9 +26,9 @@ expected a content type
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT YEAR
 ##
-## Ends in an error in state: 689.
+## Ends in an error in state: 756.
 ##
-## enum_decl_line -> ALT UIDENT . option(preceded(CONTENT,addpos(typ))) [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
+## enum_decl_line -> ALT UIDENT . option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALT UIDENT
@@ -36,9 +38,9 @@ expected a payload for your enum case, or another case or declaration
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT YEAR
 ##
-## Ends in an error in state: 688.
+## Ends in an error in state: 755.
 ##
-## enum_decl_line -> ALT . UIDENT option(preceded(CONTENT,addpos(typ))) [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
+## enum_decl_line -> ALT . UIDENT option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DECLARATION ATTR_START ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALT
@@ -46,23 +48,11 @@ source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT YEAR
 
 expected the name of an enum case
 
-source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON YEAR
-##
-## Ends in an error in state: 685.
-##
-## code_item -> DECLARATION ENUM UIDENT COLON . list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
-##
-## The known suffix of the stack is as follows:
-## DECLARATION ENUM UIDENT COLON
-##
-
-expected an enum case
-
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT YEAR
 ##
-## Ends in an error in state: 684.
+## Ends in an error in state: 752.
 ##
-## code_item -> DECLARATION ENUM UIDENT . COLON list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION ENUM UIDENT . COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION ENUM UIDENT
@@ -72,9 +62,9 @@ expected a colon
 
 source_file: BEGIN_CODE DECLARATION ENUM YEAR
 ##
-## Ends in an error in state: 683.
+## Ends in an error in state: 751.
 ##
-## code_item -> DECLARATION ENUM . UIDENT COLON list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION ENUM . UIDENT COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION ENUM
@@ -84,21 +74,23 @@ expected the name of your enum
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON YEAR
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 563.
 ##
-## code_item -> DECLARATION SCOPE UIDENT COLON . list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) . [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . attribute [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
+## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . scope_decl_item [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## DECLARATION SCOPE UIDENT COLON
+## DECLARATION SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item)
 ##
 
 expected a context item introduced by "context"
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT YEAR
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 561.
 ##
-## code_item -> DECLARATION SCOPE UIDENT . COLON list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION SCOPE UIDENT . COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION SCOPE UIDENT
@@ -108,9 +100,9 @@ expected a colon followed by the list of context items of this scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE YEAR
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 560.
 ##
-## code_item -> DECLARATION SCOPE . UIDENT COLON list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION SCOPE . UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION SCOPE
@@ -122,7 +114,7 @@ expected the name of the scope you are declaring
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 547.
 ##
 ## struct_scope -> struct_scope_base DEPENDS . separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
@@ -135,7 +127,7 @@ expected the type of the parameter of this struct data function
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT YEAR
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 546.
 ##
 ## struct_scope -> struct_scope_base . DEPENDS separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
@@ -149,7 +141,7 @@ expected a new struct data, or another declaration or scope use
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION YEAR
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 544.
 ##
 ## struct_scope_base -> CONDITION . lident [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -161,9 +153,9 @@ expected the name of this struct condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 530.
 ##
-## struct_scope_base -> DATA lident CONTENT . list(addpos(attribute)) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
+## struct_scope_base -> DATA lident CONTENT . list(attribute) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DATA lident CONTENT
@@ -173,9 +165,9 @@ expected the type of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT YEAR
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 529.
 ##
-## struct_scope_base -> DATA lident . CONTENT list(addpos(attribute)) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
+## struct_scope_base -> DATA lident . CONTENT list(attribute) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DATA lident
@@ -185,9 +177,9 @@ expected the type of this struct data, introduced by the content keyword
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA YEAR
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 528.
 ##
-## struct_scope_base -> DATA . lident CONTENT list(addpos(attribute)) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
+## struct_scope_base -> DATA . lident CONTENT list(attribute) typ_data [ SCOPE END_CODE DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DATA
@@ -197,33 +189,35 @@ expected the name of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 527.
 ##
-## code_item -> DECLARATION STRUCT list(addpos(attribute)) UIDENT COLON . list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) . [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(struct_scope) -> rev_list_with_attr(struct_scope) . attribute [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
+## rev_list_with_attr(struct_scope) -> rev_list_with_attr(struct_scope) . struct_scope [ SCOPE END_CODE DECLARATION DATA CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## DECLARATION STRUCT list(addpos(attribute)) UIDENT COLON
+## DECLARATION STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope)
 ##
 
 expected struct data or condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT YEAR
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 525.
 ##
-## code_item -> DECLARATION STRUCT list(addpos(attribute)) UIDENT . COLON list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION STRUCT list(attribute) UIDENT . COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## DECLARATION STRUCT list(addpos(attribute)) UIDENT
+## DECLARATION STRUCT list(attribute) UIDENT
 ##
 
 expected a colon
 
 source_file: BEGIN_CODE DECLARATION STRUCT YEAR
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 523.
 ##
-## code_item -> DECLARATION STRUCT . list(addpos(attribute)) UIDENT COLON list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION STRUCT . list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION STRUCT
@@ -233,11 +227,11 @@ expected the struct name
 
 source_file: BEGIN_CODE DECLARATION YEAR
 ##
-## Ends in an error in state: 453.
+## Ends in an error in state: 522.
 ##
-## code_item -> DECLARATION . STRUCT list(addpos(attribute)) UIDENT COLON list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
-## code_item -> DECLARATION . SCOPE UIDENT COLON list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
-## code_item -> DECLARATION . ENUM UIDENT COLON list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION . STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION . SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> DECLARATION . ENUM UIDENT COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION . lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION . lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION . lident CONTENT typ_data option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
@@ -250,81 +244,81 @@ expected the kind of the declaration (struct, scope or enum)
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION CARDINAL THEN
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 515.
 ##
-## assertion -> option(condition_consequence) list(addpos(attribute)) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## assertion -> ASSERTION option(condition_consequence) list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ##
 ## The known suffix of the stack is as follows:
-## option(condition_consequence) list(addpos(attribute)) noattr_expression
+## ASSERTION option(condition_consequence) list(attribute) noattr_expression
 ##
 
 expected a new scope use item
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION UNDER_CONDITION TRUE THEN
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 402.
 ##
-## condition_consequence -> UNDER_CONDITION list(addpos(attribute)) noattr_expression . CONSEQUENCE [ UIDENT TRUE SUM OUTPUT NOT MONEY_AMOUNT MONEY MINUS MINIMUM MAXIMUM MATCH LPAREN LIST LIDENT LET LBRACKET INT_LITERAL INTEGER IF FOR FILLED FALSE EXISTS DEFINED_AS DECIMAL_LITERAL DECIMAL DATE_LITERAL CONTENT COMBINE CARDINAL ATTR_START ]
+## condition_consequence -> UNDER_CONDITION list(attribute) noattr_expression . CONSEQUENCE [ UIDENT TRUE SUM OUTPUT NOT MONEY_AMOUNT MONEY MINUS MINIMUM MAXIMUM MATCH LPAREN LIST LIDENT LET LBRACKET INT_LITERAL INTEGER IF FOR FILLED FALSE EXISTS DEFINED_AS DECIMAL_LITERAL DECIMAL DATE_LITERAL CONTENT COMBINE CARDINAL ATTR_START ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## UNDER_CONDITION list(addpos(attribute)) noattr_expression
+## UNDER_CONDITION list(attribute) noattr_expression
 ##
 
 expected a consequence for this definition under condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION UNDER_CONDITION YEAR
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 400.
 ##
-## condition_consequence -> UNDER_CONDITION . list(addpos(attribute)) noattr_expression CONSEQUENCE [ UIDENT TRUE SUM OUTPUT NOT MONEY_AMOUNT MONEY MINUS MINIMUM MAXIMUM MATCH LPAREN LIST LIDENT LET LBRACKET INT_LITERAL INTEGER IF FOR FILLED FALSE EXISTS DEFINED_AS DECIMAL_LITERAL DECIMAL DATE_LITERAL CONTENT COMBINE CARDINAL ATTR_START ]
+## condition_consequence -> UNDER_CONDITION . list(attribute) noattr_expression CONSEQUENCE [ UIDENT TRUE SUM OUTPUT NOT MONEY_AMOUNT MONEY MINUS MINIMUM MAXIMUM MATCH LPAREN LIST LIDENT LET LBRACKET INT_LITERAL INTEGER IF FOR FILLED FALSE EXISTS DEFINED_AS DECIMAL_LITERAL DECIMAL DATE_LITERAL CONTENT COMBINE CARDINAL ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNDER_CONDITION
@@ -334,9 +328,9 @@ expected an expression for this condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION YEAR
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 512.
 ##
-## scope_item -> ASSERTION . assertion [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## assertion -> ASSERTION . option(condition_consequence) list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASSERTION
@@ -346,19 +340,19 @@ expected an expression that shoud be asserted during execution
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 504.
 ##
-## definition -> option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS . list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS
+## DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS
 ##
 
 expected an expression for the definition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT OF LIDENT DECREASING
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 413.
 ##
 ## separated_nonempty_list(COMMA,lident) -> lident . [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ## separated_nonempty_list(COMMA,lident) -> lident . COMMA separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
@@ -371,34 +365,37 @@ expected an expression for defining this function, introduced by the 'equals' ke
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION YEAR
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 499.
 ##
-## definition -> option(label) option(exception_to) DEFINITION . separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> DEFINITION . separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(exception_to) DEFINITION
+## DEFINITION
 ##
 
 expected the name of the variable you want to define
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION LIDENT YEAR
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 483.
 ##
-## option(addpos(exception_to)) -> exception_to . [ RULE ]
-## option(exception_to) -> exception_to . [ DEFINITION ]
+## definition -> EXCEPTION lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> EXCEPTION lident . RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## exception_to
+## EXCEPTION lident
 ##
 
 expected a rule or a definition after the exception declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION YEAR
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 467.
 ##
-## exception_to -> EXCEPTION . option(lident) [ RULE DEFINITION ]
+## definition -> EXCEPTION . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> EXCEPTION . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> EXCEPTION . RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> EXCEPTION . lident RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
 ## EXCEPTION
@@ -408,22 +405,31 @@ expected the label to which the exception is referring back
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL LIDENT DEFINED_AS
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 418.
 ##
-## definition -> option(label) . option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
-## rule -> option(label) . option(addpos(exception_to)) RULE rule_expr option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> LABEL lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> LABEL lident . EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> LABEL lident . EXCEPTION lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL lident . RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL lident . EXCEPTION RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL lident . EXCEPTION lident RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label)
+## LABEL lident
 ##
 
 expected a rule or a definition after the label declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL YEAR
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 417.
 ##
-## label -> LABEL . lident [ RULE EXCEPTION DEFINITION ]
+## definition -> LABEL . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> LABEL . lident EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> LABEL . lident EXCEPTION lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL . lident RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL . lident EXCEPTION RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> LABEL . lident EXCEPTION lident RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
 ## LABEL
@@ -433,7 +439,7 @@ expected the name of the label
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT DOT YEAR
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 392.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT DOT . separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DEFINED_AS ATTR_START ]
 ##
@@ -445,7 +451,7 @@ expected a struct field or a sub-scope context item after the dot
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT NOT FALSE
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 407.
 ##
 ## rule_consequence -> option(NOT) . FILLED [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -457,7 +463,7 @@ expected the filled keyword the this rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT OF YEAR
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 411.
 ##
 ## definition_parameters -> OF . separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ##
@@ -469,7 +475,7 @@ expected the name of the parameter for this dependent variable
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT YEAR
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 391.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . [ UNDER_CONDITION STATE OF NOT FILLED DEFINED_AS ATTR_START ]
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . DOT separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DEFINED_AS ATTR_START ]
@@ -482,12 +488,12 @@ expected 'under condition' followed by a condition, 'equals' followed by the def
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE YEAR
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 389.
 ##
-## rule -> option(label) option(addpos(exception_to)) RULE . rule_expr option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> RULE . list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(addpos(exception_to)) RULE
+## RULE
 ##
 
 expected the name of the variable subject to the rule
@@ -496,17 +502,22 @@ source_file: BEGIN_CODE SCOPE UIDENT COLON YEAR
 ##
 ## Ends in an error in state: 388.
 ##
-## code_item -> SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON . scope_item_list [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item) . [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . attribute [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . rule [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . definition [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . assertion [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . date_rounding [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON
+## SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item)
 ##
 
-expected a scope use item: a rule, definition or assertion
+expected the next item in the scope (rule, definition or assertion), or the start of a new top-level declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT YEAR
 ##
-## Ends in an error in state: 15.
+## Ends in an error in state: 19.
 ##
 ## noattr_expression -> UIDENT . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## quident -> UIDENT . DOT quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LBRACE LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTENT CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -520,22 +531,22 @@ expected a payload for the enum case constructor, or the rest of the expression 
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT YEAR
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 292.
 ##
-## noattr_expression -> EXISTS list(addpos(attribute)) lident . AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS list(attribute) lident . AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## EXISTS list(addpos(attribute)) lident
+## EXISTS list(attribute) lident
 ##
 
 expected the "in" keyword to continue this existential test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS YEAR
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 113.
 ##
-## noattr_expression -> EXISTS . list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> EXISTS . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS . list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## EXISTS
@@ -545,22 +556,22 @@ expected an identifier that will designate the existential witness for the test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT YEAR
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 305.
 ##
-## noattr_expression -> FOR ALL list(addpos(attribute)) lident . AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL list(attribute) lident . AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## FOR ALL list(addpos(attribute)) lident
+## FOR ALL list(attribute) lident
 ##
 
 expected the "in" keyword for the rest of the universal test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL YEAR
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 106.
 ##
-## noattr_expression -> FOR ALL . list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> FOR ALL . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL . list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## FOR ALL
@@ -570,10 +581,10 @@ expected an identifier for the bound variable of the universal test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR YEAR
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 105.
 ##
-## noattr_expression -> FOR . ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> FOR . ALL LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR . ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR . ALL LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## FOR
@@ -583,45 +594,45 @@ expected the "all" keyword to mean the "for all" construction of the universal t
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF TRUE SEMICOLON
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 312.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> IF list(addpos(attribute)) noattr_expression . THEN list(addpos(attribute)) noattr_expression ELSE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> IF list(attribute) noattr_expression . THEN list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## IF list(addpos(attribute)) noattr_expression
+## IF list(attribute) noattr_expression
 ##
 
 expected the "then" keyword as the conditional expression is complete
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF YEAR
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 103.
 ##
-## noattr_expression -> IF . list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression ELSE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> IF . list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF
@@ -631,88 +642,88 @@ expected an expression for the test of the conditional
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION INT_LITERAL WITH_V
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 385.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
-## option(preceded(UNDER_CONDITION,expression)) -> UNDER_CONDITION list(addpos(attribute)) noattr_expression . [ COLON ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
+## option(preceded(UNDER_CONDITION,expression)) -> UNDER_CONDITION list(attribute) noattr_expression . [ COLON ]
 ##
 ## The known suffix of the stack is as follows:
-## UNDER_CONDITION list(addpos(attribute)) noattr_expression
+## UNDER_CONDITION list(attribute) noattr_expression
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 92, spurious reduction of production option(addpos(unit_literal)) ->
-## In state 97, spurious reduction of production literal -> INT_LITERAL option(addpos(unit_literal))
-## In state 148, spurious reduction of production noattr_expression -> literal
+## In state 96, spurious reduction of production option(addpos(unit_literal)) ->
+## In state 101, spurious reduction of production literal -> INT_LITERAL option(addpos(unit_literal))
+## In state 152, spurious reduction of production noattr_expression -> literal
 ##
 
 expected a unit for this literal, or a valid operator to complete the expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LPAREN TRUE THEN
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 348.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
-## separated_nonempty_list(COMMA,expression) -> list(addpos(attribute)) noattr_expression . [ RPAREN ]
-## separated_nonempty_list(COMMA,expression) -> list(addpos(attribute)) noattr_expression . COMMA separated_nonempty_list(COMMA,expression) [ RPAREN ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
+## separated_nonempty_list(COMMA,expression) -> list(attribute) noattr_expression . [ RPAREN ]
+## separated_nonempty_list(COMMA,expression) -> list(attribute) noattr_expression . COMMA separated_nonempty_list(COMMA,expression) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## list(addpos(attribute)) noattr_expression
+## list(attribute) noattr_expression
 ##
 
 unmatched parenthesis that should have been closed by here
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LPAREN YEAR
 ##
-## Ends in an error in state: 64.
+## Ends in an error in state: 68.
 ##
 ## noattr_expression -> LPAREN . separated_nonempty_list(COMMA,expression) RPAREN [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -724,44 +735,44 @@ expected an expression inside the parenthesis
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET TRUE THEN
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 319.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## separated_nonempty_list(SEMICOLON,expression) -> list(addpos(attribute)) noattr_expression . [ RBRACKET ]
-## separated_nonempty_list(SEMICOLON,expression) -> list(addpos(attribute)) noattr_expression . SEMICOLON separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## separated_nonempty_list(SEMICOLON,expression) -> list(attribute) noattr_expression . [ RBRACKET ]
+## separated_nonempty_list(SEMICOLON,expression) -> list(attribute) noattr_expression . SEMICOLON separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## list(addpos(attribute)) noattr_expression
+## list(attribute) noattr_expression
 ##
 
 expected a semicolon or a right square bracket after the list element
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET YEAR
 ##
-## Ends in an error in state: 87.
+## Ends in an error in state: 91.
 ##
 ## noattr_expression -> LBRACKET . loption(separated_nonempty_list(SEMICOLON,expression)) RBRACKET [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -773,7 +784,7 @@ expected a list element
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH ALT YEAR
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 353.
 ##
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -786,22 +797,22 @@ expected the name of the constructor for the enum case in the pattern matching
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH YEAR
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 352.
 ##
 ## noattr_expression -> noattr_expression WITH . constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> MATCH list(addpos(attribute)) noattr_expression WITH . nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MATCH list(attribute) noattr_expression WITH . nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## MATCH list(addpos(attribute)) noattr_expression WITH
+## MATCH list(attribute) noattr_expression WITH
 ##
 
 expected a pattern matching case
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH YEAR
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 66.
 ##
-## noattr_expression -> MATCH . list(addpos(attribute)) noattr_expression WITH nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MATCH . list(attribute) noattr_expression WITH nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MATCH
@@ -811,9 +822,9 @@ expected an expression to match with
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION YEAR
 ##
-## Ends in an error in state: 384.
+## Ends in an error in state: 10.
 ##
-## option(preceded(UNDER_CONDITION,expression)) -> UNDER_CONDITION . list(addpos(attribute)) noattr_expression [ COLON ]
+## option(preceded(UNDER_CONDITION,expression)) -> UNDER_CONDITION . list(attribute) noattr_expression [ COLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNDER_CONDITION
@@ -823,9 +834,9 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT YEAR
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 9.
 ##
-## code_item -> SCOPE UIDENT . option(preceded(UNDER_CONDITION,expression)) COLON scope_item_list [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> SCOPE UIDENT . option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## SCOPE UIDENT
@@ -835,9 +846,9 @@ expected a scope use condition or the content of this scope use
 
 source_file: BEGIN_CODE SCOPE YEAR
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 8.
 ##
-## code_item -> SCOPE . UIDENT option(preceded(UNDER_CONDITION,expression)) COLON scope_item_list [ SCOPE END_CODE DECLARATION ATTR_START ]
+## code_item -> SCOPE . UIDENT option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## SCOPE
@@ -847,12 +858,14 @@ expected the name of the scope being used
 
 source_file: BEGIN_CODE YEAR
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 801.
 ##
-## source_file_item -> BEGIN_CODE . code END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
+## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . attribute [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . code_item [ SCOPE END_CODE DECLARATION ATTR_START ]
+## source_file_item -> BEGIN_CODE rev_list_with_attr(code_item) . END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
 ## The known suffix of the stack is as follows:
-## BEGIN_CODE
+## BEGIN_CODE rev_list_with_attr(code_item)
 ##
 
 expected some declaration or scope use inside this code block
@@ -886,7 +899,7 @@ source_file: BEGIN_METADATA YEAR
 ##
 ## Ends in an error in state: 5.
 ##
-## metadata_block -> BEGIN_METADATA . option(law_text) code END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
+## metadata_block -> BEGIN_METADATA . option(law_text) rev_list_with_attr(code_item) END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
 ## The known suffix of the stack is as follows:
 ## BEGIN_METADATA
@@ -896,27 +909,30 @@ expected some law text or code block
 
 source_file: BEGIN_METADATA LAW_TEXT LAW_HEADING
 ##
-## Ends in an error in state: 6.
+## Ends in an error in state: 7.
 ##
-## metadata_block -> BEGIN_METADATA option(law_text) . code END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
+## metadata_block -> BEGIN_METADATA option(law_text) rev_list_with_attr(code_item) . END_CODE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
+## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . attribute [ SCOPE END_CODE DECLARATION ATTR_START ]
+## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . code_item [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## BEGIN_METADATA option(law_text)
+## BEGIN_METADATA option(law_text) rev_list_with_attr(code_item)
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 1, spurious reduction of production nonempty_list(LAW_TEXT) -> LAW_TEXT
-## In state 713, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
-## In state 714, spurious reduction of production option(law_text) -> law_text
+## In state 779, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
+## In state 780, spurious reduction of production option(law_text) -> law_text
+## In state 6, spurious reduction of production rev_list_with_attr(code_item) ->
 ##
 
 expected some law text or code block
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT DOT YEAR
 ##
-## Ends in an error in state: 16.
+## Ends in an error in state: 20.
 ##
 ## noattr_expression -> UIDENT DOT . qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## quident -> UIDENT DOT . quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LBRACE LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTENT CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -930,7 +946,7 @@ constructor, possibly with a submodule qualification)
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT DOT UIDENT YEAR
 ##
-## Ends in an error in state: 17.
+## Ends in an error in state: 21.
 ##
 ## qlident -> UIDENT . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## quident -> UIDENT . DOT quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LBRACE LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTENT CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -947,7 +963,7 @@ expected one of:
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT DOT UIDENT DOT YEAR
 ##
-## Ends in an error in state: 18.
+## Ends in an error in state: 22.
 ##
 ## qlident -> UIDENT DOT . qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## quident -> UIDENT DOT . quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LBRACE LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTENT CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -961,9 +977,9 @@ constructor, possibly with a submodule qualification)
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM YEAR
 ##
-## Ends in an error in state: 25.
+## Ends in an error in state: 29.
 ##
-## noattr_expression -> SUM . primitive_typ OF list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> SUM . primitive_typ OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## SUM
@@ -973,7 +989,7 @@ the 'sum' operator must be followed by the type to be summed.
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT YEAR
 ##
-## Ends in an error in state: 26.
+## Ends in an error in state: 30.
 ##
 ## quident -> UIDENT . DOT quident [ XOR WITH_V WITH WE_HAVE THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## quident -> UIDENT . [ XOR WITH_V WITH WE_HAVE THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -989,7 +1005,7 @@ expected one of
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DOT YEAR
 ##
-## Ends in an error in state: 27.
+## Ends in an error in state: 31.
 ##
 ## quident -> UIDENT DOT . quident [ XOR WITH_V WITH WE_HAVE THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1001,9 +1017,9 @@ expected the structure or enumeration type of the definition under the given mod
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM BOOLEAN YEAR
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 40.
 ##
-## noattr_expression -> SUM primitive_typ . OF list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> SUM primitive_typ . OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## SUM primitive_typ
@@ -1013,9 +1029,9 @@ expected 'of' then the list on which to operate
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF YEAR
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 41.
 ##
-## noattr_expression -> SUM primitive_typ OF . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> SUM primitive_typ OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## SUM primitive_typ OF
@@ -1025,7 +1041,7 @@ expected the list on which to operate the sum
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT YEAR
 ##
-## Ends in an error in state: 39.
+## Ends in an error in state: 43.
 ##
 ## noattr_expression -> OUTPUT . OF quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT . OF quident WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1038,7 +1054,7 @@ expected 'of' then a scope to be applied
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF YEAR
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 44.
 ##
 ## noattr_expression -> OUTPUT OF . quident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT OF . quident WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1051,7 +1067,7 @@ expected a scope to be applied
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT STATE
 ##
-## Ends in an error in state: 41.
+## Ends in an error in state: 45.
 ##
 ## noattr_expression -> OUTPUT OF quident . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT OF quident . WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1063,7 +1079,7 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT STATE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
+## In state 30, spurious reduction of production quident -> UIDENT
 ##
 
 expected 'with' then the arguments to the scope call ('{ -- var : ... }'), or a
@@ -1071,7 +1087,7 @@ binary operator to be applied on the results of the call
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V YEAR
 ##
-## Ends in an error in state: 42.
+## Ends in an error in state: 46.
 ##
 ## noattr_expression -> OUTPUT OF quident WITH_V . LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1083,7 +1099,7 @@ expected the arguments to the scope call ('{ --var: ... }')
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V LBRACE YEAR
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 47.
 ##
 ## noattr_expression -> OUTPUT OF quident WITH_V LBRACE . list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1095,7 +1111,7 @@ expected a list of variable-value bindings in the form `-- var_name : <expressio
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V LBRACE ALT YEAR
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 48.
 ##
 ## list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field list(preceded(ALT,struct_content_field)) [ RBRACE ]
 ##
@@ -1107,9 +1123,9 @@ expected a variable name, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT YEAR
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 51.
 ##
-## struct_content_field -> lident . COLON list(addpos(attribute)) noattr_expression [ RBRACE ALT ]
+## struct_content_field -> lident . COLON list(attribute) noattr_expression [ RBRACE ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident
@@ -1119,9 +1135,9 @@ expected a colon, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON YEAR
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 52.
 ##
-## struct_content_field -> lident COLON . list(addpos(attribute)) noattr_expression [ RBRACE ALT ]
+## struct_content_field -> lident COLON . list(attribute) noattr_expression [ RBRACE ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident COLON
@@ -1131,9 +1147,9 @@ expected an expression, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION NOT YEAR
 ##
-## Ends in an error in state: 50.
+## Ends in an error in state: 54.
 ##
-## noattr_expression -> NOT . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> NOT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## NOT
@@ -1143,9 +1159,9 @@ expected a boolean expression to apply 'not' on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINUS YEAR
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 58.
 ##
-## noattr_expression -> MINUS . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINUS . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINUS
@@ -1155,10 +1171,10 @@ expected a numeric expression to apply '-' on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINIMUM YEAR
 ##
-## Ends in an error in state: 56.
+## Ends in an error in state: 60.
 ##
-## noattr_expression -> MINIMUM . OF list(addpos(attribute)) noattr_expression OR_IF_LIST_EMPTY THEN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> MINIMUM . OF list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINIMUM . OF list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINIMUM . OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINIMUM
@@ -1168,10 +1184,10 @@ expected 'of' then the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINIMUM OF YEAR
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 61.
 ##
-## noattr_expression -> MINIMUM OF . list(addpos(attribute)) noattr_expression OR_IF_LIST_EMPTY THEN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> MINIMUM OF . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINIMUM OF . list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINIMUM OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MINIMUM OF
@@ -1181,10 +1197,10 @@ expected an expression defining the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MAXIMUM YEAR
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 63.
 ##
-## noattr_expression -> MAXIMUM . OF list(addpos(attribute)) noattr_expression OR_IF_LIST_EMPTY THEN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> MAXIMUM . OF list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MAXIMUM . OF list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MAXIMUM . OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAXIMUM
@@ -1194,10 +1210,10 @@ expected 'of' then the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MAXIMUM OF YEAR
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 64.
 ##
-## noattr_expression -> MAXIMUM OF . list(addpos(attribute)) noattr_expression OR_IF_LIST_EMPTY THEN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> MAXIMUM OF . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MAXIMUM OF . list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MAXIMUM OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## MAXIMUM OF
@@ -1207,7 +1223,7 @@ expected an expression defining the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LIDENT YEAR
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 78.
 ##
 ## noattr_expression -> LIDENT . option(state_qualifier) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1219,10 +1235,10 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET YEAR
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 85.
 ##
-## noattr_expression -> LET . list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression IN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> LET . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN DEFINED_AS list(addpos(attribute)) noattr_expression IN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> LET . list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> LET . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -1232,31 +1248,31 @@ expected 'var equals expression' after 'let'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 328.
 ##
-## noattr_expression -> LET list(addpos(attribute)) lident DEFINED_AS . list(addpos(attribute)) noattr_expression IN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> LET list(attribute) lident DEFINED_AS . list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## LET list(addpos(attribute)) lident DEFINED_AS
+## LET list(attribute) lident DEFINED_AS
 ##
 
 expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG YEAR
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 306.
 ##
-## noattr_expression -> FOR ALL list(addpos(attribute)) lident AMONG . list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL list(attribute) lident AMONG . list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## FOR ALL list(addpos(attribute)) lident AMONG
+## FOR ALL list(attribute) lident AMONG
 ##
 
 expected an expression describing the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE YEAR
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 138.
 ##
 ## noattr_expression -> quident LBRACE . nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1268,7 +1284,7 @@ expected a list of field bindings of the form '-- fld : expression'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT YEAR
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 139.
 ##
 ## nonempty_list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field [ RBRACE ]
 ## nonempty_list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field nonempty_list(preceded(ALT,struct_content_field)) [ RBRACE ]
@@ -1281,9 +1297,9 @@ expected a 'fldname : expression' binding
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 144.
 ##
-## option(preceded(CONTENT,expression)) -> CONTENT . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## option(preceded(CONTENT,expression)) -> CONTENT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTENT
@@ -1337,453 +1353,453 @@ expected an expression defining the enumeration case content
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT CONTENT FALSE YEAR
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 146.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## option(preceded(CONTENT,expression)) -> CONTENT list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## option(preceded(CONTENT,expression)) -> CONTENT list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## CONTENT list(addpos(attribute)) noattr_expression
+## CONTENT list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 295.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression . SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression . SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression
+## EXISTS list(attribute) lident AMONG list(attribute) noattr_expression
 ##
 
 expected 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH YEAR
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 296.
 ##
-## noattr_expression -> EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH . THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH . THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH
+## EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH
 ##
 
 expected the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT YEAR
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 297.
 ##
-## noattr_expression -> EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT
+## EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT
 ##
 
 expected an expression, following the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT FALSE YEAR
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 299.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## EXISTS list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression
+## EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 308.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression . WE_HAVE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression . WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression
+## FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression
 ##
 
 expected 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE YEAR
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 309.
 ##
-## noattr_expression -> FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE
+## FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE
 ##
 
 expected the form 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE FALSE YEAR
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 311.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## FOR ALL list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression WE_HAVE list(addpos(attribute)) noattr_expression
+## FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN YEAR
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 313.
 ##
-## noattr_expression -> IF list(addpos(attribute)) noattr_expression THEN . list(addpos(attribute)) noattr_expression ELSE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> IF list(attribute) noattr_expression THEN . list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## IF list(addpos(attribute)) noattr_expression THEN
+## IF list(attribute) noattr_expression THEN
 ##
 
 expected an expression, followed by 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN FALSE YEAR
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 315.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression . ELSE list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> IF list(attribute) noattr_expression THEN list(attribute) noattr_expression . ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression
+## IF list(attribute) noattr_expression THEN list(attribute) noattr_expression
 ##
 
 expected 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE YEAR
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 316.
 ##
-## noattr_expression -> IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression ELSE . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression ELSE
+## IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE
 ##
 
 expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE FALSE YEAR
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 318.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression ELSE list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## IF list(addpos(attribute)) noattr_expression THEN list(addpos(attribute)) noattr_expression ELSE list(addpos(attribute)) noattr_expression
+## IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET UIDENT SEMICOLON YEAR
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 320.
 ##
-## separated_nonempty_list(SEMICOLON,expression) -> list(addpos(attribute)) noattr_expression SEMICOLON . separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
+## separated_nonempty_list(SEMICOLON,expression) -> list(attribute) noattr_expression SEMICOLON . separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## list(addpos(attribute)) noattr_expression SEMICOLON
+## list(attribute) noattr_expression SEMICOLON
 ##
 
 expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 330.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression . IN list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression . IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression
+## LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression
 ##
 
 expected the keyword 'in'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN YEAR
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 331.
 ##
-## noattr_expression -> LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression IN . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression IN
+## LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN
 ##
 
 expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN FALSE YEAR
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 333.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression IN list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## LET list(addpos(attribute)) lident DEFINED_AS list(addpos(attribute)) noattr_expression IN list(addpos(attribute)) noattr_expression
+## LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH FALSE YEAR
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 351.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> MATCH list(addpos(attribute)) noattr_expression . WITH nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> MATCH list(attribute) noattr_expression . WITH nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ##
 ## The known suffix of the stack is as follows:
-## MATCH list(addpos(attribute)) noattr_expression
+## MATCH list(attribute) noattr_expression
 ##
 
 expected 'with pattern -- <pattern> : <expression> ...'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD YEAR
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 354.
 ##
-## match_arm -> WILDCARD . COLON list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> WILDCARD . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## WILDCARD
@@ -1793,9 +1809,9 @@ expected ':' followed by an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON YEAR
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 355.
 ##
-## match_arm -> WILDCARD COLON . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> WILDCARD COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## WILDCARD COLON
@@ -1805,45 +1821,45 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON FALSE YEAR
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 357.
 ##
-## match_arm -> WILDCARD COLON list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> WILDCARD COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## WILDCARD COLON list(addpos(attribute)) noattr_expression
+## WILDCARD COLON list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT XOR
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 360.
 ##
-## match_arm -> constructor_binding . COLON list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> constructor_binding . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## constructor_binding
@@ -1852,17 +1868,17 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
-## In state 155, spurious reduction of production constructor_binding -> quident
+## In state 30, spurious reduction of production quident -> UIDENT
+## In state 159, spurious reduction of production constructor_binding -> quident
 ##
 
 expected a colon followed by an expression, as in '-- Case : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 361.
 ##
-## match_arm -> constructor_binding COLON . list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> constructor_binding COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## constructor_binding COLON
@@ -1872,149 +1888,77 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON FALSE YEAR
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 363.
 ##
-## match_arm -> constructor_binding COLON list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## match_arm -> constructor_binding COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## constructor_binding COLON list(addpos(attribute)) noattr_expression
+## constructor_binding COLON list(attribute) noattr_expression
 ##
 
 expected a binary operator, or the next case in the form '-- NextCase : <expression>', or a keyword ending the match expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINUS FALSE YEAR
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 375.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> MINUS list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> MINUS list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## MINUS list(addpos(attribute)) noattr_expression
+## MINUS list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION NOT FALSE YEAR
-##
-## Ends in an error in state: 372.
-##
-## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> NOT list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-##
-## The known suffix of the stack is as follows:
-## NOT list(addpos(attribute)) noattr_expression
-##
-
-expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
-
-source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON FALSE YEAR
-##
-## Ends in an error in state: 373.
-##
-## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
-## struct_content_field -> lident COLON list(addpos(attribute)) noattr_expression . [ RBRACE ALT ]
-##
-## The known suffix of the stack is as follows:
-## lident COLON list(addpos(attribute)) noattr_expression
-##
-
-expected another field in the form '-- <var>: <expression>', or a closing '}' brace
-
-source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF FALSE YEAR
 ##
 ## Ends in an error in state: 376.
 ##
@@ -2023,73 +1967,132 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF FALSE YEAR
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> SUM primitive_typ OF list(addpos(attribute)) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> NOT list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
-## SUM primitive_typ OF list(addpos(attribute)) noattr_expression
+## NOT list(attribute) noattr_expression
+##
+
+expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
+
+source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON FALSE YEAR
+##
+## Ends in an error in state: 377.
+##
+## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
+## struct_content_field -> lident COLON list(attribute) noattr_expression . [ RBRACE ALT ]
+##
+## The known suffix of the stack is as follows:
+## lident COLON list(attribute) noattr_expression
+##
+
+expected another field in the form '-- <var>: <expression>', or a closing '}' brace
+
+source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF FALSE YEAR
+##
+## Ends in an error in state: 380.
+##
+## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> SUM primitive_typ OF list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE ELSE DOT DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+##
+## The known suffix of the stack is as follows:
+## SUM primitive_typ OF list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 513.
 ##
-## assertion -> option(condition_consequence) . list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## assertion -> ASSERTION option(condition_consequence) . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(condition_consequence)
+## ASSERTION option(condition_consequence)
 ##
 
 expected either 'fulfilled' or 'not fulfilled'
 
-source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT FILLED YEAR
-##
-## Ends in an error in state: 405.
-##
-## scope_item_list -> scope_item . scope_item_list [ SCOPE END_CODE DECLARATION ATTR_START ]
-## scope_item_list -> scope_item . [ SCOPE END_CODE DECLARATION ATTR_START ]
-##
-## The known suffix of the stack is as follows:
-## scope_item
-##
-
-expected the next item in the scope, or the start of a new top-level decleration
-
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 404.
 ##
-## rule -> option(label) option(addpos(exception_to)) RULE rule_expr option(state) option(condition_consequence) . rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) . rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(addpos(exception_to)) RULE rule_expr option(state) option(condition_consequence)
+## RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence)
 ##
 
 expected either 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE YEAR
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 396.
 ##
 ## state -> STATE . lident [ UNDER_CONDITION STATE SCOPE OUTPUT NOT LIDENT INTERNAL INPUT FILLED END_CODE DEFINED_AS DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2101,79 +2104,79 @@ expected an identifier defining the name of the state
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 399.
 ##
-## rule -> option(label) option(addpos(exception_to)) RULE rule_expr option(state) . option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) . option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(addpos(exception_to)) RULE rule_expr option(state)
+## RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state)
 ##
 
 expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 502.
 ##
-## definition -> option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) . option(condition_consequence) DEFINED_AS list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) . option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state)
+## DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state)
 ##
 
 expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 503.
 ##
-## definition -> option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) . DEFINED_AS list(addpos(attribute)) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) . DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence)
+## DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence)
 ##
 
 expected 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 506.
 ##
-## definition -> option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(addpos(attribute)) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
+## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER FOR EXCEPTION EQUAL END_CODE DOT DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
 ##
 ## The known suffix of the stack is as follows:
-## option(label) option(exception_to) DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(addpos(attribute)) noattr_expression
+## DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT YEAR
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 681.
 ##
 ## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2198,7 +2201,7 @@ expected a variable name, optionally preceded by 'output'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON INTERNAL YEAR
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 589.
 ##
 ## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2223,7 +2226,7 @@ expected a variable name
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT YEAR
 ##
-## Ends in an error in state: 637.
+## Ends in an error in state: 705.
 ##
 ## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2241,7 +2244,7 @@ expected either 'condition', or 'content' followed by the expected variable type
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 640.
+## Ends in an error in state: 708.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT . typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONTENT . typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2255,7 +2258,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT BOOLEAN YEAR
 ##
-## Ends in an error in state: 641.
+## Ends in an error in state: 709.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data . DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2270,7 +2273,7 @@ for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 710.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2283,7 +2286,7 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 643.
+## Ends in an error in state: 711.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2295,7 +2298,7 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 644.
+## Ends in an error in state: 712.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2306,17 +2309,17 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
-## In state 35, spurious reduction of production primitive_typ -> quident
-## In state 471, spurious reduction of production typ_data -> primitive_typ
-## In state 485, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data
+## In state 30, spurious reduction of production quident -> UIDENT
+## In state 39, spurious reduction of production primitive_typ -> quident
+## In state 539, spurious reduction of production typ_data -> primitive_typ
+## In state 554, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument specification
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 645.
+## Ends in an error in state: 713.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2328,7 +2331,7 @@ expected a 'state' declaration for the preceding declaration, or the next declar
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION STATE LIDENT YEAR
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 574.
 ##
 ## list(state) -> state . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2341,7 +2344,7 @@ declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 647.
+## Ends in an error in state: 715.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2352,17 +2355,17 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
-## In state 35, spurious reduction of production primitive_typ -> quident
-## In state 471, spurious reduction of production typ_data -> primitive_typ
-## In state 485, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data
+## In state 30, spurious reduction of production quident -> UIDENT
+## In state 39, spurious reduction of production primitive_typ -> quident
+## In state 539, spurious reduction of production typ_data -> primitive_typ
+## In state 554, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data
 ##
 
 expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION YEAR
 ##
-## Ends in an error in state: 650.
+## Ends in an error in state: 718.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2376,7 +2379,7 @@ expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS YEAR
 ##
-## Ends in an error in state: 651.
+## Ends in an error in state: 719.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2389,7 +2392,7 @@ expected the form 'depends on <ident> content <type>'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 652.
+## Ends in an error in state: 720.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2401,7 +2404,7 @@ expected the form 'depends on (<ident> content <type> [, <ident> content <type> 
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 653.
+## Ends in an error in state: 721.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2412,17 +2415,17 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
-## In state 35, spurious reduction of production primitive_typ -> quident
-## In state 471, spurious reduction of production typ_data -> primitive_typ
-## In state 485, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data
+## In state 30, spurious reduction of production quident -> UIDENT
+## In state 39, spurious reduction of production primitive_typ -> quident
+## In state 539, spurious reduction of production typ_data -> primitive_typ
+## In state 554, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument declaration (', <ident> content <type>')
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 654.
+## Ends in an error in state: 722.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2434,7 +2437,7 @@ expected the next definition in scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT YEAR
 ##
-## Ends in an error in state: 661.
+## Ends in an error in state: 728.
 ##
 ## scope_decl_item -> lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
@@ -2452,7 +2455,7 @@ expected the form '<ident> scope <Scope_name>', or a scope variable declaration
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT SCOPE YEAR
 ##
-## Ends in an error in state: 662.
+## Ends in an error in state: 729.
 ##
 ## scope_decl_item -> lident SCOPE . quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2464,7 +2467,7 @@ expected a scope name
 
 source_file: BEGIN_CODE DECLARATION LIDENT YEAR
 ##
-## Ends in an error in state: 695.
+## Ends in an error in state: 763.
 ##
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
@@ -2478,7 +2481,7 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 696.
+## Ends in an error in state: 764.
 ##
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
@@ -2492,7 +2495,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT BOOLEAN YEAR
 ##
-## Ends in an error in state: 697.
+## Ends in an error in state: 765.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data . DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT typ_data . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
@@ -2507,7 +2510,7 @@ expected 'equals <expression>', optionally preceded by 'depends on <var> content
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 698.
+## Ends in an error in state: 766.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
@@ -2520,7 +2523,7 @@ expected a variable name, following the form 'depends on <var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 699.
+## Ends in an error in state: 767.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
@@ -2532,7 +2535,7 @@ expected a variable name, following the form 'depends on (<var> content <type>, 
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 700.
+## Ends in an error in state: 768.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
@@ -2543,10 +2546,10 @@ source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 26, spurious reduction of production quident -> UIDENT
-## In state 35, spurious reduction of production primitive_typ -> quident
-## In state 471, spurious reduction of production typ_data -> primitive_typ
-## In state 485, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data
+## In state 30, spurious reduction of production quident -> UIDENT
+## In state 39, spurious reduction of production primitive_typ -> quident
+## In state 539, spurious reduction of production typ_data -> primitive_typ
+## In state 554, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data
 ##
 
 expected ')', or ',' followed by another argument declaration in the form '<var>
@@ -2554,7 +2557,7 @@ content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 701.
+## Ends in an error in state: 769.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . option(opt_def) [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
@@ -2566,9 +2569,9 @@ expected 'equals <expression>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN DEFINED_AS YEAR
 ##
-## Ends in an error in state: 702.
+## Ends in an error in state: 770.
 ##
-## option(opt_def) -> DEFINED_AS . list(addpos(attribute)) noattr_expression [ SCOPE END_CODE DECLARATION ATTR_START ]
+## option(opt_def) -> DEFINED_AS . list(attribute) noattr_expression [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFINED_AS
@@ -2578,10 +2581,10 @@ expected an expression
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT YEAR
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 551.
 ##
-## separated_nonempty_list(COMMA,var_content) -> lident . CONTENT typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
-## separated_nonempty_list(COMMA,var_content) -> lident . CONTENT typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident . CONTENT list(attribute) typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident . CONTENT list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident
@@ -2591,10 +2594,10 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 484.
+## Ends in an error in state: 552.
 ##
-## separated_nonempty_list(COMMA,var_content) -> lident CONTENT . typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
-## separated_nonempty_list(COMMA,var_content) -> lident CONTENT . typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident CONTENT . list(attribute) typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident CONTENT . list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident CONTENT
@@ -2604,68 +2607,68 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT BOOLEAN YEAR
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 554.
 ##
-## separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data . [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
-## separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data . COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data . [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data . COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## lident CONTENT typ_data
+## lident CONTENT list(attribute) typ_data
 ##
 
 expected 'equals <expression>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT COMMA YEAR
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 555.
 ##
-## separated_nonempty_list(COMMA,var_content) -> lident CONTENT typ_data COMMA . separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> lident CONTENT list(attribute) typ_data COMMA . separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## lident CONTENT typ_data COMMA
+## lident CONTENT list(attribute) typ_data COMMA
 ##
 
 expected the definition of another argument in the form '<var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 704.
+## Ends in an error in state: 772.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . OF funcall_args [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . WITH constructor_binding [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . BUT_REPLACE LBRACE nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . CONTAINS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . MULT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . DIV list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . PLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . MINUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . PLUSPLUS list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . LESSER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . LESSER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . GREATER list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . GREATER_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . NOT_EQUAL list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . AND list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . OR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . XOR list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . FOR list(addpos(attribute)) lident AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(addpos(attribute)) noattr_expression SUCH THAT list(addpos(attribute)) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
-## option(opt_def) -> DEFINED_AS list(addpos(attribute)) noattr_expression . [ SCOPE END_CODE DECLARATION ATTR_START ]
+## noattr_expression -> noattr_expression . CONTAINS list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . MULT list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . DIV list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . PLUS list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . MINUS list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . PLUSPLUS list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . LESSER list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . LESSER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . GREATER list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . GREATER_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . NOT_EQUAL list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . AND list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . OR list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . XOR list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . FOR list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## noattr_expression -> noattr_expression . FOR LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER FOR EQUAL END_CODE DOT DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
+## option(opt_def) -> DEFINED_AS list(attribute) noattr_expression . [ SCOPE END_CODE DECLARATION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
-## DEFINED_AS list(addpos(attribute)) noattr_expression
+## DEFINED_AS list(attribute) noattr_expression
 ##
 
 expected a binary operator continuing the expression, or a keyword ending the expression and starting the next item
 
 source_file: BEGIN_DIRECTIVE YEAR
 ##
-## Ends in an error in state: 715.
+## Ends in an error in state: 781.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE . directive END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2677,7 +2680,7 @@ expected a directive, e.g. 'Include: <filename>'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE YEAR
 ##
-## Ends in an error in state: 725.
+## Ends in an error in state: 791.
 ##
 ## directive -> LAW_INCLUDE . COLON nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2689,7 +2692,7 @@ expected ':', then a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON YEAR
 ##
-## Ends in an error in state: 726.
+## Ends in an error in state: 792.
 ##
 ## directive -> LAW_INCLUDE COLON . nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2701,7 +2704,7 @@ expected a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG YEAR
 ##
-## Ends in an error in state: 727.
+## Ends in an error in state: 793.
 ##
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . [ END_DIRECTIVE AT_PAGE ]
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . nonempty_list(DIRECTIVE_ARG) [ END_DIRECTIVE AT_PAGE ]
@@ -2714,7 +2717,7 @@ expected a page specification in the form '@p.<number>', or a newline
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG AT_PAGE YEAR
 ##
-## Ends in an error in state: 732.
+## Ends in an error in state: 798.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE directive . END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2726,7 +2729,7 @@ expected a newline
 
 source_file: LAW_HEADING YEAR
 ##
-## Ends in an error in state: 737.
+## Ends in an error in state: 803.
 ##
 ## source_file -> source_file_item . source_file [ # ]
 ##

--- a/compiler/surface/parser.mly
+++ b/compiler/surface/parser.mly
@@ -15,7 +15,14 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  *)
+*)
+
+(*
+  Note: this file uses the Menhir "new syntax":
+  https://gallium.inria.fr/~fpottier/menhir/manual.html#sec25
+
+  In particular, `<>` returns the variables bound by the rule (single variable or as a tuple); and `~` binds to a same-named variable.
+*)
 
 %{
   open Catala_utils
@@ -167,7 +174,7 @@ let attr(x) ==
 }
 
 let posattr(x) ==
-| ~ = attr(addpos(x)) ; <>
+| attr(addpos(x))
 
 let rev_list_with_attr(x) :=
 | l = rev_list_with_attr(x) ; a = attribute ; {
@@ -206,8 +213,7 @@ let typ_data :=
 
 let typ == t = typ_data ; <Data>
 
-let uident ==
-| ~ = addpos(UIDENT) ; <>
+let uident == addpos(UIDENT)
 
 let lident :=
 | i = LIDENT ; {
@@ -222,8 +228,7 @@ let lident :=
       (i, get_pos $sloc)
 }
 
-let scope_var ==
-| b = separated_nonempty_list(DOT, addpos(LIDENT)) ; <>
+let scope_var == separated_nonempty_list(DOT, addpos(LIDENT))
 
 let quident :=
 | uid = uident ; DOT ; quid = quident ; {
@@ -242,13 +247,11 @@ let mbinder ==
 | LPAREN ; ids = separated_nonempty_list(COMMA,attr(lident)) ; RPAREN ; <>
 
 let state_qualifier ==
-| STATE ; state = posattr(LIDENT) ; <>
+| STATE ; posattr(LIDENT)
 
-let expression ==
-| ~ = attr(noattr_expression) ; <>
+let expression == attr(noattr_expression)
 
-let noattr_expression :=
-| ~ = addpos(naked_expression) ; <>
+let noattr_expression := addpos(naked_expression)
 (* Required for leading expressions to explicitely apply to the outermost expression *)
 
 let naked_expression ==
@@ -297,7 +300,7 @@ let naked_expression ==
 }
 | LBRACKET ; l = separated_list(SEMICOLON, expression) ; RBRACKET ;
   <ArrayLit>
-| e = struct_or_enum_inject ; <>
+| struct_or_enum_inject
 | e1 = noattr_expression ;
   OF ;
   args = funcall_args ; {
@@ -554,14 +557,14 @@ let rule :=
 }
 
 let definition_parameters :=
-| OF ; args = separated_nonempty_list(COMMA,lident) ; <>
+| OF ; separated_nonempty_list(COMMA,lident)
 
 
 let label ==
-| LABEL ; i = lident ; <>
+| LABEL ; lident
 
 let state :=
-| STATE ; s = lident ; <>
+| STATE ; lident
 
 let exception_to ==
 | EXCEPTION ; i = ioption(lident) ; {
@@ -635,10 +638,10 @@ let date_rounding :=
 }
 
 let scope_item ==
-| ~ = rule ; <>
-| ~ = definition ; <>
-| ~ = assertion ; <>
-| ~ = date_rounding ; <>
+| rule
+| definition
+| assertion
+| date_rounding
 
 let scope_item_list ==
 | items = list_with_attr(scope_item) ; {
@@ -870,7 +873,7 @@ let code_item :=
 }
 
 let opt_def ==
-| DEFINED_AS; e = expression; <>
+| DEFINED_AS; expression
 
 let code ==
 | items = list_with_attr(code_item) ; {

--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -347,7 +347,7 @@ let rec parse_source ?resolve_included_file (lexbuf : Sedlexing.lexbuf) :
   let source_file_name = lexbuf_file lexbuf in
   Message.debug "Parsing %a" File.format source_file_name;
   let language = Cli.file_lang source_file_name in
-  let commands = localised_parser language lexbuf in
+  let commands = Parser_state.with_state (localised_parser language) lexbuf in
   let program =
     expand_includes ?resolve_included_file source_file_name commands
   in

--- a/compiler/surface/parser_state.ml
+++ b/compiler/surface/parser_state.ml
@@ -1,0 +1,71 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2025 Inria,
+   contributors: Louis Gesbert <louis.gesbert@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Catala_utils
+
+type t = {
+  current_file : File.t;
+  mutable current_heading : Ast.law_heading list;
+}
+
+let state : t list ref = ref []
+
+let get_state () =
+  match !state with
+  | [] -> failwith "Running the parser must be done within Parser.with_state"
+  | st :: _ -> st
+
+let with_state f lexbuf =
+  let current_file =
+    (fst (Sedlexing.lexing_positions lexbuf)).Lexing.pos_fname
+  in
+  let cur_state = { current_file; current_heading = [] } in
+  state := cur_state :: !state;
+  let ret = f lexbuf in
+  match !state with
+  | new_state :: r ->
+    assert (new_state.current_file = current_file);
+    state := r;
+    ret
+  | [] -> assert false
+
+let new_heading heading lpos =
+  let state = get_state () in
+  let title, id, is_archive, precedence = heading in
+  let upper_headings =
+    List.filter
+      (fun hd -> hd.Ast.law_heading_precedence < precedence)
+      state.current_heading
+  in
+  let pos =
+    Pos.overwrite_law_info (Pos.from_lpos lpos)
+      (List.map (fun h -> Mark.remove h.Ast.law_heading_name) upper_headings)
+  in
+  let heading =
+    {
+      Ast.law_heading_name = title, pos;
+      law_heading_id = id;
+      law_heading_is_archive = is_archive;
+      law_heading_precedence = precedence;
+    }
+  in
+  state.current_heading <- heading :: upper_headings;
+  heading
+
+let get_current_heading () =
+  List.map
+    (fun h -> Mark.remove h.Ast.law_heading_name)
+    (get_state ()).current_heading

--- a/compiler/surface/parser_state.mli
+++ b/compiler/surface/parser_state.mli
@@ -1,0 +1,35 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2025 Inria,
+   contributors: Louis Gesbert <louis.gesbert@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+(** Our parser crosses the bounds of LR parsing for two features:
+    - attaching breadcrumbs to every position (leading titles, subtitles, etc.)
+    - attaching attributes to the directly following node, notwithstanding the
+      normal syntax hierarchy
+
+    for these purposes we maintain a little bit of state and contained
+    side-effects. *)
+
+type t
+
+val with_state : (Sedlexing.lexbuf -> 'a) -> Sedlexing.lexbuf -> 'a
+(** Mandatory wrapper around parser calls *)
+
+val new_heading :
+  string * string option * bool * int ->
+  Lexing.position * Lexing.position ->
+  Ast.law_heading
+
+val get_current_heading : unit -> string list

--- a/tests/array/good/aggregation_4.catala_en
+++ b/tests/array/good/aggregation_4.catala_en
@@ -40,13 +40,17 @@ scope Section121SinglePerson:
 
 ```catala-test-inline
 $ catala lcalc --closure-conversion
-type Eoption = | ENone of unit | ESome of any
+type Eoption =
+  | ENone of unit
+  | ESome of any
 
 type Period = { begin: date; end: date; }
+
 type Section121SinglePerson_in = {
   date_of_sale_or_exchange_in: date;
   property_ownage_in: list of Period {begin: date; end: date};
 }
+
 type Section121SinglePerson = { requirements_ownership_met: bool; }
 
 let topval closure_aggregate_periods_from_last_five_years :

--- a/tests/attributes/good/parser_conflict.catala_en
+++ b/tests/attributes/good/parser_conflict.catala_en
@@ -1,0 +1,34 @@
+```catala
+declaration scope S:
+  output x content integer
+  output y content integer
+
+scope S:
+  definition x equals #[attr_exp] 33
+  #[attr_def]
+  definition y equals 44
+
+declaration enumeration E:
+  #[attr.field] -- Constr
+
+#[attr.enumdecl]
+declaration enumeration F:
+  -- Foo
+```
+
+```catala-test-inline
+$ catala scopelang --disable-warnings
+type E =
+  | #[attr.field] Constr of unit
+
+#[attr.enumdecl]
+type F =
+  | Foo of unit
+
+type S = { x: integer; y: integer; }
+
+
+let scope S (x: integer|internal|output) (y: integer|internal|output) =
+  let x : integer = error_empty ⟨ ⟨true ⊢ ⟨#[attr_exp] 33⟩⟩ | false ⊢ ∅ ⟩;
+  let y : integer = error_empty ⟨ ⟨true ⊢ ⟨44⟩⟩ | false ⊢ ∅ ⟩
+```

--- a/tests/attributes/good/simple.catala_en
+++ b/tests/attributes/good/simple.catala_en
@@ -8,10 +8,15 @@ declaration scope S:
   context output bla content integer #
   output x content money
   #[attr.unit]
+  #[a]
   output o content money
   #[attr.expr = false]
   #[attr.multi = "string"]
   output o2 content (money, #[attr.typ] integer)
+
+#[struct.attribute]
+declaration scope S2:
+  output x content integer
 
 declaration structure Str:
   #[field.lbl = "psst"]
@@ -23,57 +28,59 @@ attributes.can
           \  \"line\"
 as well"
 ] (integer, date)
+
+#[enum00]
+#[this.is_an = Enum]
+declaration enumeration Enu:
+  -- Foo
+  #[constructor = "Bar"]
+  -- Bar
+
 ```
 
 ```catala-test-inline
-$ catala lcalc --disable-warnings
-type Eoption = | ENone of unit | ESome of any
+$ catala scopelang --disable-warnings
+#[enum00]
+#[this.is_an = <expr>]
+type Enu =
+  | Foo of unit
+  | #[constructor = "Bar"] Bar of unit
 
-type S_in = { bla_in: option (integer, source_position); }
+#[attr = "Referring to the scope declaration"]
 type S = {
   bla: integer;
   x: money;
-  o: money;
+  #[a] #[attr.unit] o: money;
+  #[attr.multi = "string"] #[attr.expr = <expr>]
   o2: (money, #[attr.typ] integer);
 }
+
+#[struct.attribute]
+type S2 = { x: integer; }
+
 type Str = {
-  fld: #[typ] integer;
+  #[field.lbl = "psst"] fld: #[typ] integer;
   fld2: #[attributes.can = "be multi-   \"line\"\nas well"] (integer, date);
 }
 
-let scope s
-  (s_in: S_in {bla_in: option (integer, source_position)})
-  : S {bla: integer; x: money; o: money; o2: (money, #[attr.typ] integer)}
-  =
-  let get bla : option (integer, source_position) = s_in.bla_in in
-  let set bla__1 : integer =
-    match
-      (match bla with
-       | ENone →
-         ESome
-           (match (ENone ()) with
-            | ENone → error NoValue
-            | ESome arg → arg.0, <simple:8.18-21>)
-       | ESome x → ESome x)
-    with
-    | ENone → error NoValue
-    | ESome arg → arg.0
-  in
-  let set x : money =
-    match (ENone ()) with
-    | ENone → error NoValue
-    | ESome arg → arg.0
-  in
-  let set o : money =
-    match (ENone ()) with
-    | ENone → error NoValue
-    | ESome arg → arg.0
-  in
-  let set o2 : (money, #[attr.typ] integer) =
-    match (ENone ()) with
-    | ENone → error NoValue
-    | ESome arg → arg.0
-  in
-  return { S bla = bla__1; x = x; o = o; o2 = o2; }
 
+#[attr = "Referring to the scope declaration"]
+let scope S
+    (bla: ⟨integer⟩|context|output)
+    (x: money|internal|output)
+    (o: money|internal|output)
+    (o2: (money, #[attr.typ] integer)|internal|output)
+  =
+  let bla : integer = reentrant or by default error_empty ⟨false ⊢ ∅⟩;
+  let x : money = error_empty ⟨false ⊢ ∅⟩;
+  #[a]
+  #[attr.unit]
+  let o : money = error_empty ⟨false ⊢ ∅⟩;
+  #[attr.multi = "string"]
+  #[attr.expr = <expr>]
+  let o2 : (money, #[attr.typ] integer) = error_empty ⟨false ⊢ ∅⟩
+
+#[struct.attribute]
+let scope S2 (x: integer|internal|output) =
+  let x : integer = error_empty ⟨false ⊢ ∅⟩
 ```

--- a/tests/bool/good/test_bool.catala_en
+++ b/tests/bool/good/test_bool.catala_en
@@ -54,13 +54,14 @@ $ catala test-scope TestBool
 
 ```catala-test-inline
 $ catala Scopelang 
-struct TestBool = {
-  foo: bool
-  bar: integer
-}
 
-let scope TestBool (foo: ⟨bool⟩|context|output) (bar: ⟨integer⟩|context|
-  output) =
+type TestBool = { foo: bool; bar: integer; }
+
+
+let scope TestBool
+    (foo: ⟨bool⟩|context|output)
+    (bar: ⟨integer⟩|context|output)
+  =
   let bar : integer = reentrant or by default
     error_empty ⟨ ⟨true ⊢ ⟨1⟩⟩ | false ⊢ ∅ ⟩;
   let foo : bool = reentrant or by default

--- a/tests/date/bad/rounding_option_conflict.catala_en
+++ b/tests/date/bad/rounding_option_conflict.catala_en
@@ -29,15 +29,15 @@ $ catala test-scope Test
 │
 │  You cannot set multiple date rounding modes.
 │
-├─➤ tests/date/bad/rounding_option_conflict.catala_en:10.14-10.24:
+├─➤ tests/date/bad/rounding_option_conflict.catala_en:10.3-10.24:
 │    │
 │ 10 │   date round decreasing
-│    │              ‾‾‾‾‾‾‾‾‾‾
+│    │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 │
-├─➤ tests/date/bad/rounding_option_conflict.catala_en:12.14-12.24:
+├─➤ tests/date/bad/rounding_option_conflict.catala_en:12.3-12.24:
 │    │
 │ 12 │   date round increasing
-│    │              ‾‾‾‾‾‾‾‾‾‾
+│    │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 └─
 #return code 123#
 ```

--- a/tests/exception/bad/ambiguous_unlabeled_exception.catala_en
+++ b/tests/exception/bad/ambiguous_unlabeled_exception.catala_en
@@ -21,12 +21,12 @@ $ catala test-scope A
 │  disambiguate.
 │
 │ Ambiguous exception
-├─➤ tests/exception/bad/ambiguous_unlabeled_exception.catala_en:12.3-13.15:
+├─➤ tests/exception/bad/ambiguous_unlabeled_exception.catala_en:12.3-13.24:
 │    │
 │ 12 │   exception
 │    │   ‾‾‾‾‾‾‾‾‾
 │ 13 │   definition x equals 2
-│    │   ‾‾‾‾‾‾‾‾‾‾‾‾
+│    │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 ├─ Test
 │
 │ Candidate definition

--- a/tests/exception/bad/missing_unlabeled_definition.catala_en
+++ b/tests/exception/bad/missing_unlabeled_definition.catala_en
@@ -15,12 +15,12 @@ $ catala test-scope A
 │
 │  This exception does not have a corresponding definition.
 │
-├─➤ tests/exception/bad/missing_unlabeled_definition.catala_en:8.3-9.15:
+├─➤ tests/exception/bad/missing_unlabeled_definition.catala_en:8.3-9.24:
 │   │
 │ 8 │   exception
 │   │   ‾‾‾‾‾‾‾‾‾
 │ 9 │   definition x equals 1
-│   │   ‾‾‾‾‾‾‾‾‾‾‾‾
+│   │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 └─ Test
 #return code 123#
 ```

--- a/tests/exception/bad/one_ambiguous_exception.catala_en
+++ b/tests/exception/bad/one_ambiguous_exception.catala_en
@@ -27,12 +27,12 @@ $ catala test-scope A
 │  disambiguate.
 │
 │ Ambiguous exception
-├─➤ tests/exception/bad/one_ambiguous_exception.catala_en:18.3-19.15:
+├─➤ tests/exception/bad/one_ambiguous_exception.catala_en:18.3-19.24:
 │    │
 │ 18 │   exception
 │    │   ‾‾‾‾‾‾‾‾‾
 │ 19 │   definition y equals 3
-│    │   ‾‾‾‾‾‾‾‾‾‾‾‾
+│    │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 ├─ Test
 │
 │ Candidate definition

--- a/tests/exception/good/groups_of_exceptions.catala_en
+++ b/tests/exception/good/groups_of_exceptions.catala_en
@@ -62,13 +62,11 @@ $ catala test-scope Test
 
 ```catala-test-inline
 $ catala Scopelang
-struct Foo = {
-  x: integer
-}
 
-struct Test = {
-  x: integer
-}
+type Foo = { x: integer; }
+
+type Test = { x: integer; }
+
 
 let scope Foo (y: integer|input) (x: integer|internal|output) =
   let x : integer =

--- a/tests/func/good/closure_conversion.catala_en
+++ b/tests/func/good/closure_conversion.catala_en
@@ -25,9 +25,12 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Lcalc -O --closure-conversion
-type Eoption = | ENone of unit | ESome of any
+type Eoption =
+  | ENone of unit
+  | ESome of any
 
 type S_in = { x_in: bool; }
+
 type S = { z: integer; }
 
 let topval closure_f : (closure_env, integer) → integer =

--- a/tests/func/good/closure_return.catala_en
+++ b/tests/func/good/closure_return.catala_en
@@ -23,9 +23,12 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Lcalc -O --closure-conversion
-type Eoption = | ENone of unit | ESome of any
+type Eoption =
+  | ENone of unit
+  | ESome of any
 
 type S_in = { x_in: bool; }
+
 type S = { f: ((closure_env, integer) → integer, closure_env); }
 
 let topval closure_f : (closure_env, integer) → integer =

--- a/tests/func/good/scope_call_func_struct_closure.catala_en
+++ b/tests/func/good/scope_call_func_struct_closure.catala_en
@@ -54,23 +54,31 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Lcalc -O --closure-conversion 
-type Eoption = | ENone of unit | ESome of any
+type Eoption =
+  | ENone of unit
+  | ESome of any
 
 type Result = {
   r: ((closure_env, integer) → integer, closure_env);
   q: integer;
 }
+
 type SubFoo1_in = { x_in: integer; }
+
 type SubFoo1 = {
   x: integer;
   y: ((closure_env, integer) → integer, closure_env);
 }
+
 type SubFoo2_in = { x1_in: integer; x2_in: integer; }
+
 type SubFoo2 = {
   x1: integer;
   y: ((closure_env, integer) → integer, closure_env);
 }
+
 type Foo_in = { b_in: option (bool, source_position); }
+
 type Foo = { z: integer; }
 
 let topval closure_y : (closure_env, integer) → integer =

--- a/tests/monomorphisation/good/context_var.catala_en
+++ b/tests/monomorphisation/good/context_var.catala_en
@@ -10,16 +10,17 @@ scope TestXor:
 
 ```catala-test-inline
 $ catala lcalc --monomorphize-types
-type option_1 = | None_1 of unit | Some_1 of tuple_1 {
-                                               elt_0: bool;
-                                               elt_1: source_position
-                                             }
+type option_1 =
+  | None_1 of unit
+  | Some_1 of tuple_1 {elt_0: bool; elt_1: source_position}
 
 type TestXor_in = {
   t_in: option_1[None_1: unit | Some_1:
           tuple_1 {elt_0: bool; elt_1: source_position}];
 }
+
 type TestXor = { t: bool; }
+
 type tuple_1 = { elt_0: bool; elt_1: source_position; }
 
 let scope test_xor
@@ -79,7 +80,7 @@ let scope TestXor2 (test_xor2_in: TestXor2_in): TestXor2 {o: bool} =
   in
   let set o : bool =
     match
-      (Some_1 { tuple_1 elt_0 = t.t; elt_1 = <context_var:69.23-26>; })
+      (Some_1 { tuple_1 elt_0 = t.t; elt_1 = <context_var:70.23-26>; })
     with
     | None_1 → error NoValue
     | Some_1 arg → arg.elt_0

--- a/tests/name_resolution/good/conflicts.catala_en
+++ b/tests/name_resolution/good/conflicts.catala_en
@@ -58,11 +58,16 @@ code hoists a closure or not)
 
 ```catala-test-inline
 $ catala lcalc --closure-conversion
-type Eoption = | ENone of unit | ESome of any
+type Eoption =
+  | ENone of unit
+  | ESome of any
 
 type Assert_in = { assert: integer; }
+
 type Assert__1 = { assert: integer; }
+
 type Assert_in__1 = {  }
+
 type Assert__2 = { assert: bool; }
 
 let topval closure_assert : (closure_env, integer) → integer =

--- a/tests/parsing/bad/multiple_errors.catala_en
+++ b/tests/parsing/bad/multiple_errors.catala_en
@@ -21,9 +21,10 @@ $ catala test-scope A
 ┌─[ERROR (1/2)]─
 │
 │  Syntax error at "definitoin":
-│  » expected a scope use item: a rule, definition or assertion.
+│  » expected the next item in the scope (rule, definition or assertion), or
+│    the start of a new top-level declaration.
 │  Those are valid at this point: "definition", "rule", "assertion",
-│  "exception", "label", "date".
+│  "exception", "label", "date", "declaration", "scope".
 │
 ├─➤ tests/parsing/bad/multiple_errors.catala_en:12.3-12.13:
 │    │

--- a/tests/variable_state/good/subscope.catala_en
+++ b/tests/variable_state/good/subscope.catala_en
@@ -44,8 +44,11 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-inline
 $ catala Scopelang -s A
-let scope A (foo#bar: ⟨integer⟩|context) (foo#baz: integer|internal)
-  (foo#fizz: integer|internal|output) =
+let scope A
+    (foo#bar: ⟨integer⟩|context)
+    (foo#baz: integer|internal)
+    (foo#fizz: integer|internal|output)
+  =
   let foo#bar : integer = reentrant or by default
     error_empty ⟨ ⟨true ⊢ ⟨1⟩⟩ | false ⊢ ∅ ⟩;
   let foo#baz : integer =


### PR DESCRIPTION
This required some parsing acrobatics, because declarations don't have terminators, and trailing attributes would be a shift/reduce conflict.

This also extends printing to show attributes where suitable.