### PR TITLE
Provide version bound for json-data-encoding

### DIFF
--- a/catala.opam
+++ b/catala.opam
@@ -49,11 +49,11 @@ depends: [
   "alcotest" {>= "1.5.0"}
   "ninja_utils" {= "0.9.0"}
   "otoml" {>= "1.0"}
+  "json-data-encoding" { >= "1.0.1" }
   "odoc" {with-doc}
   "ocamlformat" {?cataladevmode & cataladevmode & = "0.28.1"}
   "obelisk" {?cataladevmode & cataladevmode}
   "conf-ninja" {post}
-  "json-data-encoding"
   # --- the following are "optional runtime dependencies" ---
   # they're listed here mostly for documentation ; one can export
   # OPAMVAR_cataladevmode=1 before installation to automatically get them


### PR DESCRIPTION
Without this bound, `make dependencies-ocaml` refused to install it and I had the following error:

```text
$ make install
dune build @install --promote-install-files
File "compiler/shared_ast/dune", line 13, characters 2-20:
13 |   json-data-encoding))
       ^^^^^^^^^^^^^^^^^^
Error: Library "json-data-encoding" not found.
-> required by library "catala.shared_ast" in
   _build/default/compiler/shared_ast
-> required by executable catala in compiler/dune:31
-> required by _build/default/compiler/catala.exe
-> required by _build/install/default/bin/catala
-> required by _build/default/catala.install
-> required by alias install
make: *** [Makefile:102 : prepare-install] Erreur 1
```

