### PR TITLE
Add runtimes as .PHONY in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,4 +374,4 @@ help_catala:
 ##########################################
 .PHONY: inspect clean all english alltest pygments install build_dev build doc	\
 	format dependencies dependencies-ocaml catala.html help parser-messages	\
-	plugins website-assets.tar website-assets-base
+	plugins website-assets.tar website-assets-base runtimes


### PR DESCRIPTION
`runtimes` being a directory, `make runtimes` does not try to recompile it as it exists.
