### PR TITLE
Fix clerk issue when calling clerk run with absolute paths

### DIFF
--- a/build_system/clerk_cli.ml
+++ b/build_system/clerk_cli.ml
@@ -391,7 +391,9 @@ let init
           set_root_dir root;
           ( Catala_utils.File.reverse_path ~from_dir ~to_dir:rel,
             Clerk_config.default_config )
-        | None -> Fun.id, Clerk_config.default_config))
+        | None ->
+          ( Catala_utils.File.make_relative_to ~dir:from_dir,
+            Clerk_config.default_config )))
     | Some f ->
       let root = Filename.dirname f in
       let config = Clerk_config.read f in


### PR DESCRIPTION
This PR fixes a bug that prevent clerk run/test/etc. from processing files with an absolute path.
This issue is only triggered when no `clerk.toml` is discovered from the cwd (+ absolute path files arguments).

E.g., 
- copy `tests/money/good/simple.catala_en` in, let's say, `/tmp/foo/simple.catala_en`
- `cd /tmp`
- clerk run `foo/simple.catala_en` works while clerk run `/tmp/foo/simple.catala_en`

In both cases, a `_build` directory is created in the current working dir; which is not ideal but, at least, executes the program.