### PR TITLE
Carry over field positions to display helpful errors

### DIFF
--- a/compiler/catala_utils/uid.ml
+++ b/compiler/catala_utils/uid.ml
@@ -83,13 +83,19 @@ end
 (* - Raw idents - *)
 
 module MarkedString = struct
-  type info = string Mark.pos
+  module M = struct
+    type info = string Mark.pos
+    type t = info
 
-  let to_string (s, _) = s
-  let format fmt i = String.format fmt (to_string i)
-  let equal = Mark.equal String.equal
-  let compare = Mark.compare String.compare
-  let hash = Mark.hash String.hash
+    let to_string (s, _) = s
+    let format fmt i = String.format fmt (to_string i)
+    let equal = Mark.equal String.equal
+    let compare = Mark.compare String.compare
+    let hash = Mark.hash String.hash
+  end
+
+  include M
+  module Map = Map.Make (M)
 end
 
 module Gen (S : Style) () = Make (MarkedString) (S) ()

--- a/compiler/catala_utils/uid.mli
+++ b/compiler/catala_utils/uid.mli
@@ -33,10 +33,16 @@ module type Info = sig
   (** Hashing disregards position *)
 end
 
-module MarkedString : Info with type info = string Mark.pos
 (** The only kind of information carried in Catala identifiers is the original
     string of the identifier annotated with the position where it is declared or
     used. *)
