### PR TITLE
Customtarget

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build examples
         run: |
           cd ~/catala-examples
-          . ~/catala/_python_venv/bin/activate && opam --cli=2.1 exec -- make all testsuite install
+          opam --cli=2.1 exec -- make all testsuite install
       - name: Generate examples test report
         if: ${{ always() }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 build.ninja
 **/#*
 **/.#*
+*.~*~
 .envrc
 .direnv
 **/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ alltest: dependencies-python
 	$(MAKE) testsuite && \
 	$(test_title) "Running catala-examples" && \
 	$(call local_tmp_clone,catala-examples) && \
-	$(MAKE) -C catala-examples.tmp \
+	$(PY_VENV_ACTIVATE) $(MAKE) -C catala-examples.tmp \
 	  CATALA=$(CURDIR)/_build/install/default/bin/catala \
 	  CLERK=$(CURDIR)/_build/install/default/bin/clerk \
 	  BUILD=../_build/default \

--- a/build_system/clerk_cli.ml
+++ b/build_system/clerk_cli.ml
@@ -374,9 +374,14 @@ let init
     let dir =
       match build_dir with None -> config.global.build_dir | Some dir -> dir
     in
-    let d = File.clean_path dir in
-    File.ensure_dir d;
-    d
+    let dir =
+      match test_flags with
+      | [] -> dir
+      | flags -> File.((dir / "test") ^ String.concat "" flags)
+    in
+    let dir = File.clean_path dir in
+    File.ensure_dir dir;
+    dir
     (* Note: it could be safer here to use File.(Sys.getcwd () / "_build") by
        default, but Ninja treats relative and absolute paths separately so that
        you wouldn't then be able to build target _build/foo.ml but would have to

--- a/build_system/clerk_cli.ml
+++ b/build_system/clerk_cli.ml
@@ -388,6 +388,7 @@ let init
         config with
         global =
           {
+            config.global with
             build_dir;
             catala_exe;
             catala_opts = config.global.catala_opts @ catala_opts;

--- a/build_system/clerk_cli.mli
+++ b/build_system/clerk_cli.mli
@@ -16,6 +16,7 @@
    the License. *)
 
 open Cmdliner
+open Catala_utils
 
 val catala_exe : string option Term.t
 val catala_opts : string list Term.t
@@ -28,26 +29,6 @@ val runtest_out : string option Term.t
 val backend : [> `C | `Interpret | `OCaml | `Python | `Java ] Term.t
 val run_command : string Term.t
 val vars_override : (string * string) list Term.t
-
-module Global : sig
-  val color : Catala_utils.Global.when_enum Term.t
-  val debug : bool Term.t
-
-  val term :
-    (autotest:bool ->
-    config_file:Catala_utils.File.t option ->
-    catala_exe:Catala_utils.File.t option ->
-    catala_opts:string list ->
-    build_dir:Catala_utils.File.t option ->
-    include_dirs:string list ->
-    vars_override:(string * string) list ->
-    color:Catala_utils.Global.when_enum ->
-    debug:bool ->
-    ninja_output:Catala_utils.File.t option ->
-    'a) ->
-    'a Term.t
-end
-
 val files_or_folders : string list Term.t
 val files : string list Term.t
 val single_file : string Term.t
@@ -59,3 +40,22 @@ val report_xml : bool Term.t
 val diff_command : string option option Term.t
 val ninja_flags : string list Term.t
 val info : Cmd.info
+
+val color : Global.when_enum Term.t
+(** Already included in [init_term] *)
+
+val debug : bool Term.t
+(** Already included in [init_term] *)
+
+(** {2 Initialisation of options} *)
+
+type config = {
+  options : Clerk_config.t;
+  fix_path : File.t -> File.t;
+  ninja_file : File.t option;
+  test_flags : string list;
+}
+
+val init_term : ?allow_test_flags:bool -> unit -> config Term.t
+(** Reads the supplied command-line flags and configuration file and runs
+    globals initialisation routines *)

--- a/build_system/clerk_config.mli
+++ b/build_system/clerk_config.mli
@@ -17,7 +17,7 @@
 open Catala_utils
 
 type backend = ..
-type backend += C | OCaml
+type backend += C | OCaml | Java | Python
 
 val register_backend : name:string -> backend -> unit
 
@@ -26,6 +26,7 @@ type doc_backend = Html | Latex
 type global = {
   include_dirs : string list;
   build_dir : string;
+  catala_exe : File.t option;
   catala_opts : string list;
 }
 
@@ -49,11 +50,21 @@ type doc = {
   doc_options : string list;
 }
 
+type custom_rule = {
+  backend : backend;
+  in_exts : string list; (* ocaml/%.cmi *)
+  out_exts : string list; (* ocaml/%.cma *)
+  commandline : string list;
+      (* ${OCAMLOPT_EXE} ${OCAML_FLAGS} -I ${dir} ${in} -a -o ${out} *)
+}
+
 type config_file = {
   global : global;
+  variables : (string * string) list;
   modules : module_ list;
   targets : target list;
   docs : doc list;
+  custom_rules : custom_rule list;
 }
 
 type t = config_file

--- a/build_system/clerk_config.mli
+++ b/build_system/clerk_config.mli
@@ -24,10 +24,12 @@ val register_backend : name:string -> backend -> unit
 type doc_backend = Html | Latex
 
 type global = {
-  include_dirs : string list;
-  build_dir : string;
+  include_dirs : File.t list;
+  build_dir : File.t;
+  target_dir : File.t;
   catala_exe : File.t option;
   catala_opts : string list;
+  default_targets : string list;
 }
 
 type module_ = {
@@ -37,10 +39,10 @@ type module_ = {
 }
 
 type target = {
-  name : string;
-  entrypoints : string list;
-  backend : backend;
-  backend_options : string list;
+  tname : string;
+  tmodules : string list;
+  backends : backend list;
+  include_runtime : bool;
 }
 
 type doc = {
@@ -60,7 +62,7 @@ type custom_rule = {
 
 type config_file = {
   global : global;
-  variables : (string * string) list;
+  variables : (string * string list) list;
   modules : module_ list;
   targets : target list;
   docs : doc list;

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -20,6 +20,7 @@ open Catala_utils
 type backend = OCaml | Python | C | Java | Tests
 
 val all_backends : backend list
+val backend_from_config : Clerk_config.backend -> backend
 
 module Var : sig
   type t = Ninja_utils.Var.t
@@ -34,9 +35,11 @@ module Var : sig
   val ocamlc_exe : t
   val ocamlopt_exe : t
   val ocaml_flags : t
+  val ocaml_include : t
   val runtime_ocaml_libs : t
   val cc_exe : t
   val c_flags : t
+  val c_include : t
   val runtime_c_libs : t
   val python : t
   val runtime_python_dir : t

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -48,37 +48,22 @@ module Var : sig
 end
 
 val base_bindings :
-  catala_exe:File.t option ->
-  catala_flags:string list ->
-  build_dir:File.t ->
-  include_dirs:File.t list ->
-  ?vars_override:(string * string) list ->
-  ?test_flags:string list ->
+  autotest:bool ->
+  enabled_backends:backend list ->
+  config:Clerk_cli.config ->
+  (Var.t * string list) list
+
+val run_ninja :
+  config:Clerk_cli.config ->
   ?enabled_backends:backend list ->
   autotest:bool ->
-  unit ->
-  Ninja_utils.def list
-
-val ninja_init :
-  autotest:bool ->
-  config_file:File.t option ->
-  catala_exe:File.t option ->
-  catala_opts:string list ->
-  build_dir:File.t option ->
-  include_dirs:File.t list ->
-  vars_override:(string * string) list ->
-  color:Global.when_enum ->
-  debug:bool ->
-  ninja_output:File.t option ->
-  enabled_backends:backend list ->
-  extra:Ninja_utils.def Seq.t ->
-  test_flags:string list ->
-  (build_dir:File.t ->
-  fix_path:(File.t -> File.t) ->
-  nin_file:File.t ->
-  items:Clerk_scan.item Seq.t ->
-  var_bindings:Ninja_utils.Binding.t list ->
-  'a) ->
+  ?clean_up_env:bool ->
+  ?ninja_flags:string list ->
+  (Format.formatter -> Clerk_scan.item list -> (Var.t * string list) list -> 'a) ->
   'a
-(** The last argument is a continuation that will be executed upon the generated
-    ninja file *)
+(** Scan the source tree, run a ninja process, and send to it the expected build
+    instructions. A callback can be supplied to retrieve the source items, and
+    optionally add entries to the ninja file.
+
+    By default, all backends are enabled, the env is not cleaned of CATALA_*
+    variables *)

--- a/build_system/clerk_scan.ml
+++ b/build_system/clerk_scan.ml
@@ -69,7 +69,6 @@ let rec find_test_scope ~lang file =
 
 let catala_file (file : File.t) (lang : Catala_utils.Global.backend_lang) : item
     =
-  let module L = Surface.Lexer_common in
   let rec parse
       (lines :
         (string * L.line_token * (Lexing.position * Lexing.position)) Seq.t)
@@ -112,7 +111,7 @@ let catala_file (file : File.t) (lang : Catala_utils.Global.backend_lang) : item
       ((* If there are includes, they must be checked for test scopes as well *)
        Lazy.force item.has_scope_tests
       || List.exists
-           (fun f -> find_test_scope ~lang (Mark.remove f))
+           (fun l -> find_test_scope ~lang (Mark.remove l))
            item.included_files)
   in
   { item with has_scope_tests }

--- a/build_system/clerk_toml_encoding.mli
+++ b/build_system/clerk_toml_encoding.mli
@@ -40,6 +40,7 @@ val encode : 'a -> 'a t -> Otoml.t
 val string : string descr
 val pair : 'a descr -> 'b descr -> ('a * 'b) descr
 val list : 'a descr -> 'a list descr
+val binding_list : 'a descr -> (string * 'a) list descr
 
 (** Object's Field constructors *)
 
@@ -123,6 +124,16 @@ val table2 : 'a t -> 'b t -> ('a * 'b) t
 val table3 : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
 val table4 : 'a t -> 'b t -> 'c t -> 'd t -> ('a * 'b * 'c * 'd) t
 val table5 : 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> ('a * 'b * 'c * 'd * 'e) t
+
+val table6 :
+  'a t ->
+  'b t ->
+  'c t ->
+  'd t ->
+  'e t ->
+  'f t ->
+  ('a * 'b * 'c * 'd * 'e * 'f) t
+
 val merge_tables : 'a t -> 'b t -> ('a * 'b) t
 
 (** Conversion operators *)

--- a/build_system/clerk_toml_encoding.mli
+++ b/build_system/clerk_toml_encoding.mli
@@ -38,6 +38,7 @@ val encode : 'a -> 'a t -> Otoml.t
 (** Basic constructors *)
 
 val string : string descr
+val bool : bool descr
 val pair : 'a descr -> 'b descr -> ('a * 'b) descr
 val list : 'a descr -> 'a list descr
 val binding_list : 'a descr -> (string * 'a) list descr
@@ -76,6 +77,15 @@ val obj5 :
   'd field ->
   'e field ->
   ('a * 'b * 'c * 'd * 'e) descr
+
+val obj6 :
+  'a field ->
+  'b field ->
+  'c field ->
+  'd field ->
+  'e field ->
+  'f field ->
+  ('a * 'b * 'c * 'd * 'e * 'f) descr
 
 val merge_objs : 'a descr -> 'b descr -> ('a * 'b) descr
 

--- a/compiler/catala_utils/file.ml
+++ b/compiler/catala_utils/file.ml
@@ -255,6 +255,16 @@ let copy ~src ~dst =
 
 let copy_in ~src ~dir = copy ~src ~dst:(dir / Filename.basename src)
 
+let rec copy_dir ?(filter = fun _ -> true) ~src ~dst:dst0 () =
+  Array.iter
+    (fun base ->
+      let src = src / base and dst = dst0 / base in
+      if Sys.is_directory src then copy_dir ~filter ~src ~dst ()
+      else if filter base then (
+        ensure_dir dst0;
+        copy ~src ~dst))
+    (Sys.readdir src)
+
 let rec remove t =
   match Unix.lstat t with
   (* Don't use Sys.file_exists or Sys.is_directory here, they would follow
@@ -380,6 +390,7 @@ let check_exec t =
 
 let dirname = Filename.dirname
 let basename = Filename.basename
+let extension t = String.remove_prefix ~prefix:"." (Filename.extension t)
 let ( /../ ) a b = parent a / b
 
 let equal a b =

--- a/compiler/catala_utils/file.mli
+++ b/compiler/catala_utils/file.mli
@@ -101,6 +101,11 @@ val copy : src:t -> dst:t -> unit
 val copy_in : src:t -> dir:t -> unit
 (** Same as [copy], but copies the file into the given, existing dir. *)
 
+val copy_dir : ?filter:(t -> bool) -> src:t -> dst:t -> unit -> unit
+(** Recursively copy a directory with its contents using [copy]. [filter] is
+    applied to basenames. Empty directories are not created. Does not care for
+    links or attributes, or file reading errors. *)
+
 val remove : t -> unit
 (** Recursively removes files and directories. Dangerous!
 
@@ -137,6 +142,10 @@ val basename : t -> t
 
 val dirname : t -> t
 (** [Filename.dirname], re-exported for convenience *)
+
+val extension : t -> string
+(** Like [Filename.extension], but without the leading dot (doesn't, therefore,
+    differenciate between empty extension and no extension) *)
 
 val parent : t -> t
 (** Similar to [dirname], except it strips the last **non-"." or ".."** element


### PR DESCRIPTION
Two commits here:
- the first one cleans up how ninja is run and information passed around it.
- the second adds two new configurations fields in `clerk.toml`, details copied below for convenience:

## Custom targets

```toml
[[target]]
name = "french_law"
modules = ["Prestations_familiales", "Allocations_familiales"]
backends = ["c", "python", "ocaml"]
include_runtime = true
```

This will install all the concerned files (including dependencies) into
`_targets/french_law` (should "target" be singular ?), with a subdirectory for
each backend. This should make it easier to retrieve the desired artifacts in a
given app.

`clerk build` without arguments will now build all targets by default.

## Custom rules

This is more experimental, and doesn't combine with point 1 at the moment.
It allows to add one custom compilation step at the end of the compilations done
by catala, for example it could be used to generate a `.so` with

```toml
[[rule]]
out_exts = ["so"]
in_exts = ["o"]
backend = "c"
commandline = ["$CC", "$CFLAGS", "$C_INCLUDE_FLAGS", "$RUNTIME_C_LIBS", "$src", "-shared", "-o", "$dst"]
```

The commandline does variable expansion ; w e are now leaning more in the
direction of using a custom `target` and then letting the user compile directly
as they wish (perhaps providing at least Makefiles / .d files for helping with
dependencies).

However, we don't yet have a story for plugins (e.g. generation of _web_api.ml /
js files) so this is a step in the exploration of what we could do there.