### PR TITLE
Fix code generator and explain plugin bugs

### DIFF
--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -309,6 +309,11 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
   | EInj { e = ELit LUnit, _; cons; name } ->
     Format.fprintf fmt "@[<hov 2>%a.%a@]" format_to_module_name (`Ename name)
       format_enum_cons_name cons
+  | EInj { cons; name; _ }
+    when EnumName.equal name Expr.option_enum
+         && EnumConstructor.equal cons Expr.none_constr ->
+    Format.fprintf fmt "@[<hov 2>%a.%a@]" format_to_module_name (`Ename name)
+      format_enum_cons_name cons
   | EInj { e; cons; name } ->
     Format.fprintf fmt "@[<hov 2>%a.%a@ %a@]" format_to_module_name
       (`Ename name) format_enum_cons_name cons format_with_parens e


### PR DESCRIPTION
This commit fixes two related issues preventing the `explain` plugin from working:

1. Fix OCaml code generator for `Optional.Absent` (`compiler/lcalc/to_ocaml.ml`)
   - Added special case to generate `Optional.Absent` without `unit` argument
   - Previously generated `Optional.Absent()` which failed compilation
   - This was causing `stdlib` `Period` modules to fail compilation

2. Fix `explain` plugin runtime errors (`compiler/plugins/explain.ml`)
   - Added error handling for standalone test scopes (line 761)
   - Added support for general function applications (line 952)
   - Fixed assertion failures on unexpected expression types

The explain plugin now works end-to-end and successfully generates .dot and .svg visualization files.



## Checklist

None of the below apply as far as I can tell. I don't believe the `explain` plugin is even documented.

### If this PR adds a feature or has breaking changes

* [ ] Complete or update the documentation for the feature on the Catala book at https://github.com/CatalaLang/catala-book.
  * [ ] The corresponding PR is: 
* [ ] Update the existing Catala code in case of breaking changes at https://github.com/CatalaLang/catala-examples.
  * [ ] The corresponding PR is: 

### If this PR contains syntax changes
I confirm that have have checked and updated each of the following items if this PR impacts them:

* [ ] Syntax cheat sheet at `doc/syntax/syntax_*.catala_*` and `doc/syntax/catala_*.typ`.
* [ ] Syntax highlighting plugins in `syntax_highlighting/` (all of them).
* [ ] Syntax constructions in the `tree-sitter` grammar:
  - Base grammar: https://github.com/CatalaLang/tree-sitter-catala/blob/master/grammar.js
    - [ ] The corresponding PR is: 
  - Formatting spec: https://github.com/CatalaLang/catala-format/blob/master/catala.scm
    - [ ] The corresponding PR is: 