+module MarkedString : sig
+  include Info with type info = string Mark.pos
+
+  type t = info
+
+  module Map : Map.S with type key = t
+end
 
 (** Identifiers have abstract types, but are comparable so they can be used as
     keys in maps or sets. Their underlying information can be retrieved at any

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -91,6 +91,7 @@ module LabelName =
 (** Used for unresolved structs/maps in desugared *)
 
 module Ident = String
+module MarkedIdent = Uid.MarkedString
 
 (** Only used by desugared/scopelang *)
 
@@ -606,13 +607,13 @@ and ('a, 'b, 'm) base_gexpr =
   | EDStructAmend : {
       name_opt : StructName.t option;
       e : ('a, 'm) gexpr;
-      fields : ('a, 'm) gexpr Ident.Map.t;
+      fields : ('a, 'm) gexpr MarkedIdent.Map.t;
     }
       -> ('a, < syntacticNames : yes ; .. >, 'm) base_gexpr
   | EDStructAccess : {
       name_opt : StructName.t option;
       e : ('a, 'm) gexpr;
-      field : Ident.t;
+      field : MarkedIdent.t;
     }
       -> ('a, < syntacticNames : yes ; .. >, 'm) base_gexpr
       (** [desugared] has ambiguous struct fields *)

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -134,13 +134,13 @@ val estruct :
 val edstructamend :
   name_opt:StructName.t option ->
   e:('a, 'm) boxed_gexpr ->
-  fields:('a, 'm) boxed_gexpr Ident.Map.t ->
+  fields:('a, 'm) boxed_gexpr MarkedIdent.Map.t ->
   'm mark ->
   ((< syntacticNames : yes ; .. > as 'a), 'm) boxed_gexpr
 
 val edstructaccess :
   name_opt:StructName.t option ->
-  field:Ident.t ->
+  field:MarkedIdent.t ->
   e:('a, 'm) boxed_gexpr ->
   'm mark ->
   ((< syntacticNames : yes ; .. > as 'a), 'm) boxed_gexpr

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -719,11 +719,11 @@ module ExprGen (C : EXPR_PARAM) = struct
       | ELocation loc -> location fmt loc
       | EDStructAccess { e; field; _ } ->
         Format.fprintf fmt "@[<hv 2>%a%a@,%a%a%a@]" (lhs exprc) e punctuation
-          "." punctuation "\"" Ident.format field punctuation "\""
+          "." punctuation "\"" MarkedIdent.format field punctuation "\""
       | EDStructAmend { e; fields; _ } ->
         Format.fprintf fmt "@[<hv 2>@[<hov>%a %a@ with@]@ %a@;<1 -2>%a@]"
           punctuation "{" (lhs exprc) e
-          (Ident.Map.format_bindings ~pp_sep:Format.pp_print_space
+          (MarkedIdent.Map.format_bindings ~pp_sep:Format.pp_print_space
              (fun fmt pp_field_name field_expr ->
                Format.fprintf fmt "@[<hv 2>%t %a@ %a%a@]" pp_field_name
                  punctuation "=" (lhs exprc) field_expr punctuation ";"))
@@ -1217,8 +1217,8 @@ let rec s_expr : type a. Format.formatter -> (a, 't) gexpr -> unit =
   let pf = fprintf in
   let pp_sep fmt () = pf fmt ",@ " in
   let ppl fmt l = pf fmt "@[<hov 2>[ %a ]@]" (pp_print_list ~pp_sep s_expr) l in
-  let pp_ident fmt (sf, e) =
-    pf fmt "@[<hov 1>%a: %a@]" Ident.format sf s_expr e
+  let pp_marked_id fmt (sf, e) =
+    pf fmt "@[<hov 1>%a: %a@]" MarkedIdent.format sf s_expr e
   in
   let pp_field fmt (sf, e) =
     pf fmt "@[<hov 1>%a: %a@]" StructField.format sf s_expr e
@@ -1282,14 +1282,14 @@ let rec s_expr : type a. Format.formatter -> (a, 't) gexpr -> unit =
       (pp_print_list ~pp_sep pp_arg)
       args
   | EDStructAmend { name_opt; e; fields } ->
-    let fields = Ident.Map.bindings fields in
+    let fields = MarkedIdent.Map.bindings fields in
     pf fmt "@[<hov 1>DStructAmend<%a>(%a, @[<hov 1>{ %a }@])@]"
       (pp_opt StructName.format) name_opt s_expr e
-      (pp_print_list ~pp_sep pp_ident)
+      (pp_print_list ~pp_sep pp_marked_id)
       fields
   | EDStructAccess { name_opt; e; field } ->
-    pf fmt "@[<hov 1>DStructAccess<%a>(%s, %a)@]" (pp_opt StructName.format)
-      name_opt field s_expr e
+    pf fmt "@[<hov 1>DStructAccess<%a>(%a, %a)@]" (pp_opt StructName.format)
+      name_opt MarkedIdent.format field s_expr e
   | EStructAccess { name; e; field } ->
     pf fmt "@[<hov 1>StructAccess<%a>(%a, %a)@]" StructName.format name
       StructField.format field s_expr e

--- a/tests/struct/bad/struct_duplicate.catala_en
+++ b/tests/struct/bad/struct_duplicate.catala_en
@@ -1,0 +1,33 @@
+```catala
+declaration structure Str:
+  data fld1 content integer
+  data fld2 content money
+  data fld3 content date
+
+declaration scope S:
+  internal s0 content Str
+  output s1 content Str
+
+scope S:
+  definition s0 equals
+    Str {
+      -- fld1: 0
+      -- fld2: $1
+      -- fld3: |2003-01-01|
+    }
+  definition s1 equals s0 but replace { -- fld1: 0 -- fld1: 2 }
+```
+
+```catala-test-cli
+$ catala test-scope S2
+┌─[ERROR]─
+│
+│  Duplicate redefinition of field fld1.
+│
+├─➤ tests/struct/bad/struct_duplicate.catala_en:18.55-18.59:
+│    │
+│ 18 │   definition s1 equals s0 but replace { -- fld1: 0 -- fld1: 2 }
+│    │                                                       ‾‾‾‾
+└─
+#return code 123#
+```

--- a/tests/struct/bad/struct_update.catala_en
+++ b/tests/struct/bad/struct_update.catala_en
@@ -24,10 +24,10 @@ $ catala test-scope S
 │
 │  Field flx1 does not belong to structure Str
 │
-├─➤ tests/struct/bad/struct_update.catala_en:17.60-17.62:
+├─➤ tests/struct/bad/struct_update.catala_en:17.54-17.58:
 │    │
 │ 17 │   definition s1 equals s0 but replace { --fld1: 0 -- flx1: 99 }
-│    │                                                            ‾‾
+│    │                                                      ‾‾‾‾
 │
 │ Declaration of structure Str
 ├─➤ tests/struct/bad/struct_update.catala_en:2.23-2.26:


### PR DESCRIPTION
This PR fixes the position of error messages related to struct replace constructions.

Fixes https://github.com/CatalaLang/catala-language-server/issues/197

