### PR TITLE
Expose clerk utilities for LSP

### DIFF
--- a/build_system/clerk_scan.mli
+++ b/build_system/clerk_scan.mli
@@ -22,10 +22,10 @@ open Catala_utils
 
 type item = {
   file_name : File.t;
-  module_def : string option;
+  module_def : string Mark.pos option;
   extrnal : bool;
-  used_modules : string list;
-  included_files : File.t list;
+  used_modules : string Mark.pos list;
+  included_files : File.t Mark.pos list;
   has_inline_tests : bool;
   has_scope_tests : bool Lazy.t;
 }

--- a/build_system/dune
+++ b/build_system/dune
@@ -1,8 +1,8 @@
 (library
- (name clerk_config)
- (public_name catala.clerk_config)
- (libraries catala.catala_utils otoml)
- (modules clerk_config clerk_toml_encoding))
+ (name clerk_lib)
+ (public_name catala.clerk_lib)
+ (libraries catala.catala_utils catala.surface otoml)
+ (modules clerk_config clerk_scan clerk_toml_encoding))
 
 (library
  (name clerk_driver)
@@ -11,20 +11,21 @@
   catala.runtime_ocaml
   catala.catala_utils
   catala.surface
-  catala.clerk_config
+  catala.clerk_lib
   ninja_utils
   cmdliner
   re
   ocolor
   otoml)
  (modules
-  clerk_scan
   clerk_report
   clerk_runtest
   clerk_cli
   clerk_poll
   clerk_rules
-  clerk_driver))
+  clerk_driver)
+ (flags
+  (:standard -open Clerk_lib)))
 
 (rule
  (target custom_linking.sexp)


### PR DESCRIPTION
This PR adds `Clerk_scan` to the current clerk's "lib" so that the LSP server can reason more easily on clerk projects.
It also adds positions to module scanning to display proper errors (with a helpful location) when modules conflicts are discovered.

Related PR: https://github.com/CatalaLang/catala-language-server/pull/102