### PR TITLE
Stdlib: refactor day_of_week computation

### DIFF
--- a/stdlib/date_en.catala_en
+++ b/stdlib/date_en.catala_en
@@ -3,6 +3,7 @@
 > Module Date_en
 
 > Using Date_internal as D
+> Using List_en as List
 
 ## Helper functions
 
@@ -248,7 +249,7 @@ declaration is_young_enough_rounding_up
 
 ## Days of the week enumeration
 ```catala-metadata
-declaration enumeration Days:
+declaration enumeration Day_of_week:
   -- Monday
   -- Tuesday
   -- Wednesday
@@ -258,123 +259,43 @@ declaration enumeration Days:
   -- Sunday
 ```
 
-## Tomohiko Sakamoto Algorithm : find the Day of the week for a given date
+## Find the Day of the week for a given date (Tomohiko Sakamoto Algorithm)
+
 ```catala-metadata
-declaration scope Day_of_the_of_given_date :
-  input output given_date content date
-
-  internal sakamoto_list content (integer, integer, integer, integer, integer, integer, integer, integer, integer, integer, integer, integer)
-  internal month_number content integer
-  internal n_number content integer
-  internal year_number content integer
-
-  internal day_number content integer
-  output day_of_the_week content Days
-```
-
-```catala
-scope Day_of_the_of_given_date :
-  definition sakamoto_list
-  equals (0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4)
-```
-```catala
-scope Day_of_the_of_given_date :
-  definition month_number
-  equals get_month of given_date
-```
-```catala
-scope Day_of_the_of_given_date :
-  definition year_number
-  equals 
+declaration day_of_week content Day_of_week
+  depends on given_date content date
+  equals
+  let weekdays equals [Sunday; Monday; Tuesday; Wednesday; Thursday; Friday; Saturday] in
+  let sakamoto_list equals [0; 3; 2; 5; 0; 3; 5; 1; 4; 6; 2; 4] in
+  let month_number equals get_month of given_date in
+  let year_number equals
     if month_number < 3
-      then get_year of given_date - 1
-    else get_year of given_date 
-```
-
-```catala
-scope Day_of_the_of_given_date :
-  definition n_number under condition
-    month_number = 1
-  consequence equals sakamoto_list.1
-  definition n_number under condition
-    month_number = 2
-  consequence equals sakamoto_list.2
-
-  definition n_number under condition
-    month_number = 3
-  consequence equals sakamoto_list.3
-
-  definition n_number under condition
-    month_number = 4
-  consequence equals sakamoto_list.4
-
-  definition n_number under condition
-    month_number = 5
-  consequence equals sakamoto_list.5
-
-  definition n_number under condition
-    month_number = 6
-  consequence equals sakamoto_list.6
-
-  definition n_number under condition
-    month_number = 7
-  consequence equals sakamoto_list.7
-
-  definition n_number under condition
-    month_number = 8
-  consequence equals sakamoto_list.8
-
-  definition n_number under condition
-    month_number = 9
-  consequence equals sakamoto_list.9
-
-  definition n_number under condition
-    month_number = 10
-  consequence equals sakamoto_list.10
-
-  definition n_number under condition
-    month_number = 11
-  consequence equals sakamoto_list.11
-
-  definition n_number under condition
-    month_number = 12
-  consequence equals sakamoto_list.12
-```
-
-```catala
-scope Day_of_the_of_given_date :
-  definition day_number
-  equals 
-    (year_number + integer of (year_number / 4) - integer of (year_number / 100) + integer of (year_number / 400) + n_number + get_day of given_date) 
-    - 7 * integer of ((year_number + integer of (year_number / 4) - integer of (year_number / 100) + integer of (year_number / 400) + n_number + get_day of given_date) /7)
-```
-
-```catala
-scope Day_of_the_of_given_date :
-  definition day_of_the_week under condition
-    day_number = 0
-  consequence equals Sunday
-  definition day_of_the_week under condition
-    day_number = 1
-  consequence equals Monday
-
-  definition day_of_the_week under condition
-    day_number = 2
-  consequence equals Tuesday
-
-  definition day_of_the_week under condition
-    day_number = 3
-  consequence equals Wednesday
-
-  definition day_of_the_week under condition
-    day_number = 4
-  consequence equals Thursday
-
-  definition day_of_the_week under condition
-    day_number = 5
-  consequence equals Friday
-
-  definition day_of_the_week under condition
-    day_number = 6
-  consequence equals Saturday
+    then get_year of given_date - 1
+    else get_year of given_date
+  in
+  let n_number equals
+    match (List.nth_element of sakamoto_list, month_number) with pattern
+    -- Present content n: n
+    -- Absent: impossible
+  in
+  let day_number equals
+    (year_number
+     + integer of (year_number / 4)
+     - integer of (year_number / 100)
+     + integer of (year_number / 400)
+     + n_number
+     + get_day of given_date)
+    - 7 * integer of (
+      (year_number
+       + integer of (year_number / 4)
+       - integer of (year_number / 100)
+       + integer of (year_number / 400)
+       + n_number
+       + get_day of given_date)
+      / 7
+    )
+  in
+  match (List.nth_element of weekdays, (day_number + 1)) with pattern
+  -- Present content d: d
+  -- Absent: impossible
 ```

