### PR TITLE
Add Integer.sum, etc. to the stdlib

### DIFF
--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -1005,3 +1005,5 @@ let lex_line ~context (lexbuf : lexbuf) : (string * L.line_token) option =
      | eof -> None
      | Star any_but_eol, (eol | eof) -> Some (Utf8.lexeme lexbuf, LINE_ANY)
      | _ -> assert false)
+
+let sum_string = MS_SUM

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -169,4 +169,7 @@ module type LocalisedLexer = sig
     Sedlexing.lexbuf ->
     (string * line_token) option
   (** Low-level lexer intended for dependency extraction *)
+
+  val sum_string : string
+  (** Temporary hack while the "sum" keyword is being deprecated *)
 end

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -101,4 +101,7 @@ module type LocalisedLexer = sig
   (** Low-level lexer intended for dependency extraction. The whole line
       (including ["\n"] is always returned together with the token. [None] for
       EOF. The call updates the passed context reference as expected *)
+
+  val sum_string : string
+  (** Temporary hack while the "sum" keyword is being deprecated *)
 end

--- a/compiler/surface/parser.messages
+++ b/compiler/surface/parser.messages
@@ -1,9 +1,9 @@
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT CONTENT UIDENT YEAR
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 36.
 ##
-## quident -> UIDENT . DOT quident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
-## quident -> UIDENT . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## quident -> UIDENT . DOT quident [ XOR WITH_V WITH WE_HAVE TO THEN SUM SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## quident -> UIDENT . [ XOR WITH_V WITH WE_HAVE TO THEN SUM SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT
@@ -13,7 +13,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 810.
 ##
 ## option(preceded(CONTENT,posattr(typ))) -> CONTENT . list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -25,7 +25,7 @@ expected a content type
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT YEAR
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 809.
 ##
 ## enum_decl_line -> ALT UIDENT . option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -37,7 +37,7 @@ expected a payload for your enum case, or another case or declaration
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT YEAR
 ##
-## Ends in an error in state: 807.
+## Ends in an error in state: 808.
 ##
 ## enum_decl_line -> ALT . UIDENT option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -49,7 +49,7 @@ expected the name of an enum case
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT YEAR
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 805.
 ##
 ## code_item -> DECLARATION ENUM UIDENT . COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -61,7 +61,7 @@ expected a colon
 
 source_file: BEGIN_CODE DECLARATION ENUM YEAR
 ##
-## Ends in an error in state: 803.
+## Ends in an error in state: 804.
 ##
 ## code_item -> DECLARATION ENUM . UIDENT COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -73,11 +73,11 @@ expected the name of your enum
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON YEAR
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 616.
 ##
 ## code_item -> DECLARATION SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
-## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . attribute [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . scope_decl_item [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . attribute [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . scope_decl_item [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## DECLARATION SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item)
@@ -87,7 +87,7 @@ expected a context item introduced by "context"
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT YEAR
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 614.
 ##
 ## code_item -> DECLARATION SCOPE UIDENT . COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -99,7 +99,7 @@ expected a colon followed by the list of context items of this scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE YEAR
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 613.
 ##
 ## code_item -> DECLARATION SCOPE . UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -113,7 +113,7 @@ expected the name of the scope you are declaring
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 598.
+## Ends in an error in state: 599.
 ##
 ## struct_scope -> struct_scope_base DEPENDS . separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -126,7 +126,7 @@ expected the type of the parameter of this struct data function
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT YEAR
 ##
-## Ends in an error in state: 597.
+## Ends in an error in state: 598.
 ##
 ## struct_scope -> struct_scope_base . DEPENDS separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -140,7 +140,7 @@ expected a new struct data, or another declaration or scope use
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION YEAR
 ##
-## Ends in an error in state: 595.
+## Ends in an error in state: 596.
 ##
 ## struct_scope_base -> CONDITION . lident [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -152,7 +152,7 @@ expected the name of this struct condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 578.
+## Ends in an error in state: 579.
 ##
 ## struct_scope_base -> DATA lident CONTENT . list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -164,7 +164,7 @@ expected the type of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT YEAR
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 578.
 ##
 ## struct_scope_base -> DATA lident . CONTENT list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -176,7 +176,7 @@ expected the type of this struct data, introduced by the content keyword
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA YEAR
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 577.
 ##
 ## struct_scope_base -> DATA . lident CONTENT list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -188,7 +188,7 @@ expected the name of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 575.
+## Ends in an error in state: 576.
 ##
 ## code_item -> DECLARATION STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(struct_scope) -> rev_list_with_attr(struct_scope) . attribute [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -202,7 +202,7 @@ expected struct data or condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT YEAR
 ##
-## Ends in an error in state: 573.
+## Ends in an error in state: 574.
 ##
 ## code_item -> DECLARATION STRUCT list(attribute) UIDENT . COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -214,7 +214,7 @@ expected a colon
 
 source_file: BEGIN_CODE DECLARATION STRUCT YEAR
 ##
-## Ends in an error in state: 571.
+## Ends in an error in state: 572.
 ##
 ## code_item -> DECLARATION STRUCT . list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -226,7 +226,7 @@ expected the struct name
 
 source_file: BEGIN_CODE DECLARATION YEAR
 ##
-## Ends in an error in state: 566.
+## Ends in an error in state: 567.
 ##
 ## code_item -> DECLARATION . STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION . SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -244,7 +244,7 @@ expected the kind of the declaration (struct, scope or enum)
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION LIDENT THEN
 ##
-## Ends in an error in state: 559.
+## Ends in an error in state: 560.
 ##
 ## assertion -> ASSERTION list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
@@ -275,15 +275,15 @@ source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION LIDENT THEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 83, spurious reduction of production option(state_qualifier) ->
-## In state 89, spurious reduction of production noattr_expression -> LIDENT option(state_qualifier)
+## In state 84, spurious reduction of production option(state_qualifier) ->
+## In state 90, spurious reduction of production noattr_expression -> LIDENT option(state_qualifier)
 ##
 
 expected a new scope use item
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION TRUE THEN
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 448.
 ##
 ## condition_consequence -> UNDER_CONDITION list(attribute) noattr_expression . CONSEQUENCE [ NOT FILLED DEFINED_AS ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
@@ -315,7 +315,7 @@ expected a consequence for this definition under condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION YEAR
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 446.
 ##
 ## condition_consequence -> UNDER_CONDITION . list(attribute) noattr_expression CONSEQUENCE [ NOT FILLED DEFINED_AS ]
 ##
@@ -327,7 +327,7 @@ expected an expression for this condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION YEAR
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 558.
 ##
 ## assertion -> ASSERTION . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -339,7 +339,7 @@ expected an expression that shoud be asserted during execution
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 550.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -351,7 +351,7 @@ expected an expression for the definition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT OF LIDENT DECREASING
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 459.
 ##
 ## separated_nonempty_list(COMMA,lident) -> lident . [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ## separated_nonempty_list(COMMA,lident) -> lident . COMMA separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
@@ -364,7 +364,7 @@ expected an expression for defining this function, introduced by the 'equals' ke
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION YEAR
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 545.
 ##
 ## definition -> DEFINITION . separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -376,7 +376,7 @@ expected the name of the variable you want to define
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION LIDENT YEAR
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 529.
 ##
 ## definition -> EXCEPTION lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## rule -> EXCEPTION lident . RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -389,7 +389,7 @@ expected a rule or a definition after the exception declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION YEAR
 ##
-## Ends in an error in state: 512.
+## Ends in an error in state: 513.
 ##
 ## definition -> EXCEPTION . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> EXCEPTION . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -404,7 +404,7 @@ expected the label to which the exception is referring back
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL LIDENT DEFINED_AS
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 464.
 ##
 ## definition -> LABEL lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> LABEL lident . EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -421,7 +421,7 @@ expected a rule or a definition after the label declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL YEAR
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 463.
 ##
 ## definition -> LABEL . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> LABEL . lident EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -438,7 +438,7 @@ expected the name of the label
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT DOT YEAR
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 438.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT DOT . separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
 ##
@@ -450,7 +450,7 @@ expected a struct field or a sub-scope context item after the dot
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT NOT FALSE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 451.
 ##
 ## rule_consequence -> NOT . FILLED [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -462,7 +462,7 @@ expected the filled keyword the this rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT OF YEAR
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 457.
 ##
 ## definition_parameters -> OF . separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ##
@@ -474,7 +474,7 @@ expected the name of the parameter for this dependent variable
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT YEAR
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 437.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . DOT separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
@@ -487,7 +487,7 @@ expected 'under condition' followed by a condition, 'equals' followed by the def
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE YEAR
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 435.
 ##
 ## rule -> RULE . list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -499,7 +499,7 @@ expected the name of the variable subject to the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON YEAR
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 434.
 ##
 ## code_item -> SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . attribute [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -530,7 +530,7 @@ expected a payload for the enum case constructor, or the rest of the expression 
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT YEAR
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 312.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident . AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -542,7 +542,7 @@ expected the "in" keyword to continue this existential test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS YEAR
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 118.
 ##
 ## noattr_expression -> EXISTS . list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> EXISTS . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -555,7 +555,7 @@ expected an identifier that will designate the existential witness for the test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT YEAR
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 325.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident . AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -567,7 +567,7 @@ expected the "in" keyword for the rest of the universal test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL YEAR
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 111.
 ##
 ## noattr_expression -> FOR ALL . list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> FOR ALL . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -580,7 +580,7 @@ expected an identifier for the bound variable of the universal test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR YEAR
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 110.
 ##
 ## noattr_expression -> FOR . ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> FOR . ALL LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -593,7 +593,7 @@ expected the "all" keyword to mean the "for all" construction of the universal t
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF TRUE SEMICOLON
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 332.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -625,7 +625,7 @@ expected the "then" keyword as the conditional expression is complete
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF YEAR
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 108.
 ##
 ## noattr_expression -> IF . list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -637,7 +637,7 @@ expected an expression for the test of the conditional
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION INT_LITERAL WITH_V
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 431.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
@@ -668,16 +668,16 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION INT_LITERAL WITH_V
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 101, spurious reduction of production option(addpos(unit_literal)) ->
-## In state 106, spurious reduction of production literal -> INT_LITERAL option(addpos(unit_literal))
-## In state 157, spurious reduction of production noattr_expression -> literal
+## In state 102, spurious reduction of production option(addpos(unit_literal)) ->
+## In state 107, spurious reduction of production literal -> INT_LITERAL option(addpos(unit_literal))
+## In state 158, spurious reduction of production noattr_expression -> literal
 ##
 
 expected a unit for this literal, or a valid operator to complete the expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LPAREN TRUE THEN
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 368.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
@@ -710,7 +710,7 @@ unmatched parenthesis that should have been closed by here
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LPAREN YEAR
 ##
-## Ends in an error in state: 73.
+## Ends in an error in state: 74.
 ##
 ## noattr_expression -> LPAREN . separated_nonempty_list(COMMA,expression) RPAREN [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -722,7 +722,7 @@ expected an expression inside the parenthesis
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET TRUE THEN
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 339.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -755,7 +755,7 @@ expected a semicolon or a right square bracket after the list element
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET YEAR
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 97.
 ##
 ## noattr_expression -> LBRACKET . loption(separated_nonempty_list(SEMICOLON,expression)) RBRACKET [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -767,7 +767,7 @@ expected a list element
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH ALT YEAR
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 399.
 ##
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -780,7 +780,7 @@ expected the name of the constructor for the enum case in the pattern matching
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH YEAR
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 398.
 ##
 ## noattr_expression -> noattr_expression WITH . constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> MATCH list(attribute) noattr_expression WITH . nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -793,7 +793,7 @@ expected a pattern matching case
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH YEAR
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 66.
 ##
 ## noattr_expression -> MATCH . list(attribute) noattr_expression WITH nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -841,7 +841,7 @@ expected the name of the scope being used
 
 source_file: BEGIN_CODE YEAR
 ##
-## Ends in an error in state: 853.
+## Ends in an error in state: 854.
 ##
 ## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . attribute [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . code_item [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -906,8 +906,8 @@ source_file: BEGIN_METADATA LAW_TEXT LAW_HEADING
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 1, spurious reduction of production nonempty_list(LAW_TEXT) -> LAW_TEXT
-## In state 831, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
-## In state 832, spurious reduction of production option(law_text) -> law_text
+## In state 832, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
+## In state 833, spurious reduction of production option(law_text) -> law_text
 ## In state 6, spurious reduction of production rev_list_with_attr(code_item) ->
 ##
 
@@ -960,7 +960,7 @@ constructor, possibly with a submodule qualification)
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM YEAR
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 31.
 ##
 ## noattr_expression -> SUM . primitive_typ OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -972,9 +972,9 @@ the 'sum' operator must be followed by the type to be summed.
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DOT YEAR
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 37.
 ##
