### PR TITLE
Avoid shell / native windows build

### DIFF
--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -296,7 +296,12 @@ let[@ocamlformat "disable"] static_base_rules enabled_backends =
         ~description:["<catala>"; "tests"; "⇐"; !input];
 
       Nj.rule "dir-tests"
-        ~command:["cat"; !input; ">"; !output; ";"]
+        ~command:
+        (if Sys.win32 then
+          ["cmd"; "/c"; "type"; !input; ">"; !output; ";"]
+        else
+          ["cat"; !input; ">"; !output; ";"]
+        )
         ~description:["<test>"; !test_id];
      ]
    else [])

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -233,7 +233,11 @@ let[@ocamlformat "disable"] static_base_rules enabled_backends =
   let open Var in
   [
     Nj.rule "copy"
-      ~command:["cp"; "-f"; !input; !output]
+      ~command:
+        (if Sys.win32 then
+           ["cmd"; "/c"; "copy"; "/Y"; !input; !output]
+         else 
+           ["cp"; "-f"; !input; !output])
       ~description:["<copy>"; !input];
   ] @ (if List.mem OCaml enabled_backends then [
       Nj.rule "catala-ocaml"

--- a/compiler/catala_utils/file.ml
+++ b/compiler/catala_utils/file.ml
@@ -309,6 +309,7 @@ let () =
     in
     let count =
       if not Unix.(isatty stdin) then from_env ()
+      else if Sys.win32 then default
       else
         try
           (* terminfo *)
@@ -351,11 +352,18 @@ let check_file f =
   with Unix.Unix_error _ | Sys_error _ -> None
 
 let get_command t =
+  let cmd, args =
+    if Sys.win32 then
+      let t_exe =
+        if not (String.ends_with ~suffix:"exe" t) then t ^ ".exe" else t
+      in
+      "where.exe", [t_exe]
+    else "/bin/sh", ["-c"; "command -v " ^ Filename.quote t]
+  in
   String.trim
   @@ process_out
        ~check_exit:(function 0 -> () | _ -> raise Not_found)
-       "/bin/sh"
-       ["-c"; "command -v " ^ Filename.quote t]
+       cmd args
 
 let check_exec t =
   try

--- a/compiler/catala_utils/file.ml
+++ b/compiler/catala_utils/file.ml
@@ -355,7 +355,7 @@ let get_command t =
   let cmd, args =
     if Sys.win32 then
       let t_exe =
-        if not (String.ends_with ~suffix:"exe" t) then t ^ ".exe" else t
+        if not (Filename.check_suffix t ".exe") then t ^ ".exe" else t
       in
       "where.exe", [t_exe]
     else "/bin/sh", ["-c"; "command -v " ^ Filename.quote t]


### PR DESCRIPTION
Needs some cleanup, but it can build + run examples from the CNAF POC natively using clerk.

![Capture d’écran du 2025-06-10 22-12-29](https://github.com/user-attachments/assets/e791f676-7ba4-48bf-92f9-a86a97bebbc7)
