### PR TITLE
Fix spurious fence errors in parsing

### DIFF
--- a/compiler/surface/parser_driver.ml
+++ b/compiler/surface/parser_driver.ml
@@ -200,7 +200,7 @@ module ParserAux (LocalisedLexer : Lexer_common.LocalisedLexer) = struct
       let dummy_cp = I.input_needed env in
       iterate (-1, dummy_cp) candidates_checkpoints
     in
-    (* We do not consider paths were progress isn't significant *)
+    (* We do not consider paths where progress isn't significant *)
     if best_progress < 2 then None else Some best_cp
 
   (** Main parsing loop *)
@@ -239,6 +239,10 @@ module ParserAux (LocalisedLexer : Lexer_common.LocalisedLexer) = struct
         match best_effort_checkpoint with
         | None ->
           (* No reasonable solution, aborting *)
+          (* Let's reset the lexer buffer in order to not trigger the unclosed
+             block finalizer: we have at least one error to report *)
+          ignore (Lexer_common.flush_acc ());
+          Lexer_common.context := Law;
           []
         | Some best_effort_checkpoint ->
           loop lexer_buffer token_list lexbuf last_input_needed

--- a/tests/parsing/bad/unrecoverable_error.catala_en
+++ b/tests/parsing/bad/unrecoverable_error.catala_en
@@ -13,7 +13,7 @@ scope A:
 
 ```catala-test-cli
 $ catala test-scope A
-┌─[ERROR]─ 1/2 ─
+┌─[ERROR]─
 │
 │  Syntax error at "x": unexpected token.
 │  Those are valid at this point: "all".
@@ -24,18 +24,6 @@ $ catala test-scope A
 │    │             ‾
 │
 │ Maybe you wanted to write: "all"?
-└─
-┌─[ERROR]─ 2/2 ─
-│
-│  Unclosed block or missing newline at the end of file.
-│  Did you forget a ``` delimiter ?
-│
-├─➤ tests/parsing/bad/unrecoverable_error.catala_en:3.1-4.1:
-│   │
-│ 3 │ ```catala
-│   │ ‾‾‾‾‾‾‾‾‾
-│ 4 │ declaration scope A:
-│   │ 
 └─
 #return code 123#
 ```

--- a/tests/parsing/bad/unrecoverable_error.catala_en
+++ b/tests/parsing/bad/unrecoverable_error.catala_en
@@ -1,0 +1,41 @@
+## Unrecoverable parsing error
+
+```catala
+declaration scope A:
+  output i content integer
+
+scope A:
+  definition i equals
+    # a token "all" is intentionally missing
+    combine x among [ 1 ; 2 ; 3 ] in acc initially 0 with
+      x + acc
+```
+
+```catala-test-cli
+$ catala test-scope A
+┌─[ERROR]─ 1/2 ─
+│
+│  Syntax error at "x": unexpected token.
+│  Those are valid at this point: "all".
+│
+├─➤ tests/parsing/bad/unrecoverable_error.catala_en:10.13-10.14:
+│    │
+│ 10 │     combine x among [ 1 ; 2 ; 3 ] in acc initially 0 with
+│    │             ‾
+│
+│ Maybe you wanted to write: "all"?
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  Unclosed block or missing newline at the end of file.
+│  Did you forget a ``` delimiter ?
+│
+├─➤ tests/parsing/bad/unrecoverable_error.catala_en:3.1-4.1:
+│   │
+│ 3 │ ```catala
+│   │ ‾‾‾‾‾‾‾‾‾
+│ 4 │ declaration scope A:
+│   │ 
+└─
+#return code 123#
+```


### PR DESCRIPTION
This PR fixes an issue that occurs when the parse fails to recover from a parsing error and ends up in the lexer finalizer that triggers an error regarding unclosed fences which is completely unrelated and misleading for the user. 

A test is there to exhibit the behavior and its fix.