-## quident -> UIDENT DOT . quident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
+## quident -> UIDENT DOT . quident [ XOR WITH_V WITH WE_HAVE TO THEN SUM SUCH STATE SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OUTPUT OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LIDENT LESSER_EQUAL LESSER LABEL IS INTERNAL INPUT IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEPENDS DEFINITION DEFINED_AS DECLARATION DATE DATA CONTEXT CONTENT CONTAINS CONSEQUENCE CONDITION COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
 ## The known suffix of the stack is as follows:
 ## UIDENT DOT
@@ -984,7 +984,7 @@ expected the structure or enumeration type of the definition under the given mod
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF YEAR
 ##
-## Ends in an error in state: 41.
+## Ends in an error in state: 42.
 ##
 ## noattr_expression -> SUM primitive_typ OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -996,7 +996,7 @@ expected the list on which to operate the sum
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT YEAR
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 44.
 ##
 ## noattr_expression -> OUTPUT . OF quident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT . OF quident WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1009,7 +1009,7 @@ expected 'of' then a scope to be applied
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF YEAR
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 45.
 ##
 ## noattr_expression -> OUTPUT OF . quident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT OF . quident WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1022,7 +1022,7 @@ expected a scope to be applied
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT STATE
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 46.
 ##
 ## noattr_expression -> OUTPUT OF quident . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> OUTPUT OF quident . WITH_V LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1034,7 +1034,7 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT STATE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
