### PR TITLE
OCaml: use constant constructors for constructors with empty payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ alltest: dependencies-python
 	$(test_title) "Running catala-examples" && \
 	$(call local_tmp_clone,catala-examples) && \
 	$(PY_VENV_ACTIVATE) $(MAKE) -C catala-examples.tmp \
-	  CATALA_FLAGS=
+	  CATALA_FLAGS= \
 	  CATALA=$(CURDIR)/_build/install/default/bin/catala \
 	  CLERK=$(CURDIR)/_build/install/default/bin/clerk \
 	  BUILD=../_build/default \

--- a/runtimes/ocaml/catala_runtime.ml
+++ b/runtimes/ocaml/catala_runtime.ml
@@ -30,7 +30,7 @@ type date_rounding = Dates_calc.date_rounding =
 type duration = Dates_calc.period
 
 module Optional = struct
-  type 'a t = Absent of unit | Present of 'a
+  type 'a t = Absent | Present of 'a
 end
 
 type io_input = NoInput | OnlyInput | Reentrant
@@ -792,11 +792,11 @@ let handle_exceptions (exceptions : ('a * code_location) Optional.t array) :
     if i < len then
       match exceptions.(i) with
       | Optional.Present _ as new_val -> new_val :: filt_except (i + 1)
-      | Optional.Absent () -> filt_except (i + 1)
+      | Optional.Absent -> filt_except (i + 1)
     else []
   in
   match filt_except 0 with
-  | [] -> Optional.Absent ()
+  | [] -> Optional.Absent
   | [res] -> res
   | res ->
     error Conflict

--- a/runtimes/ocaml/catala_runtime.mli
+++ b/runtimes/ocaml/catala_runtime.mli
@@ -45,7 +45,7 @@ type code_location = {
 }
 
 module Optional : sig
-  type 'a t = Absent of unit | Present of 'a
+  type 'a t = Absent | Present of 'a
 end
 
 (** This type characterizes the three levels of visibility for a given scope

--- a/stdlib/ocaml/list_internal.ml
+++ b/stdlib/ocaml/list_internal.ml
@@ -12,7 +12,7 @@ let nth_element : 't array -> integer -> 't Optional.t =
  fun arr n ->
   let n = Z.to_int n - 1 in
   if 0 <= n && n < Array.length arr then Optional.Present arr.(n)
-  else Optional.Absent ()
+  else Optional.Absent
 
 (* Toplevel def remove_nth_element *)
 let remove_nth_element : 't array -> integer -> 't array =

--- a/tests/modules/good/mod_def.catala_en
+++ b/tests/modules/good/mod_def.catala_en
@@ -112,7 +112,7 @@ let () =
   | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
 module List_en = List_en
 
-module Enum1 = struct type t = Yes of unit | No of unit | Maybe of unit end
+module Enum1 = struct type t = Yes | No | Maybe end
 
 module S = struct
   type t = {sr: money; e1: Enum1.t}
@@ -137,7 +137,7 @@ let s : S_in.t -> S.t = fun _ ->
              start_line=29; start_column=24; end_line=29; end_column=30;
              law_headings=["Test modules + inclusions 1"]})))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
                            start_line=16; start_column=10;
                            end_line=16; end_column=12;
@@ -146,12 +146,12 @@ let s : S_in.t -> S.t = fun _ ->
   let e1: Enum1.t =
     match
       (Optional.Present
-         ((Enum1.Maybe ()),
+         ((Enum1.Maybe),
            ({filename="tests/modules/good/mod_def.catala_en";
              start_line=30; start_column=24; end_line=30; end_column=29;
              law_headings=["Test modules + inclusions 1"]})))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/modules/good/mod_def.catala_en";
                            start_line=17; start_column=10;
                            end_line=17; end_column=12;
@@ -170,7 +170,7 @@ let half : integer -> decimal =
 
 (* Toplevel def maybe *)
 let maybe : Enum1.t -> Enum1.t =
-  fun (_: Enum1.t) -> Enum1.Maybe ()
+  fun (_: Enum1.t) -> Enum1.Maybe
 
 let () =
   Catala_runtime.register_module "Mod_def"

--- a/tests/name_resolution/good/conflicts.catala_en
+++ b/tests/name_resolution/good/conflicts.catala_en
@@ -218,7 +218,7 @@ let assert__1 : Assert_in.t -> Assert.t = fun _ ->
                 start_line=23; start_column=3; end_line=23; end_column=59;
                 law_headings=[]})))
        with
