### PR TITLE
Clerk loop with clerk start when there are external module

### DIFF
--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1490,16 +1490,28 @@ let runtest_cmd =
 
 let start_cmd =
   let run config quiet (ninja_flags : string list) =
-    Clerk_rules.run_ninja ~code_coverage:false ~quiet ~config
-      ~enabled_backends:[OCaml] ~autotest:false ~ninja_flags (fun nin_ppf _ _ ->
-        Nj.format_def nin_ppf
-          (Nj.Default
-             (Nj.Default.make
-                [
-                  "@runtime-ocaml";
-                  "Stdlib_fr@ocaml-module";
-                  "Stdlib_en@ocaml-module";
-                ]));
+    let targets = config.Cli.options.targets in
+    let enabled_backends =
+      let open Clerk_config in
+      List.concat_map
+        (fun target -> List.map Clerk_rules.backend_from_config target.backends)
+        targets
+      |> List.sort_uniq compare
+    in
+    let default =
+      List.fold_left
+        (fun default_rules backend ->
+          let name = rules_backend backend |> string_of_backend in
+          let rule_stdlib_fr = Format.sprintf "Stdlib_fr@%s-module" name in
+          let rule_stdlib_en = Format.sprintf "Stdlib_en@%s-module" name in
+          let runtime_rule = Format.sprintf "@runtime-%s" name in
+          runtime_rule :: rule_stdlib_fr :: rule_stdlib_en :: default_rules)
+        ["Stdlib_fr@src"; "Stdlib_en@src"]
+        enabled_backends
+    in
+    Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet ~config
+      ~enabled_backends ~autotest:false ~ninja_flags (fun nin_ppf _ _ ->
+        Nj.format_def nin_ppf (Nj.Default (Nj.Default.make default));
         0)
   in
   let doc =

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -1043,6 +1043,7 @@ let with_ninja_process
     callback_ret
 
 let run_ninja
+    ?(include_dir = true)
     ~config
     ?(enabled_backends = all_backends)
     ~quiet
@@ -1063,8 +1064,9 @@ let run_ninja
       let stdlib_tree =
         Scan.tree stdlib_dir |> Seq.map (fun (f, fl, items) -> f, fl, items)
       in
+      let item_tree = if include_dir then Scan.tree "." else Seq.empty in
       let item_tree =
-        Scan.tree "."
+        item_tree
         |> Seq.filter_map (fun (f, fl, items) ->
             if insource && String.starts_with f ~prefix:"stdlib" then None
             else

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -30,6 +30,7 @@ val base_bindings :
   (Var.t * string list) list
 
 val run_ninja :
+  ?include_dir:bool ->
   config:Clerk_cli.config ->
   ?enabled_backends:backend list ->
   quiet:bool ->


### PR DESCRIPTION
When writing a catala project with an external module, I came across a loop in the error messages that was unexpected.
<img width="1752" height="863" alt="image" src="https://github.com/user-attachments/assets/72a6a8f9-e4b2-465e-986f-a39b139ea735" />

Using clerk build hints me to use catala gen external that hints me to use clerk start but I can't use clerk start as there is an external module. It's a loop that can be easily fixed by creating the external OCaml file but it's nicer if clerk start would work.

To do so instead of building the whole repo when using clerk start, we only build the stdlib (which is represented by the flag include dir). Also instead of force build the OCaml rules, I've made the code to build the backend specified by the targets. If there are two targets one in c and one in java, clerk start will build the stdlib for java and c.