+## In state 36, spurious reduction of production quident -> UIDENT
 ##
 
 expected 'with' then the arguments to the scope call ('{ -- var : ... }'), or a
@@ -1042,7 +1042,7 @@ binary operator to be applied on the results of the call
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V YEAR
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 47.
 ##
 ## noattr_expression -> OUTPUT OF quident WITH_V . LBRACE list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1054,7 +1054,7 @@ expected the arguments to the scope call ('{ --var: ... }')
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V LBRACE YEAR
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 48.
 ##
 ## noattr_expression -> OUTPUT OF quident WITH_V LBRACE . list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1066,7 +1066,7 @@ expected a list of variable-value bindings in the form `-- var_name : <expressio
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION OUTPUT OF UIDENT WITH_V LBRACE ALT YEAR
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 49.
 ##
 ## list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field list(preceded(ALT,struct_content_field)) [ RBRACE ]
 ##
@@ -1078,7 +1078,7 @@ expected a variable name, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT YEAR
 ##
-## Ends in an error in state: 51.
+## Ends in an error in state: 52.
 ##
 ## struct_content_field -> lident . COLON list(attribute) noattr_expression [ RBRACE ALT ]
 ##
@@ -1090,7 +1090,7 @@ expected a colon, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON YEAR
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 53.
 ##
 ## struct_content_field -> lident COLON . list(attribute) noattr_expression [ RBRACE ALT ]
 ##
@@ -1102,7 +1102,7 @@ expected an expression, following the form '-- var_name : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION NOT YEAR
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 55.
 ##
 ## noattr_expression -> NOT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1114,7 +1114,7 @@ expected a boolean expression to apply 'not' on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINUS YEAR
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 58.
 ##
 ## noattr_expression -> MINUS . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1126,7 +1126,7 @@ expected a numeric expression to apply '-' on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINIMUM YEAR
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 60.
 ##
 ## noattr_expression -> MINIMUM . OF list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> MINIMUM . OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1139,7 +1139,7 @@ expected 'of' then the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINIMUM OF YEAR
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 61.
 ##
 ## noattr_expression -> MINIMUM OF . list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> MINIMUM OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1152,7 +1152,7 @@ expected an expression defining the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MAXIMUM YEAR
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 63.
 ##
 ## noattr_expression -> MAXIMUM . OF list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> MAXIMUM . OF list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1165,7 +1165,7 @@ expected 'of' then the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MAXIMUM OF YEAR
 ##