-       | Optional.Absent _ ->
+       | Optional.Absent ->
            (Optional.Present
               (false,
                 ({filename="tests/name_resolution/good/conflicts.catala_en";
@@ -226,7 +226,7 @@ let assert__1 : Assert_in.t -> Assert.t = fun _ ->
                   law_headings=[]})))
        | Optional.Present x -> (Optional.Present x))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/name_resolution/good/conflicts.catala_en";
                            start_line=19; start_column=10;
                            end_line=19; end_column=16; law_headings=[]}])))

--- a/tests/name_resolution/good/keywords.catala_en
+++ b/tests/name_resolution/good/keywords.catala_en
@@ -116,7 +116,7 @@ let stdlib : Stdlib_in.t -> Stdlib__1.t = fun stdlib_in ->
              start_line=11; start_column=26; end_line=11; end_column=52;
              law_headings=[]})))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
                            start_line=5; start_column=10;
                            end_line=5; end_column=14; law_headings=[]}])))
@@ -136,7 +136,7 @@ let test : Test_in.t -> Test.t = fun _ ->
                         start_line=18; start_column=27;
                         end_line=18; end_column=29; law_headings=[]})))
                with
-               | Optional.Absent _ -> (raise
+               | Optional.Absent -> (raise
                    (Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
                                       start_line=18; start_column=14;
                                       end_line=18; end_column=19;
@@ -155,7 +155,7 @@ let test : Test_in.t -> Test.t = fun _ ->
              start_line=19; start_column=25; end_line=19; end_column=31;
              law_headings=[]})))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/name_resolution/good/keywords.catala_en";
                            start_line=15; start_column=10;
                            end_line=15; end_column=13; law_headings=[]}])))

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -106,7 +106,7 @@ let s : S_in.t -> S.t = fun s_in ->
     match
       (match a
        with
-       | Optional.Absent _ ->
+       | Optional.Absent ->
            (Optional.Present
               ((match
                   (Optional.Present
@@ -116,7 +116,7 @@ let s : S_in.t -> S.t = fun s_in ->
                          start_line=11; start_column=5;
                          end_line=13; end_column=6; law_headings=["Article"]})))
                 with
-                | Optional.Absent _ -> (raise
+                | Optional.Absent -> (raise
                     (Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
                                        start_line=7; start_column=18;
                                        end_line=7; end_column=19;
@@ -127,7 +127,7 @@ let s : S_in.t -> S.t = fun s_in ->
                   law_headings=["Article"]})))
        | Optional.Present x -> (Optional.Present x))
     with
-    | Optional.Absent _ -> (raise
+    | Optional.Absent -> (raise
         (Error (NoValue, [{filename="tests/name_resolution/good/let_in2.catala_en";
                            start_line=7; start_column=18;
                            end_line=7; end_column=19;


### PR DESCRIPTION
This is a more targeted fix for #913 than what #914 proposes: only the OCaml backend is affected on the specific "constructor with no payload" case.

It is mostly orthogonal though: if there is more reason to change the representation in the compiler, #914 remains valid.

The hard part was to adjust the dark magic in the live (native runtime)/(interpreter) translations to account for the change in the OCaml data representation.



## Checklist

### If this PR adds a feature or has breaking changes

* [x] Update the existing Catala code in case of breaking changes at https://github.com/CatalaLang/catala-examples.
  * [x] The corresponding PR is: CatalaLang/catala-examples/pull/37

* LSP sister PR: CatalaLang/catala-language-server/pull/181