### PR TITLE
Remove unused SubScopeVarDefinition

### DIFF
--- a/compiler/dcalc/from_scopelang.ml
+++ b/compiler/dcalc/from_scopelang.ml
@@ -591,19 +591,11 @@ let translate_rule
     'm Ast.expr scope_body_expr Bindlib.box)
     * 'm ctx =
   match rule with
-  | S.ScopeVarDefinition { var; typ; e; _ }
-  | S.SubScopeVarDefinition { var; typ; e; _ } ->
+  | S.ScopeVarDefinition { var; typ; e; io } ->
     let scope_var = Mark.remove var in
     let decl_pos = Expr.no_attrs_pos (Mark.get (ScopeVar.get_info scope_var)) in
     let pos_mark, _ = pos_mark_mk e in
-    let scope_let_kind, io =
-      match rule with
-      | S.ScopeVarDefinition { io; _ } -> ScopeVarDefinition, io
-      | S.SubScopeVarDefinition _ ->
-        ( SubScopeVarDefinition,
-          { io_input = NoInput, decl_pos; io_output = false, decl_pos } )
-      | S.Assertion _ -> assert false
-    in
+    let scope_let_kind = ScopeVarDefinition in
     let a_name = ScopeVar.get_info (Mark.remove var) in
     let a_var = Var.make (Mark.remove a_name) in
     let new_e = translate_expr ctx e in
@@ -771,10 +763,7 @@ let translate_scope_decl
          or not ? *)
       Message.error ~pos:pos_sigma "Scope %a has no content" ScopeName.format
         scope_name
-    | ( S.ScopeVarDefinition { e; _ }
-      | S.SubScopeVarDefinition { e; _ }
-      | S.Assertion { e; _ } )
-      :: _ ->
+    | (S.ScopeVarDefinition { e; _ } | S.Assertion { e; _ }) :: _ ->
       Expr.no_attrs (Mark.get e)
   in
   let scope_mark =

--- a/compiler/scopelang/ast.ml
+++ b/compiler/scopelang/ast.ml
@@ -45,12 +45,6 @@ type 'm rule =
       io : Desugared.Ast.io;
       e : 'm expr;
     }
-  | SubScopeVarDefinition of {
-      var : (ScopeVar.t, Pos.t list) Mark.ed;
-      var_within_origin_scope : ScopeVar.t;
-      typ : typ;
-      e : 'm expr;
-    }
   | Assertion of { e : 'm expr; pos : Pos.t }
 
 type scope_var_ty = {
@@ -80,9 +74,6 @@ let type_rule decl_ctx env = function
   | ScopeVarDefinition ({ typ; e; _ } as def) ->
     let e = Typing.expr decl_ctx ~env ~typ e in
     ScopeVarDefinition { def with e = Expr.unbox e }
-  | SubScopeVarDefinition ({ typ; e; _ } as def) ->
-    let e = Typing.expr decl_ctx ~env ~typ e in
-    SubScopeVarDefinition { def with e = Expr.unbox e }
   | Assertion { e; pos } ->
     let typ = Mark.add (Expr.pos e) (TLit TBool) in
     let e = Typing.expr decl_ctx ~env ~typ e in

--- a/compiler/scopelang/ast.mli
+++ b/compiler/scopelang/ast.mli
@@ -39,12 +39,6 @@ type 'm rule =
       io : Desugared.Ast.io;
       e : 'm expr;
     }
-  | SubScopeVarDefinition of {
-      var : ScopeVar.t * Pos.t list;  (** Variable within the current scope *)
-      var_within_origin_scope : ScopeVar.t;
-      typ : typ; (* non-thunked at this point for reentrant vars *)
-      e : 'm expr;
-    }
   | Assertion of { e : 'm expr; pos : Pos.t }
 
 type scope_var_ty = {

--- a/compiler/scopelang/dependency.ml
+++ b/compiler/scopelang/dependency.ml
@@ -110,9 +110,7 @@ let rec expr_used_defs modul e =
 let expr_used_defs e = expr_used_defs None e
 
 let rule_used_defs = function
-  | Ast.Assertion { e; _ }
-  | Ast.ScopeVarDefinition { e; _ }
-  | Ast.SubScopeVarDefinition { e; _ } ->
+  | Ast.Assertion { e; _ } | Ast.ScopeVarDefinition { e; _ } ->
     (* TODO: maybe this info could be passed on from previous passes without
        walking through all exprs again *)
     expr_used_defs e

--- a/compiler/scopelang/print.ml
+++ b/compiler/scopelang/print.ml
@@ -67,11 +67,6 @@ let scope ?debug fmt (name, (decl, _pos)) =
               Format.pp_print_space fmt ()
             | _ -> ())
           (Print.expr ?debug ()) e
-      | SubScopeVarDefinition { var; typ; e; _ } ->
-        Print.attrs fmt (Mark.get (ScopeVar.get_info (fst var)));
-        Format.fprintf fmt "@[<hov 2>%a %a %a %a %a@ %a@]" Print.keyword "let"
-          ScopeVar.format (Mark.remove var) Print.punctuation ":" Print.typ typ
-          Print.punctuation "=" (Print.expr ?debug ()) e
       | Assertion { e; _ } ->
         Format.fprintf fmt "%a %a" Print.keyword "assert" (Print.expr ?debug ())
           e)

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -691,9 +691,6 @@ type ('e, 'elt, 'last) bound_list =
 type scope_let_kind =
   | DestructuringInputStruct  (** [let x = input.field]*)
   | ScopeVarDefinition  (** [let x = error_on_empty e]*)
-  | SubScopeVarDefinition
-      (** [let s.x = fun _ -> e] or [let s.x = error_on_empty e] for input-only
-          subscope variables. *)
   | CallingSubScope  (** [let result = s ({ x = s.x; y = s.x; ...}) ]*)
   | DestructuringSubScopeResults  (** [let s.x = result.x ]**)
   | Assertion  (** [let () = assert e]*)

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -811,7 +811,6 @@ let scope_let_kind ?debug:(_debug = true) fmt k =
   match k with
   | DestructuringInputStruct -> keyword fmt "get"
   | ScopeVarDefinition -> keyword fmt "set"
-  | SubScopeVarDefinition -> keyword fmt "sub_set"
   | CallingSubScope -> keyword fmt "call"
   | DestructuringSubScopeResults -> keyword fmt "sub_get"
   | Assertion -> keyword fmt "assert"

--- a/compiler/verification/conditions.ml
+++ b/compiler/verification/conditions.ml
@@ -316,12 +316,9 @@ let rec generate_verification_conditions_scope_body_expr
             (Print.expr ()) e)
       | DestructuringInputStruct ->
         { ctx with input_vars = scope_let_var :: ctx.input_vars }, [], []
-      | ScopeVarDefinition | SubScopeVarDefinition ->
+      | ScopeVarDefinition ->
         (* For scope variables, we should check both that they never evaluate to
-           emptyError nor conflictError. But for subscope variable definitions,
-           what we're really doing is adding exceptions to something defined in
-           the subscope so we just ought to verify only that the exceptions
-           overlap. *)
+           emptyError nor conflictError. *)
         let e =
           Expr.unbox (Expr.remove_logging_calls scope_let.scope_let_expr)
         in


### PR DESCRIPTION
After digging a little with @vincent-botbol and @AltGr  we came to the conclusion that `SubScopeVarDefinition` is unused. 

This is a cleanup PR to remove it.