-## Ends in an error in state: 63.
+## Ends in an error in state: 64.
 ##
 ## noattr_expression -> MAXIMUM OF . list(attribute) noattr_expression OR_IF_LIST_EMPTY THEN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> MAXIMUM OF . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1178,7 +1178,7 @@ expected an expression defining the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LIDENT YEAR
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 84.
 ##
 ## noattr_expression -> LIDENT . option(state_qualifier) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1190,7 +1190,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET YEAR
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 91.
 ##
 ## noattr_expression -> LET . list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> LET . LPAREN separated_nonempty_list(COMMA,attr(lident)) RPAREN DEFINED_AS list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1203,7 +1203,7 @@ expected 'var equals expression' after 'let'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 348.
 ##
 ## noattr_expression -> LET list(attribute) lident DEFINED_AS . list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1215,7 +1215,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG YEAR
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 326.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident AMONG . list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1227,7 +1227,7 @@ expected an expression describing the list to operate on
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE YEAR
 ##
-## Ends in an error in state: 143.
+## Ends in an error in state: 144.
 ##
 ## noattr_expression -> quident LBRACE . nonempty_list(preceded(ALT,struct_content_field)) RBRACE [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1239,7 +1239,7 @@ expected a list of field bindings of the form '-- fld : expression'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT YEAR
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 145.
 ##
 ## nonempty_list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field [ RBRACE ]
 ## nonempty_list(preceded(ALT,struct_content_field)) -> ALT . struct_content_field nonempty_list(preceded(ALT,struct_content_field)) [ RBRACE ]
@@ -1252,7 +1252,7 @@ expected a 'fldname : expression' binding
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 150.
 ##
 ## option(preceded(CONTENT,expression)) -> CONTENT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1308,7 +1308,7 @@ expected an expression defining the enumeration case content
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT CONTENT FALSE YEAR
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 152.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1340,7 +1340,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 315.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1372,7 +1372,7 @@ expected 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH YEAR
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 316.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH . THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1384,7 +1384,7 @@ expected the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT YEAR
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 317.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1396,7 +1396,7 @@ expected an expression, following the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT FALSE YEAR
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 319.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1428,7 +1428,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 328.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1460,7 +1460,7 @@ expected 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE YEAR
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 329.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1472,7 +1472,7 @@ expected the form 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE FALSE YEAR
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 331.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1504,7 +1504,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN YEAR
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 333.
 ##
 ## noattr_expression -> IF list(attribute) noattr_expression THEN . list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1516,7 +1516,7 @@ expected an expression, followed by 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN FALSE YEAR
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 335.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1548,7 +1548,7 @@ expected 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE YEAR
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 336.
 ##
 ## noattr_expression -> IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1560,7 +1560,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE FALSE YEAR
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 338.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1592,7 +1592,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET UIDENT SEMICOLON YEAR
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 340.
 ##
 ## separated_nonempty_list(SEMICOLON,expression) -> list(attribute) noattr_expression SEMICOLON . separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
 ##
@@ -1604,7 +1604,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 350.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1636,7 +1636,7 @@ expected the keyword 'in'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN YEAR
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 351.
 ##
 ## noattr_expression -> LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1648,7 +1648,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN FALSE YEAR
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 353.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1680,7 +1680,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH FALSE YEAR
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 397.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1712,7 +1712,7 @@ expected 'with pattern -- <pattern> : <expression> ...'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD YEAR
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 400.
 ##
 ## match_arm -> WILDCARD . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1724,7 +1724,7 @@ expected ':' followed by an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON YEAR
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 401.
 ##
 ## match_arm -> WILDCARD COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1736,7 +1736,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON FALSE YEAR
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 403.
 ##
 ## match_arm -> WILDCARD COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1768,7 +1768,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT XOR
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 406.
 ##
 ## match_arm -> constructor_binding . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1779,15 +1779,15 @@ source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
-## In state 164, spurious reduction of production constructor_binding -> quident
+## In state 36, spurious reduction of production quident -> UIDENT
+## In state 165, spurious reduction of production constructor_binding -> quident
 ##
 
 expected a colon followed by an expression, as in '-- Case : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 407.
 ##
 ## match_arm -> constructor_binding COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1799,7 +1799,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON FALSE YEAR
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 409.
 ##
 ## match_arm -> constructor_binding COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1831,7 +1831,7 @@ expected a binary operator, or the next case in the form '-- NextCase : <express
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINUS FALSE YEAR
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 421.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1863,7 +1863,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION NOT FALSE YEAR
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 422.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1895,7 +1895,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON FALSE YEAR
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 423.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
@@ -1927,7 +1927,7 @@ expected another field in the form '-- <var>: <expression>', or a closing '}' br
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF FALSE YEAR
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 426.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1959,7 +1959,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 449.
+## Ends in an error in state: 450.
 ##
 ## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) . rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -1971,9 +1971,9 @@ expected either 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE YEAR
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 442.
 ##
-## state -> STATE . lident [ UNDER_CONDITION STATE SCOPE OUTPUT NOT LIDENT INTERNAL INPUT FILLED END_CODE DOCSTRING DEFINED_AS DECLARATION CONTEXT ATTR_START ]
+## state -> STATE . lident [ UNDER_CONDITION SUM STATE SCOPE OUTPUT NOT LIDENT INTERNAL INPUT FILLED END_CODE DOCSTRING DEFINED_AS DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATE
@@ -1983,7 +1983,7 @@ expected an identifier defining the name of the state
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 445.
 ##
 ## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) . option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -1995,7 +1995,7 @@ expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 547.
