### PR TITLE
Quick fix for non-latin idents

### DIFF
--- a/compiler/catala_utils/string.ml
+++ b/compiler/catala_utils/string.ml
@@ -35,17 +35,25 @@ let map_utf8 f s =
   utf8_seq s |> Seq.map f |> Seq.iter (Buffer.add_utf_8_uchar buf);
   Buffer.contents buf
 
-let to_id s =
-  to_ascii s
-  |> map (function
-       | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9') as c -> c
-       | _ -> '_')
-
-let is_uppercase_ascii = function 'A' .. 'Z' -> true | _ -> false
-
 let begins_with_uppercase (s : string) : bool =
   (not (s = ""))
   && get_utf_8_uchar s 0 |> Uchar.utf_decode_uchar |> Uucp.Case.is_upper
+
+let to_id s =
+  if s = "_" then s
+  else
+    let s =
+      Ubase.from_utf8 ~strip:"" s
+      |> map (function
+           | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9') as c -> c
+           | _ -> '_')
+    in
+    if length s < 1 || get s 0 = '_' then
+      let pfx = if begins_with_uppercase s then "X" else "x" in
+      pfx ^ s
+    else s
+
+let is_uppercase_ascii = function 'A' .. 'Z' -> true | _ -> false
 
 let to_snake_case (s : string) : string =
   let out = Buffer.create (2 * length s) in

--- a/tests/name_resolution/good/cyrillic.catala_en
+++ b/tests/name_resolution/good/cyrillic.catala_en
@@ -1,0 +1,21 @@
+# Identifier made of non-latin characters
+
+[Discussion](https://zulip.catala-lang.org/#narrow/channel/1-general/topic/Non-latin.20characters.20in.20idents/with/75728)
+
+```catala
+#[test]
+declaration scope IncomeTax2:
+  context суммаНалоговыхБаз content money
+  output суммаНалоговыхБаг content money # doesn't mean anything, but could trigger a conflict
+
+scope IncomeTax2:
+  definition суммаНалоговыхБаз equals $10
+  definition суммаНалоговыхБаг equals суммаНалоговыхБаз
+```
+
+```catala-test-cli
+$ catala test-scope IncomeTax2
+┌─[RESULT]─ IncomeTax2 ─
+│ суммаНалоговыхБаг = $10.00
+└─
+```


### PR DESCRIPTION
A better solution would rely on a transliteration where needed, preservation for the backends that support it ; this is simpler in that it will replace the names, which is robust but makes the generated code much less readable.
