### PR TITLE
clerk exceptions JSON: rename law_heading to law_headings, fix to outermost-first order

### DIFF
--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -135,8 +135,8 @@ let pos_to_json (pos : Pos.t) : Yojson.Safe.t =
       "start_column", `Int (Pos.get_start_column pos);
       "end_line", `Int (Pos.get_end_line pos);
       "end_column", `Int (Pos.get_end_column pos);
-      ( "law_heading",
-        `List (List.map (fun s -> `String s) (Pos.get_law_info pos)) );
+      ( "law_headings",
+        `List (List.rev_map (fun s -> `String s) (Pos.get_law_info pos)) );
     ]
 
 let rec exception_tree_to_json (t : exception_tree) : Yojson.Safe.t =


### PR DESCRIPTION
Since we don't yet have consumers for the `clerk exceptions` JSON, maybe it's the right time to fix the wrinkles

Rename `law_heading` to `law_headings` and reverse the order so that it's outermost-first (section > subsection > sub-sub-section)