+## Ends in an error in state: 548.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) . option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -2007,7 +2007,7 @@ expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 549.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) . DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -2019,7 +2019,7 @@ expected 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 552.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
@@ -2051,22 +2051,22 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT YEAR
 ##
-## Ends in an error in state: 733.
+## Ends in an error in state: 734.
 ##
-## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT . lident CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . OUTPUT lident CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT . lident CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT
@@ -2076,22 +2076,22 @@ expected a variable name, optionally preceded by 'output'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON INTERNAL YEAR
 ##
-## Ends in an error in state: 641.
+## Ends in an error in state: 642.
 ##
-## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> INTERNAL . lident CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . OUTPUT lident CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> INTERNAL . lident CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## INTERNAL
@@ -2101,15 +2101,15 @@ expected a variable name
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT YEAR
 ##
-## Ends in an error in state: 757.
+## Ends in an error in state: 758.
 ##
-## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident . CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident . CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident
@@ -2119,10 +2119,10 @@ expected either 'condition', or 'content' followed by the expected variable type
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 762.
+## Ends in an error in state: 763.
 ##
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONTENT typ_data DEPENDS
@@ -2132,9 +2132,9 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 763.
+## Ends in an error in state: 764.
 ##
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONTENT typ_data DEPENDS LPAREN
@@ -2144,9 +2144,9 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 764.
+## Ends in an error in state: 765.
 ##
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content)
@@ -2155,19 +2155,19 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
-## In state 39, spurious reduction of production primitive_typ -> quident
-## In state 589, spurious reduction of production typ_data -> primitive_typ
-## In state 606, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 36, spurious reduction of production quident -> UIDENT
+## In state 40, spurious reduction of production primitive_typ -> quident
+## In state 590, spurious reduction of production typ_data -> primitive_typ
+## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument specification
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 766.
 ##
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN
@@ -2177,9 +2177,9 @@ expected a 'state' declaration for the preceding declaration, or the next declar
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION STATE LIDENT YEAR
 ##
-## Ends in an error in state: 626.
+## Ends in an error in state: 627.
 ##
-## list(state) -> state . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## list(state) -> state . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## state
@@ -2190,9 +2190,9 @@ declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 767.
+## Ends in an error in state: 768.
 ##
-## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content)
@@ -2201,21 +2201,21 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
-## In state 39, spurious reduction of production primitive_typ -> quident
-## In state 589, spurious reduction of production typ_data -> primitive_typ
-## In state 606, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 36, spurious reduction of production quident -> UIDENT
+## In state 40, spurious reduction of production primitive_typ -> quident
+## In state 590, spurious reduction of production typ_data -> primitive_typ
+## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION YEAR
 ##
-## Ends in an error in state: 770.
+## Ends in an error in state: 771.
 ##
-## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident CONDITION . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONDITION
@@ -2225,10 +2225,10 @@ expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS YEAR
 ##
-## Ends in an error in state: 771.
+## Ends in an error in state: 772.
 ##
-## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONDITION DEPENDS
@@ -2238,9 +2238,9 @@ expected the form 'depends on <ident> content <type>'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 772.
+## Ends in an error in state: 773.
 ##
-## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONDITION DEPENDS LPAREN
@@ -2250,9 +2250,9 @@ expected the form 'depends on (<ident> content <type> [, <ident> content <type> 
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 773.
+## Ends in an error in state: 774.
 ##
-## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content)
@@ -2261,19 +2261,19 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
-## In state 39, spurious reduction of production primitive_typ -> quident
-## In state 589, spurious reduction of production typ_data -> primitive_typ
-## In state 606, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 36, spurious reduction of production quident -> UIDENT
+## In state 40, spurious reduction of production primitive_typ -> quident
+## In state 590, spurious reduction of production typ_data -> primitive_typ
+## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument declaration (', <ident> content <type>')
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 774.
+## Ends in an error in state: 775.
 ##
-## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN
@@ -2283,15 +2283,15 @@ expected the next definition in scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT YEAR
 ##
-## Ends in an error in state: 780.
+## Ends in an error in state: 781.
 ##
-## scope_decl_item -> lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . CONTENT typ_data list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . SCOPE quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
-## scope_decl_item -> lident . CONDITION list(state) [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONTENT typ_data list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . SCOPE quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONDITION DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident . CONDITION list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident
@@ -2301,9 +2301,9 @@ expected the form '<ident> scope <Scope_name>', or a scope variable declaration
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT SCOPE YEAR
 ##
-## Ends in an error in state: 781.
+## Ends in an error in state: 782.
 ##
-## scope_decl_item -> lident SCOPE . quident [ SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
+## scope_decl_item -> lident SCOPE . quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## lident SCOPE
@@ -2313,7 +2313,7 @@ expected a scope name
 
 source_file: BEGIN_CODE DECLARATION LIDENT YEAR
 ##