--- a/stdlib/date_fr.catala_fr
+++ b/stdlib/date_fr.catala_fr
@@ -3,6 +3,7 @@
 > Module Date_fr
 
 > Usage de Date_internal en tant que D
+> Usage de List_fr en tant que Liste
 
 ## Fonctions utilitaires
 
@@ -242,7 +243,7 @@ déclaration est_assez_jeune_arrondi_supérieur
 
 ## Gestion des jours de la semaine et des jours fériés
 ```catala-metadata
-déclaration énumération Jours:
+déclaration énumération Jour_de_la_semaine:
   -- Lundi
   -- Mardi
   -- Mercredi
@@ -252,124 +253,43 @@ déclaration énumération Jours:
   -- Dimanche
 ```
 
-## Algorithme de Sakamoto, détermination jour de la semaine d'une date donée
+## Détermination du jour de la semaine d'une date donnée (algorithme de Sakamoto)
+
 ```catala-metadata
-déclaration champ d'application Jour_de_la_semaine_depuis_date :
-  entrée résultat date_entrée contenu date
-
-  interne liste_Sakamoto contenu (entier, entier, entier, entier, entier, entier, entier, entier, entier, entier, entier, entier)
-  interne mois_nombre contenu entier
-  interne n_nombre contenu entier
-  interne année_nombre contenu entier
-
-  interne jour_nombre contenu entier
-  résultat jour_de_la_semaine_depuis_date contenu Jours
+déclaration jour_de_la_semaine contenu Jour_de_la_semaine
+  dépend de date_donnée contenu date
+  égal à
+  soit weekdays égal à [Lundi; Mardi; Mercredi; Jeudi; Vendredi; Samedi; Dimanche] dans
+  soit sakamoto_list égal à [0; 3; 2; 5; 0; 3; 5; 1; 4; 6; 2; 4] dans
+  soit month_number égal à accès_mois de date_donnée dans
+  soit year_number égal à
+    si month_number < 3
+    alors accès_année de date_donnée - 1
+    sinon accès_année de date_donnée
+  dans
+  soit n_number égal à
+    selon (Liste.nième_élément de sakamoto_list, month_number) sous forme
+    -- Présent contenu n: n
+    -- Absent: impossible
+  dans
+  soit day_number égal à
+    (year_number
+     + entier de (year_number / 4)
+     - entier de (year_number / 100)
+     + entier de (year_number / 400)
+     + n_number
+     + accès_jour de date_donnée)
+    - 7 * entier de (
+      (year_number
+       + entier de (year_number / 4)
+       - entier de (year_number / 100)
+       + entier de (year_number / 400)
+       + n_number
+       + accès_jour de date_donnée)
+      / 7
+    )
+  dans
+  selon (Liste.nième_élément de weekdays, (day_number + 1)) sous forme
+  -- Présent contenu d: d
+  -- Absent: impossible
 ```
