### PR TITLE
Fix qualification of constructors after disambiguation

### DIFF
--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -264,10 +264,6 @@ let rec check_formula (op, pos_op) e =
     check_formula (op1, pos_op1) e2
   | _ -> ()
 
-(** Helper that restores surface positions in module paths. *)
-let restore_position path_item mname =
-  ModuleName.map_info (fun (mn, _) -> mn, Mark.get path_item) mname
-
 let translate_literal l pos =
   match l with
   | S.LNumber ((Int i, _), None) -> LInt (Runtime.integer_of_string i)
@@ -644,7 +640,8 @@ let rec translate_expr
         let uid = Name_resolution.get_scope ctxt id in
         (* Retain the correct positions *)
         ScopeName.map_info
-          (fun (_ml, pos) -> List.map2 restore_position path resolved_path, pos)
+          (fun (path1, pos) ->
+            (if resolved_path = [] then path1 else resolved_path), pos)
           uid
       in
       uid, ScopeName.Map.find uid ctxt.scopes
@@ -717,9 +714,9 @@ let rec translate_expr
       | Some (Name_resolution.TScope (_, { out_struct_name = s_uid; _ })) ->
         (* Retain the correct positions *)
         StructName.map_info
-          (fun (_, (s, _pos)) ->
-            let path = List.map2 restore_position path resolved_path in
-            path, (s, Mark.get s_name))
+          (fun (path1, (s, _pos)) ->
+            ( (if resolved_path = [] then path1 else resolved_path),
+              (s, Mark.get s_name) ))
           s_uid
       | _ ->
         Message.error ~pos:(Mark.get s_name)
@@ -812,9 +809,9 @@ let rec translate_expr
         let e_uid = Name_resolution.get_enum ctxt enum in
         (* Retain the correct positions *)
         EnumName.map_info
-          (fun (_, (x, _pos)) ->
-            let path = List.map2 restore_position path resolved_path in
-            path, (x, Mark.get enum))
+          (fun (path1, (x, _pos)) ->
+            ( (if resolved_path = [] then path1 else resolved_path),
+              (x, Mark.get enum) ))
           e_uid
       in
       try

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -313,11 +313,14 @@ let format_var_str (fmt : Format.formatter) (v : string) : unit =
 let format_var (fmt : Format.formatter) (v : 'm Var.t) : unit =
   format_var_str fmt (Bindlib.name_of v)
 
-let rec needs_parens (e : 'm expr) : bool =
+let rec needs_parens ?context (e : 'm expr) : bool =
   match Mark.remove e with
-  | EApp { f = EAbs { binder; _ }, _; _ } ->
-    let _, body = Bindlib.unmbind binder in
-    needs_parens body
+  | EApp { f = EAbs { binder; _ }, _; _ } -> (
+    match context with
+    | Some ((EInj _ | EArray _), _) -> true
+    | _ ->
+      let _, body = Bindlib.unmbind binder in
+      needs_parens ?context body)
   | ELit (LBool _ | LUnit)
   | EVar _ | ETuple _
   | EInj { e = ELit LUnit, _; _ }
@@ -328,9 +331,9 @@ let rec needs_parens (e : 'm expr) : bool =
 let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
     unit =
   let format_expr = format_expr ctx in
-  let format_with_parens (fmt : Format.formatter) (e : 'm expr) =
-    if needs_parens e then Format.fprintf fmt "(%a)" format_expr e
-    else format_expr fmt e
+  let format_with_parens (fmt : Format.formatter) (e1 : 'm expr) =
+    if needs_parens ~context:e e1 then Format.fprintf fmt "(%a)" format_expr e1
+    else format_expr fmt e1
   in
   match Mark.remove e with
   | EVar v -> Format.fprintf fmt "%a" format_var v
@@ -381,9 +384,6 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
   | EInj { e = ELit LUnit, _; cons; name } ->
     Format.fprintf fmt "@[<hov 2>%a.%a@]" format_to_module_name (`Ename name)
       format_enum_cons_name cons
-  | EInj { e = (EApp { f = EAbs _, _; _ }, _) as e; cons; name } ->
-    Format.fprintf fmt "@[<hov 2>%a.%a@ (%a)@]" format_to_module_name
-      (`Ename name) format_enum_cons_name cons format_expr e
   | EInj { e; cons; name } ->
     Format.fprintf fmt "@[<hov 2>%a.%a@ %a@]" format_to_module_name
       (`Ename name) format_enum_cons_name cons format_with_parens e

--- a/runtimes/ocaml/catala_runtime.ml
+++ b/runtimes/ocaml/catala_runtime.ml
@@ -322,15 +322,15 @@ module Value = struct
     | V (Tuple t1, v1), V (Tuple t2, v2) ->
       List.for_all2 (equal pos) (t1 v1) (t2 v2)
     | V (Struct str1, v1), V (Struct str2, v2) ->
-      (* str1.name = str2.name
-       * && *)
+      str1.name = str2.name
+      &&
       (* could be an assert if well-typed ? *)
       List.for_all2
         (fun (fld1, rv1) (fld2, rv2) -> fld1 = fld2 && equal pos rv1 rv2)
         (str1.fields v1) (str2.fields v2)
     | V (Enum en1, v1), V (Enum en2, v2) ->
-      (* en1.name = en2.name
-       * && *)
+      en1.name = en2.name
+      &&
       (* could be an assert if well-typed ? *)
       let n1, _, x1 = en1.constr v1 in
       let n2, _, x2 = en2.constr v2 in
@@ -533,8 +533,8 @@ module type ExternalTypeSpec = sig
       the left-hand side is respectively smaller, equal or greater than the
       right-hand side *)
 
-  (* val to_expr : t -> string (\** Must output a valid OCaml expression that
-     encodes the given value *\) *)
+  (* val to_expr : t -> string (** Must output a valid OCaml expression that
+     encodes the given value *) *)
 
   val print : t -> string
   (** User-directed printing of the value *)


### PR DESCRIPTION
This is the proper fix for b25a3d6.
Also includes a fix for parens in the OCaml printing.
(note: based upon #1013)