-## Ends in an error in state: 815.
+## Ends in an error in state: 816.
 ##
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2327,7 +2327,7 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 817.
 ##
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2341,7 +2341,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 818.
+## Ends in an error in state: 819.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2354,7 +2354,7 @@ expected a variable name, following the form 'depends on <var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 819.
+## Ends in an error in state: 820.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2366,7 +2366,7 @@ expected a variable name, following the form 'depends on (<var> content <type>, 
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 820.
+## Ends in an error in state: 821.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2377,10 +2377,10 @@ source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 35, spurious reduction of production quident -> UIDENT
-## In state 39, spurious reduction of production primitive_typ -> quident
-## In state 589, spurious reduction of production typ_data -> primitive_typ
-## In state 606, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 36, spurious reduction of production quident -> UIDENT
+## In state 40, spurious reduction of production primitive_typ -> quident
+## In state 590, spurious reduction of production typ_data -> primitive_typ
+## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected ')', or ',' followed by another argument declaration in the form '<var>
@@ -2388,7 +2388,7 @@ content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 821.
+## Ends in an error in state: 822.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2400,7 +2400,7 @@ expected 'equals <expression>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN DEFINED_AS YEAR
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 823.
 ##
 ## option(opt_def) -> DEFINED_AS . list(attribute) noattr_expression [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2412,10 +2412,10 @@ expected an expression
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT YEAR
 ##
-## Ends in an error in state: 603.
+## Ends in an error in state: 604.
 ##
-## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
-## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## list(attribute) lident
@@ -2425,10 +2425,10 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 604.
+## Ends in an error in state: 605.
 ##
-## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
-## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## list(attribute) lident CONTENT
@@ -2438,9 +2438,9 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT COMMA YEAR
 ##
-## Ends in an error in state: 607.
+## Ends in an error in state: 608.
 ##
-## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data COMMA . separated_nonempty_list(COMMA,var_content) [ STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
+## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data COMMA . separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
 ## The known suffix of the stack is as follows:
 ## list(attribute) lident CONTENT list(attribute) typ_data COMMA
@@ -2450,7 +2450,7 @@ expected the definition of another argument in the form '<var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 824.
+## Ends in an error in state: 825.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL END_CODE DOT DOCSTRING DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL END_CODE DOT DOCSTRING DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
@@ -2482,7 +2482,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_DIRECTIVE YEAR
 ##
-## Ends in an error in state: 833.
+## Ends in an error in state: 834.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE . directive END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2494,7 +2494,7 @@ expected a directive, e.g. 'Include: <filename>'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE YEAR
 ##
-## Ends in an error in state: 843.
+## Ends in an error in state: 844.
 ##
 ## directive -> LAW_INCLUDE . COLON nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2506,7 +2506,7 @@ expected ':', then a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON YEAR
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 845.
 ##
 ## directive -> LAW_INCLUDE COLON . nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2518,7 +2518,7 @@ expected a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG YEAR
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 846.
 ##
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . [ END_DIRECTIVE AT_PAGE ]
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . nonempty_list(DIRECTIVE_ARG) [ END_DIRECTIVE AT_PAGE ]
@@ -2531,7 +2531,7 @@ expected a page specification in the form '@p.<number>', or a newline
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG AT_PAGE YEAR
 ##
-## Ends in an error in state: 850.
+## Ends in an error in state: 851.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE directive . END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2543,7 +2543,7 @@ expected a newline
 
 source_file: LAW_HEADING YEAR
 ##
-## Ends in an error in state: 855.
+## Ends in an error in state: 856.
 ##
 ## source_file -> source_file_item . source_file [ # ]
 ##

--- a/compiler/surface/parser.mly
+++ b/compiler/surface/parser.mly
@@ -63,6 +63,7 @@
   val lex_builtin: string -> Ast.builtin_expression option
   val lex_primitive_type: string -> Ast.primitive_typ option
   val lex_builtin_constr: string -> Ast.builtin_constr option
+  val sum_string: string
 end>
 
 (* The token is returned for every line of law text, make them right-associative
@@ -237,6 +238,12 @@ let lident :=
         "Reserved builtin name"
   | None ->
       (i, get_pos $sloc)
+}
+| SUM ; {
+  (* TEMPORARY: this is for backwards-compat with the deprecated
+     "sum integer of..." syntax.
+     When that is removed, the SUM keyword will go *)
+  (Localisation.sum_string, get_pos $sloc)
 }
 
 let scope_var == separated_nonempty_list(DOT, addpos(LIDENT))

--- a/doc/syntax/syntax_en.typ
+++ b/doc/syntax/syntax_en.typ
@@ -306,9 +306,6 @@ map each (x, y) among (lst1, lst2)
 lst1 ++ lst2
 ```, [Merge],
 ```catala-en-code
-sum integer of lst
-```, [Aggregation],
-```catala-en-code
 number of lst
 ```, [Count],
 ```catala-en-code

--- a/doc/syntax/syntax_fr.typ
+++ b/doc/syntax/syntax_fr.typ
@@ -315,9 +315,6 @@ transforme chaque (x, y)
 lst1 ++ lst2
 ```, [Réunion],
 ```catala-fr-code
-somme entier de lst
-```, [Agrégation],
-```catala-fr-code
 nombre de lst
 ```, [Comptage],
 ```catala-fr-code

--- a/stdlib/decimal_en.catala_en
+++ b/stdlib/decimal_en.catala_en
@@ -108,4 +108,10 @@ declaration round_to_decimal
     nth_decimal content integer
   equals
     D.round_to_decimal of d, nth_decimal
+
+## Sums the elements of a list of Decimal
+declaration sum
+  content decimal
+  depends on l content list of decimal
+  equals combine all x among l in total initially 0.0 with total + x
 ```

--- a/stdlib/decimal_fr.catala_fr
+++ b/stdlib/decimal_fr.catala_fr
@@ -110,4 +110,11 @@ déclaration arrondi_à_la_décimale
     nième_décimale contenu entier
   égal à
     D.round_to_decimal de d, nième_décimale
+
+## Calcule la somme des éléments d'une liste de décimaux
+déclaration somme
+  contenu décimal
+  dépend de l contenu liste de décimal
+  égal à
+    combine tout x parmi l dans total initialement 0,0 avec total + x
 ```