-
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition liste_Sakamoto
-  égal à (0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4)
-```
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition mois_nombre
-  égal à accès_mois de date_entrée
-```
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition année_nombre
-  égal à 
-    si mois_nombre < 3
-      alors accès_année de date_entrée - 1
-    sinon accès_année de date_entrée 
-```
-
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition n_nombre sous condition
-    mois_nombre = 1
-  conséquence égal à liste_Sakamoto.1
-  définition n_nombre sous condition
-    mois_nombre = 2
-  conséquence égal à liste_Sakamoto.2
-
-  définition n_nombre sous condition
-    mois_nombre = 3
-  conséquence égal à liste_Sakamoto.3
-
-  définition n_nombre sous condition
-    mois_nombre = 4
-  conséquence égal à liste_Sakamoto.4
-
-  définition n_nombre sous condition
-    mois_nombre = 5
-  conséquence égal à liste_Sakamoto.5
-
-  définition n_nombre sous condition
-    mois_nombre = 6
-  conséquence égal à liste_Sakamoto.6
-
-  définition n_nombre sous condition
-    mois_nombre = 7
-  conséquence égal à liste_Sakamoto.7
-
-  définition n_nombre sous condition
-    mois_nombre = 8
-  conséquence égal à liste_Sakamoto.8
-
-  définition n_nombre sous condition
-    mois_nombre = 9
-  conséquence égal à liste_Sakamoto.9
-
-  définition n_nombre sous condition
-    mois_nombre = 10
-  conséquence égal à liste_Sakamoto.10
-
-  définition n_nombre sous condition
-    mois_nombre = 11
-  conséquence égal à liste_Sakamoto.11
-
-  définition n_nombre sous condition
-    mois_nombre = 12
-  conséquence égal à liste_Sakamoto.12
-```
-
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition jour_nombre
-  égal à 
-    (année_nombre + entier de (année_nombre / 4) - entier de (année_nombre / 100) + entier de (année_nombre / 400) + n_nombre + accès_jour de date_entrée) 
-    - 7 * entier de ((année_nombre + entier de (année_nombre / 4) - entier de (année_nombre / 100) + entier de (année_nombre / 400) + n_nombre + accès_jour de date_entrée) /7)
-```
-
-```catala
-champ d'application Jour_de_la_semaine_depuis_date :
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 0
-  conséquence égal à Dimanche
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 1
-  conséquence égal à Lundi
-
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 2
-  conséquence égal à Mardi
-
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 3
-  conséquence égal à Mercredi
-
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 4
-  conséquence égal à Jeudi
-
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 5
-  conséquence égal à Vendredi
-
-  définition jour_de_la_semaine_depuis_date sous condition
-    jour_nombre = 6
-  conséquence égal à Samedi
-```
-

--- a/tests/attributes/good/debug_print.catala_en
+++ b/tests/attributes/good/debug_print.catala_en
@@ -23,6 +23,8 @@ $ catala interpret -s A --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/list_en.catala_en"
+[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
@@ -32,8 +34,6 @@ $ catala interpret -s A --debug
 [DEBUG] Parsing "libcatala/integer_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_internal.catala_en"
-[DEBUG] Parsing "libcatala/list_en.catala_en"
-[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] = DESUGARED =
 [DEBUG] Name resolution...
 [DEBUG] Desugaring...
@@ -44,9 +44,9 @@ $ catala interpret -s A --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
-  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
-  Decimal_internal Decimal_en List_internal List_en Stdlib_en
+[DEBUG] Loading shared modules... Date_internal List_internal List_en Date_en
+  Duration_en MonthYear_en Period_internal Period_en Money_internal Money_en
+  Integer_en Decimal_internal Decimal_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] 0 (at tests/attributes/good/debug_print.catala_en:9.38-9.47)
 [DEBUG] value of x = 0 (at tests/attributes/good/debug_print.catala_en:10.57-10.64)

--- a/tests/backends/python_enum.catala_en
+++ b/tests/backends/python_enum.catala_en
@@ -128,13 +128,13 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import List_en as list_en
 from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en
 from . import Integer_en as integer_en
 from . import Decimal_en as decimal_en
-from . import List_en as list_en
 
 class E_Code(Enum):
     AAAAAAA = 0

--- a/tests/backends/python_name_clash.catala_en
+++ b/tests/backends/python_name_clash.catala_en
@@ -26,13 +26,13 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import List_en as list_en
 from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en
 from . import Integer_en as integer_en
 from . import Decimal_en as decimal_en
-from . import List_en as list_en
 
 class SomeName:
     def __init__(self, o: Integer) -> None:

--- a/tests/backends/simple.catala_en
+++ b/tests/backends/simple.catala_en
@@ -39,13 +39,13 @@ $ catala c
 
 #include <Stdlib_en.h>
 #include <Date_en.h>
+#include <List_en.h>
 #include <Duration_en.h>
 #include <MonthYear_en.h>
 #include <Period_en.h>
 #include <Money_en.h>
 #include <Integer_en.h>
 #include <Decimal_en.h>
-#include <List_en.h>
 
 typedef struct Foo {
   CATALA_BOOL x;

--- a/tests/modules/good/mod_def.catala_en
+++ b/tests/modules/good/mod_def.catala_en
@@ -76,6 +76,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -111,12 +117,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module Mod_def = struct type t = Yes | No | Maybe end
 

--- a/tests/name_resolution/good/conflicts-module.catala_en
+++ b/tests/name_resolution/good/conflicts-module.catala_en
@@ -30,6 +30,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -65,12 +71,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module Closure_scoppe = struct
   type t = {scoppe: bool}
@@ -161,6 +161,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -196,12 +202,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module Closure_scoppe = struct
   type t = {scoppe: bool}

--- a/tests/name_resolution/good/conflicts.catala_en
+++ b/tests/name_resolution/good/conflicts.catala_en
@@ -143,6 +143,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -178,12 +184,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module Assert_in__1 = struct
   type t = {assert__1: integer}

--- a/tests/name_resolution/good/keywords.catala_en
+++ b/tests/name_resolution/good/keywords.catala_en
@@ -48,6 +48,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -83,12 +89,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module Stdlib__1 = struct
   type t = {when__1: date}

--- a/tests/name_resolution/good/let_in2.catala_en
+++ b/tests/name_resolution/good/let_in2.catala_en
@@ -54,6 +54,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -89,12 +95,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module S = struct
   type t = {a: bool}

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -110,6 +110,8 @@ $ catala scalc
 module stdlib_en = Stdlib_en
 module date_en = Date_en
 module date_internal = Date_internal
+module list_en = List_en
+module list_internal = List_internal
 module duration_en = Duration_en
 module month_year_en = MonthYear_en
 module period_en = Period_en
@@ -119,8 +121,6 @@ module money_internal = Money_internal
 module integer_en = Integer_en
 module decimal_en = Decimal_en
 module decimal_internal = Decimal_internal
-module list_en = List_en
-module list_internal = List_internal
 let glob1 = 44.12
 
 let glob3 (x: money) = return to_rat x + 10.
@@ -207,13 +207,13 @@ from typing import Any, List, Callable, Tuple
 from enum import Enum
 from . import Stdlib_en as stdlib_en
 from . import Date_en as date_en
+from . import List_en as list_en
 from . import Duration_en as duration_en
 from . import MonthYear_en as month_year_en
 from . import Period_en as period_en
 from . import Money_en as money_en
 from . import Integer_en as integer_en
 from . import Decimal_en as decimal_en
-from . import List_en as list_en
 
 class A:
     def __init__(self, y: bool, z: Decimal) -> None:

--- a/tests/scope/good/art191_fix_record_name_confusion.catala_en
+++ b/tests/scope/good/art191_fix_record_name_confusion.catala_en
@@ -49,6 +49,12 @@ let () =
   | Error h -> failwith "Hash mismatch for module Date_en, it may need recompiling"
 module Date_en = Date_en
 let () =
+  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
+    with
+  | Ok () -> ()
+  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
+module List_en = List_en
+let () =
   match Catala_runtime.check_module "Duration_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
     with
   | Ok () -> ()
@@ -84,12 +90,6 @@ let () =
   | Ok () -> ()
   | Error h -> failwith "Hash mismatch for module Decimal_en, it may need recompiling"
 module Decimal_en = Decimal_en
-let () =
-  match Catala_runtime.check_module "List_en" "CMX|XXXXXXXX|XXXXXXXX|XXXXXXXX"
-    with
-  | Ok () -> ()
-  | Error h -> failwith "Hash mismatch for module List_en, it may need recompiling"
-module List_en = List_en
 
 module ScopeA = struct
   type t = {a: bool}

--- a/tests/scope/good/scope_call2.catala_en
+++ b/tests/scope/good/scope_call2.catala_en
@@ -61,5 +61,5 @@ $ catala test-scope Titi
 
 ```catala-test-cli
 $ catala dependency-graph --disable-warnings
