### PR TITLE
Fix incorrect file reading

### DIFF
--- a/compiler/catala_utils/file.ml
+++ b/compiler/catala_utils/file.ml
@@ -132,11 +132,11 @@ let find_in_parents ?cwd predicate =
 
 let with_out_channel filename f =
   ensure_dir (Filename.dirname filename);
-  let oc = open_out filename in
+  let oc = open_out_bin filename in
   finally (fun () -> close_out oc) (fun () -> f oc)
 
 let with_in_channel filename f =
-  let oc = open_in filename in
+  let oc = open_in_bin filename in
   finally (fun () -> close_in oc) (fun () -> f oc)
 
 let with_formatter_of_out_channel oc f =

--- a/compiler/literate/literate_common.ml
+++ b/compiler/literate/literate_common.ml
@@ -94,9 +94,7 @@ let run_pandoc (s : string) (backend : [ `Html | `Latex ]) : string =
   in
   let return_code = Sys.command cmd in
   if return_code <> 0 then raise_failed_pandoc cmd return_code;
-  let oc = open_in tmp_file_out in
-  let tmp_file_as_string = really_input_string oc (in_channel_length oc) in
-  close_in oc;
+  let tmp_file_as_string = File.contents tmp_file_out in
   Sys.remove tmp_file_in;
   Sys.remove tmp_file_out;
   tmp_file_as_string


### PR DESCRIPTION
This PR fixes an issue on windows where we try to read the contents of a file based on the length of the input channel but on windows, when files are opened in text mode, some end of line translations happen and the result of `in_channel_length` is faulty. Hence, we should default to open files in binary mode instead (except in parsing as we somewhat care for such characters).

Relevant doc:
```ocaml
val in_channel_length : in_channel -> int
(** Return the size (number of characters) of the regular file
    on which the given channel is opened.  If the channel is opened
    on a file that is not a regular file, the result is meaningless.
    The returned size does not take into account the end-of-line
    translations that can be performed when reading from a channel
    opened in text mode. *)
```