--- a/stdlib/duration_en.catala_en
+++ b/stdlib/duration_en.catala_en
@@ -1,0 +1,24 @@
+# Durations
+
+> Module Duration_en
+
+## Helper functions
+
+Comparisons on durations can fail (e.g. there is no good answer to `30 day < 1
+month`). This is why the common `min`, `max` etc. functions are not provided for
+this module.
+
+```catala-metadata
+## Returns the argument if it is positive, 0 otherwise.
+declaration positive
+  content duration
+  depends on d content duration
+  equals
+    if d > 0 day then d else 0 day
+
+## Sums the elements of a list of Decimal
+declaration sum
+  content duration
+  depends on l content list of duration
+  equals combine all x among l in total initially 0 day with total + x
+```

--- a/stdlib/duration_fr.catala_fr
+++ b/stdlib/duration_fr.catala_fr
@@ -1,0 +1,25 @@
+# Durées
+
+> Module Duration_fr
+
+## Fonctions utilitaires
+
+La comparaison de deux durées est susceptible d'échouer (par exemple, il n'y a
+pas de bonne réponse à `30 jour < 1 mois`). Pour cette raison, les opérations
+habituelles `min`, `max`, etc. ne sont pas proposées dans ce module.
+
+```catala-metadata
+## Renvoie l'argument s'il est positif, 0 sinon.
+déclaration positif
+  contenu durée
+  dépend de d contenu durée
+  égal à
+    si d > 0 jour alors d sinon 0 jour
+
+## Calcule la somme des éléments d'une liste de durées
+déclaration somme
+  contenu durée
+  dépend de l contenu liste de durée
+  égal à
+    combine tout x parmi l dans total initialement 0 jour avec total + x
+```

--- a/stdlib/integer_en.catala_en
+++ b/stdlib/integer_en.catala_en
@@ -48,4 +48,10 @@ declaration positive
   depends on n content integer
   equals
     floor of n, 0
+
+## Sums the elements of a list of Decimal
+declaration sum
+  content integer
+  depends on l content list of integer
+  equals combine all x among l in total initially 0 with total + x
 ```

--- a/stdlib/integer_fr.catala_fr
+++ b/stdlib/integer_fr.catala_fr
@@ -49,4 +49,11 @@ déclaration positif
   dépend de variable contenu entier
   égal à
     plancher de variable, 0
+
+## Calcule la somme des éléments d'une liste de décimaux
+déclaration somme
+  contenu entier
+  dépend de l contenu liste de entier
+  égal à
+    combine tout x parmi l dans total initialement 0 avec total + x
 ```

--- a/stdlib/money_en.catala_en
+++ b/stdlib/money_en.catala_en
@@ -103,6 +103,13 @@ declaration round_to_decimal
     nth_decimal content integer
   equals
     M.round_to_decimal of m, nth_decimal
+
+## Sums the elements of a list of money
+declaration sum
+  content money
+  depends on l content list of money
+  equals combine all x among l in total initially $0 with total + x
+
 ```
 
 ## Financial operations
@@ -127,4 +134,5 @@ declaration in_default
     reference content money
   equals
     max of ($0, reference - m)
+
 ```

--- a/stdlib/money_fr.catala_fr
+++ b/stdlib/money_fr.catala_fr
@@ -104,6 +104,14 @@ déclaration arrondi_à_la_décimale
     nième_décimale contenu entier
   égal à
     M.round_to_decimal de a, nième_décimale
+
+## Calcule la somme des éléments d'une liste d'argent
+déclaration somme
+  contenu argent
+  dépend de l contenu liste de argent
+  égal à
+    combine tout x parmi l dans total initialement 0€ avec total + x
+
 ```
 
 ## Opérations financières

--- a/stdlib/stdlib_en.catala_en
+++ b/stdlib/stdlib_en.catala_en
@@ -21,6 +21,7 @@
 ```
 
 > Using Date_en as Date
+> Using Duration_en as Duration
 > Using MonthYear_en as MonthYear
 > Using Period_en as Period
 > Using Money_en as Money