-{"intra_scopes":{"Toto":{"nodes":{"9":"foo","8":"bar"},"edges":[{"from":8,"to":9}]},"Titi":{"nodes":{"12":"toto","11":"fuzz","10":"fizz"},"edges":[]}},"inter_scopes":{"nodes":{"3":"Titi","2":"Toto"},"edges":[{"from":2,"to":3},{"from":2,"to":3},{"from":2,"to":3}]},"types":{"nodes":{"10":"Titi","8":"Toto","6":"Period_en.Period","5":"MonthYear_en.MonthYear","4":"Date_en.Day_of_the_of_given_date","980147805":"Date_en.Days","809014657":"MonthYear_en.Date_en.Month","9647113":"Optional"},"edges":[{"from":8,"to":10},{"from":8,"to":10},{"from":980147805,"to":4},{"from":809014657,"to":5}]}}
+{"intra_scopes":{"Toto":{"nodes":{"2":"foo","1":"bar"},"edges":[{"from":1,"to":2}]},"Titi":{"nodes":{"5":"toto","4":"fuzz","3":"fizz"},"edges":[]}},"inter_scopes":{"nodes":{"2":"Titi","1":"Toto"},"edges":[{"from":1,"to":2},{"from":1,"to":2},{"from":1,"to":2}]},"types":{"nodes":{"8":"Titi","6":"Toto","4":"Period_en.Period","3":"MonthYear_en.MonthYear","980147805":"Date_en.Day_of_week","809014657":"MonthYear_en.Date_en.Month","9647113":"Optional"},"edges":[{"from":6,"to":8},{"from":6,"to":8},{"from":809014657,"to":3}]}}
 ```

--- a/tests/scope/good/scope_call3.catala_en
+++ b/tests/scope/good/scope_call3.catala_en
@@ -37,6 +37,8 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/list_en.catala_en"
+[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
@@ -46,8 +48,6 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Parsing "libcatala/integer_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_internal.catala_en"
-[DEBUG] Parsing "libcatala/list_en.catala_en"
-[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] = DESUGARED =
 [DEBUG] Name resolution...
 [DEBUG] Desugaring...
@@ -58,9 +58,9 @@ $ catala Interpret -t -s HousingComputation --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
-  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
-  Decimal_internal Decimal_en List_internal List_en Stdlib_en
+[DEBUG] Loading shared modules... Date_internal List_internal List_en Date_en
+  Duration_en MonthYear_en Period_internal Period_en Money_internal Money_en
+  Integer_en Decimal_internal Decimal_en Stdlib_en
 [DEBUG] Starting interpretation...
 [LOG] ≔  HousingComputation.f: <object>
 [LOG] ☛ Definition applied:

--- a/tests/scope/good/scope_call4.catala_en
+++ b/tests/scope/good/scope_call4.catala_en
@@ -44,6 +44,8 @@ $ catala interpret -s RentComputation --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/list_en.catala_en"
+[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
@@ -53,8 +55,6 @@ $ catala interpret -s RentComputation --debug
 [DEBUG] Parsing "libcatala/integer_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_internal.catala_en"
-[DEBUG] Parsing "libcatala/list_en.catala_en"
-[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] = DESUGARED =
 [DEBUG] Name resolution...
 [DEBUG] Desugaring...
@@ -65,9 +65,9 @@ $ catala interpret -s RentComputation --debug
 [DEBUG] Typechecking...
 [DEBUG] Translating to default calculus...
 [DEBUG] Typechecking again...
-[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
-  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
-  Decimal_internal Decimal_en List_internal List_en Stdlib_en
+[DEBUG] Loading shared modules... Date_internal List_internal List_en Date_en
+  Duration_en MonthYear_en Period_internal Period_en Money_internal Money_en
+  Integer_en Decimal_internal Decimal_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] End of interpretation
 ┌─[RESULT]─ RentComputation ─
@@ -95,6 +95,8 @@ $ catala Interpret --lcalc -s RentComputation --optimize --debug
 [DEBUG] Parsing "libcatala/stdlib_en.catala_en"
 [DEBUG] Parsing "libcatala/date_en.catala_en"
 [DEBUG] Parsing "libcatala/date_internal.catala_en"
+[DEBUG] Parsing "libcatala/list_en.catala_en"
+[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] Parsing "libcatala/duration_en.catala_en"
 [DEBUG] Parsing "libcatala/monthyear_en.catala_en"
 [DEBUG] Parsing "libcatala/period_en.catala_en"
@@ -104,8 +106,6 @@ $ catala Interpret --lcalc -s RentComputation --optimize --debug
 [DEBUG] Parsing "libcatala/integer_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_en.catala_en"
 [DEBUG] Parsing "libcatala/decimal_internal.catala_en"
-[DEBUG] Parsing "libcatala/list_en.catala_en"
-[DEBUG] Parsing "libcatala/list_internal.catala_en"
 [DEBUG] = DESUGARED =
 [DEBUG] Name resolution...
 [DEBUG] Desugaring...
@@ -120,9 +120,9 @@ $ catala Interpret --lcalc -s RentComputation --optimize --debug
 [DEBUG] = LCALC =
 [DEBUG] Optimizing lambda calculus...
 [DEBUG] Retyping lambda calculus...
-[DEBUG] Loading shared modules... Date_internal Date_en Duration_en
-  MonthYear_en Period_internal Period_en Money_internal Money_en Integer_en
-  Decimal_internal Decimal_en List_internal List_en Stdlib_en
+[DEBUG] Loading shared modules... Date_internal List_internal List_en Date_en
+  Duration_en MonthYear_en Period_internal Period_en Money_internal Money_en
+  Integer_en Decimal_internal Decimal_en Stdlib_en
 [DEBUG] Starting interpretation...
 [DEBUG] End of interpretation
 ┌─[RESULT]─ RentComputation ─

--- a/tests/stdlib/date.catala_en
+++ b/tests/stdlib/date.catala_en
@@ -68,4 +68,10 @@ scope Tunit:
     Date.is_young_enough_rounding_up of |2000-06-01|, 24 year, |2024-06-15| = false
     and Date.is_young_enough_rounding_up of |2000-06-01|, 24 year, |2024-05-15| = true
     and Date.is_young_enough_rounding_up of |2000-01-31|, 1 month, |2000-02-29| = true
+
+  # day of week
+  assertion
+    Date.day_of_week of |2025-12-31| = Wednesday
+    and Date.day_of_week of |2026-01-01| = Thursday
+    and Date.day_of_week of |1930-09-11| = Thursday
 ```


### PR DESCRIPTION
The written implementation was a good example of proper Catala code, but in the case of the stdlib, we prefer functions over scopes. I gathered the existing code under a single function using local variables, and also switched from tuples to lists for dynamic access.

Added some tests as well.
