### PR TITLE
fix reset_log

### DIFF
--- a/runtimes/python/src/catala/catala_runtime.py
+++ b/runtimes/python/src/catala/catala_runtime.py
@@ -769,7 +769,7 @@ log: List[LogEvent] = []
 
 
 def reset_log():
-    log = []
+    global log; log = []
 
 
 def retrieve_log() -> List[LogEvent]:


### PR DESCRIPTION
Small fix for the python runtime: clear the global log (the existing function was creating a new binding but not affecting the global one)