--- a/stdlib/stdlib_fr.catala_fr
+++ b/stdlib/stdlib_fr.catala_fr
@@ -21,6 +21,7 @@
 ```
 
 > Usage de Date_fr en tant que Date
+> Usage de Duration_fr en tant que Durée
 > Usage de MonthYear_fr en tant que MoisAnnée
 > Usage de Period_fr en tant que Période
 > Usage de Money_fr en tant que Argent

--- a/tests/array/good/aggregation_3.catala_en
+++ b/tests/array/good/aggregation_3.catala_en
@@ -13,8 +13,12 @@ scope S:
     assertion (map each i among [1; 2; 3] such that i > 2 to (i + 2) ) = [5]
 
 # Sum
+    # Old, deprecated syntax
     assertion sum integer of [1; 2; 3] = 6
     assertion sum integer of (map each i among [1; 2; 3] to (i + 2)) = 12
+    # New syntax
+    assertion Integer.sum of [1; 2; 3] = 6
+    assertion Integer.sum of (map each i among [1; 2; 3] to (i + 2)) = 12
 
 # Count
     assertion number of [1; 2; 3] = 3
@@ -63,6 +67,8 @@ let scope S (x: integer|internal|output) =
             (λ () → 0)
             map (λ (i: integer) → i + 2) [1; 2; 3])
          = 12;
+  assert (Integer_en.sum [1; 2; 3]) = 6;
+  assert (Integer_en.sum map (λ (i: integer) → i + 2) [1; 2; 3]) = 12;
   assert (length [1; 2; 3]) = 3;
   assert (length filter (λ (i: integer) → i >= 2) [1; 2; 3]) = 2;
   assert (reduce

--- a/tests/attributes/good/debug_print.catala_en
+++ b/tests/attributes/good/debug_print.catala_en
@@ -23,6 +23,7 @@ $ catala interpret -s A --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
 [DEBUG] Parsing "libcatala/period_internal.catala_en"
@@ -43,8 +44,8 @@ $ catala interpret -s A --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en MonthYear_en
-  Period_internal Period_en Money_internal Money_en Integer_en
+[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
+  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
   Decimal_internal Decimal_en List_internal List_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] 0 (at tests/attributes/good/debug_print.catala_en:9.38-9.47)

--- a/tests/backends/python_enum.catala_en
+++ b/tests/backends/python_enum.catala_en
@@ -128,6 +128,7 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -26,6 +26,7 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en

--- a/tests/backends/simple.catala_en
+++ b/tests/backends/simple.catala_en
@@ -39,6 +39,7 @@ $ catala c
 
 #include <Stdlib_en.h>
 #include <Date_en.h>
+#include <Duration_en.h>
 #include <MonthYear_en.h>
 #include <Period_en.h>
 #include <Money_en.h>

--- a/tests/modules/good/mod_def.catala_en
+++ b/tests/modules/good/mod_def.catala_en
@@ -76,6 +76,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()

--- a/tests/name_resolution/good/conflicts-module.catala_en
+++ b/tests/name_resolution/good/conflicts-module.catala_en
@@ -30,6 +30,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -155,6 +161,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -223,7 +235,7 @@ let closure_scoppe : Closure_scoppe_in.t -> Closure_scoppe.t = fun _ ->
       (let x, _
         = (true,
             ({filename="tests/name_resolution/good/conflicts-module.catala_en";
-              start_line=123; start_column=15; end_line=123; end_column=24;
+              start_line=129; start_column=15; end_line=129; end_column=24;
               law_headings=[]})) in x) else
       (let x, _
         = (false,

--- a/tests/name_resolution/good/conflicts.catala_en
+++ b/tests/name_resolution/good/conflicts.catala_en
@@ -143,6 +143,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()

--- a/tests/name_resolution/good/keywords.catala_en
+++ b/tests/name_resolution/good/keywords.catala_en
@@ -48,6 +48,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -54,6 +54,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -110,6 +110,7 @@ $ catala scalc
 module stdlib_en = Stdlib_en
 module date_en = Date_en
 module date_internal = Date_internal
+module duration_en = Duration_en
 module month_year_en = MonthYear_en
 module period_en = Period_en
 module period_internal = Period_internal
@@ -206,6 +207,7 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en

--- a/tests/scope/good/art191_fix_record_name_confusion.catala_en
+++ b/tests/scope/good/art191_fix_record_name_confusion.catala_en
@@ -49,6 +49,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module Duration_en, it may need recompiling"
+module Duration_en = Duration_en
+let () =
   match Catala_runtime.check_module "MonthYear_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()

--- a/tests/scope/good/scope_call3.catala_en
+++ b/tests/scope/good/scope_call3.catala_en
@@ -37,6 +37,7 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
 [DEBUG] Parsing "libcatala/period_internal.catala_en"
@@ -57,8 +58,8 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en MonthYear_en
-  Period_internal Period_en Money_internal Money_en Integer_en
+[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
+  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
   Decimal_internal Decimal_en List_internal List_en Stdlib_en
 [DEBUG] Starting interpretation...
 [LOG] ≔  HousingComputation.f: <object>

--- a/tests/scope/good/scope_call4.catala_en
+++ b/tests/scope/good/scope_call4.catala_en
@@ -44,6 +44,7 @@ $ catala interpret -s RentComputation --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
 [DEBUG] Parsing "libcatala/period_internal.catala_en"
@@ -64,8 +65,8 @@ $ catala interpret -s RentComputation --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en MonthYear_en
-  Period_internal Period_en Money_internal Money_en Integer_en
+[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
+  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
   Decimal_internal Decimal_en List_internal List_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] End of interpretation
@@ -94,6 +95,7 @@ $ catala Interpret --lcalc -s RentComputation --optimize --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
 [DEBUG] Parsing "libcatala/period_internal.catala_en"
@@ -118,8 +120,8 @@ $ catala Interpret --lcalc -s RentComputation --optimize --debug
 [DEBUG] = LCALC =
 [DEBUG] Optimizing lambda calculus...
 [DEBUG] Retyping lambda calculus...
-[DEBUG] Loading shared modules... Date_internal Date_en MonthYear_en
-  Period_internal Period_en Money_internal Money_en Integer_en
+[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
+  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
   Decimal_internal Decimal_en List_internal List_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] End of interpretation


### PR DESCRIPTION
and remove the older syntax 'sum integer of...' from the syntax sheet as a first step to deprecation.

The syntax is still supported, but the parser was patched to no longer recognise `sum` as a keyword outside of the `sum <type> of` construct. Therefore, the change shouldn't be breaking, but leave the time to replace the old syntax with the call to the stdlib functions.

The `Duration` stdlib module was also added, since it wasn't there yet and `sum duration of ...` is supported.

The tools and grammars don't need any change (this doesn't add syntax, and they're not affected by `sum` appearing in places where it's not a keyword).

A PR updating the book to advertise the new syntax instead of the old one is proposed at https://github.com/CatalaLang/catala-book/pull/45
