### PR TITLE
Add --prepare-only to clerk run

### DIFF
--- a/build_system/clerk_cli.ml
+++ b/build_system/clerk_cli.ml
@@ -50,6 +50,13 @@ let autotest =
            guarantee that the necessary artifacts for interpretation are \
            present.")
 
+let prepare_only =
+  Arg.(
+    value
+    & flag
+    & info ["prepare-only"]
+        ~doc:"Compile dependencies of the target(s) but do not run it.")
+
 let build_dir =
   Arg.(
     value

--- a/build_system/clerk_cli.mli
+++ b/build_system/clerk_cli.mli
@@ -21,6 +21,7 @@ open Catala_utils
 val catala_exe : string option Term.t
 val catala_opts : string list Term.t
 val autotest : bool Term.t
+val prepare_only : bool Term.t
 val build_dir : string option Term.t
 val include_dirs : string list Term.t
 val test_flags : string list Term.t

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1004,13 +1004,16 @@ let run_cmd =
       backend
       cmd
       (scope : string option)
-      (ninja_flags : string list) =
+      (ninja_flags : string list)
+      prepare_only =
     let files_or_folders = List.map config.Cli.fix_path files_or_folders in
     Clerk_rules.run_ninja ~config
       ~enabled_backends:[enable_backend backend]
       ~ninja_flags ~autotest:false
       (build_test_deps ~config ~backend files_or_folders)
-    |> run_tests config backend cmd scope
+    |> fun tests ->
+    if prepare_only then Cmd.Exit.ok
+    else run_tests config backend cmd scope tests
   in
   let doc =
     "Runs the Catala interpreter on the given files, after building their \
@@ -1025,7 +1028,8 @@ let run_cmd =
       $ Cli.backend
       $ Cli.run_command
       $ Cli.scope
-      $ Cli.ninja_flags)
+      $ Cli.ninja_flags
+      $ Cli.prepare_only)
 
 let clean_cmd =
   let run (config : Cli.config) =


### PR DESCRIPTION
Adds a --prepare-only flag to clerk, e.g., `clerk run <file> --prepare-only` builds all dependencies required to interpret `<file>`.