### PR TITLE
exceptions JSON: add law_heading breadcrumb to pos_to_json

### DIFF
--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -135,6 +135,8 @@ let pos_to_json (pos : Pos.t) : Yojson.Safe.t =
       "start_column", `Int (Pos.get_start_column pos);
       "end_line", `Int (Pos.get_end_line pos);
       "end_column", `Int (Pos.get_end_column pos);
+      ( "law_heading",
+        `List (List.map (fun s -> `String s) (Pos.get_law_info pos)) );
     ]
 
 let rec exception_tree_to_json (t : exception_tree) : Yojson.Safe.t =


### PR DESCRIPTION
This adds the law headings into the JSON representation of the exception tree, mainly so that we can have them in the vs code display.