### PR TITLE
Allow multiple bindings in match cases

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -393,7 +393,10 @@ module Content = struct
       List.iteri
         (fun i (c, bt) ->
           let header = Printf.sprintf "%d/%d" (succ i) len in
-          emit_raw ~ppf ~header c target;
+          (try emit_raw ~ppf ~header c target
+           with err ->
+             Format.fprintf ppf "@[<hov 4>failed to print:@ %a@]@,@."
+               Format.pp_print_text (Printexc.to_string err));
           if Global.options.debug then Printexc.print_raw_backtrace stderr bt)
         contents
 

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -413,37 +413,18 @@ let rec translate_expr
   in
   match Mark.remove expr with
   | Paren e -> rec_helper (Mark.set (Pos.join pos (Mark.get e)) e)
-  | Binop
-      ( (S.And, pos_op),
-        ( TestMatchCase (e1_sub, ((constructors, Some binding), pos_pattern)),
-          _pos_e1 ),
-        e2 ) ->
+  | Binop ((S.And, _), (TestMatchCase (e1_sub, pattern), pos_e1), e2) ->
     (* This sugar corresponds to [e is P x && e'] and should desugar to [match e
        with P x -> e' | _ -> false] *)
-    let enum_uid, c_uid =
-      disambiguate_constructor ctxt constructors pos_pattern
-    in
     let cases =
-      EnumConstructor.Map.mapi
-        (fun c_uid' tau ->
-          let tau = Type.unquantify tau in
-          if EnumConstructor.compare c_uid c_uid' <> 0 then
-            let nop_var = Var.make "_" in
-            Expr.make_ghost_abs [nop_var]
-              (Expr.elit (LBool false) emark)
-              [tau] pos_op
-          else
-            let binding_var = Var.make (Mark.remove binding) in
-            let local_vars =
-              Ident.Map.add (Mark.remove binding) binding_var local_vars
-            in
-            let e2 = rec_helper ~local_vars e2 in
-            Expr.make_abs
-              [Mark.add (Mark.get binding) binding_var]
-              e2 [tau] pos_op)
-        (fst (EnumName.Map.find enum_uid ctxt.enums))
+      [
+        ( S.MatchCase { match_case_pattern = pattern; match_case_expr = e2 },
+          Mark.get pattern );
+        ( S.WildCard (S.Literal (S.LBool false), Mark.get pattern),
+          Mark.get pattern );
+      ]
     in
-    Expr.ematch ~e:(rec_helper e1_sub) ~name:enum_uid ~cases emark
+    rec_helper (S.MatchWith (e1_sub, (cases, pos)), pos_e1)
   | Binop ((((S.And | S.Or | S.Xor), _) as op), e1, e2) ->
     check_formula op e1;
     check_formula op e2;
@@ -841,25 +822,23 @@ let rec translate_expr
     Expr.ematch ~e:e1 ~name:e_uid ~cases:cases_d emark
   | TestMatchCase (e1, pattern) ->
     (match snd (Mark.remove pattern) with
-    | None -> ()
-    | Some binding ->
+    | [] -> ()
+    | binding :: _ ->
       Message.warning ~pos:(Mark.get binding)
-        "This binding will be ignored (remove it to suppress warning).");
-    let enum_uid, c_uid =
-      disambiguate_constructor ctxt
-        (fst (Mark.remove pattern))
-        (Mark.get pattern)
-    in
+        "This binding will be ignored (remove it to suppress this warning).");
     let cases =
-      EnumConstructor.Map.mapi
-        (fun c_uid' tau ->
-          let nop_var = Var.make "_" in
-          Expr.make_ghost_abs [nop_var]
-            (Expr.elit (LBool (EnumConstructor.compare c_uid c_uid' = 0)) emark)
-            [tau] pos)
-        (fst (EnumName.Map.find enum_uid ctxt.enums))
+      [
+        ( S.MatchCase
+            {
+              match_case_pattern = pattern;
+              match_case_expr = S.Literal (S.LBool true), Mark.get pattern;
+            },
+          Mark.get pattern );
+        ( S.WildCard (S.Literal (S.LBool false), Mark.get pattern),
+          Mark.get pattern );
+      ]
     in
-    Expr.ematch ~e:(rec_helper e1) ~name:enum_uid ~cases emark
+    rec_helper (S.MatchWith (e1, (cases, pos)), pos)
   | ArrayLit es -> Expr.earray (List.map rec_helper es) emark
   | Tuple es -> Expr.etuple (List.map rec_helper es) emark
   | TupleAccess (e, n) ->
@@ -1210,10 +1189,45 @@ and disambiguate_match_and_build_expression
       EnumConstructor.Map.find c_uid
         (fst (EnumName.Map.find e_uid ctxt.Name_resolution.enums))
     in
-    (* [cell_type] may be quantified in the case of the option type. Here we need to use a specific instance *)
-    Expr.eabs e_binder pos_binder
-      [Type.unquantify cell_type]
-      (Mark.get case_body)
+    let nary_binder_to_tuple_function cell_type =
+      let payload_types =
+        match cell_type with TTuple tl, _ -> tl | t -> [t]
+      in
+      let m = Mark.get case_body in
+      let v = Var.make "payload" in
+      let body =
+        Expr.detuplify_application
+          [Expr.evar v m]
+          payload_types
+          (fun args ->
+            let body =
+              let args = Bindlib.box_list (List.map Mark.remove args) in
+              Bindlib.box_apply2
+                (fun bnd args ->
+                  Mark.remove (Bindlib.msubst bnd (Array.of_list args)))
+                e_binder args
+            in
+            body, m)
+      in
+      Expr.eabs
+        (Bindlib.bind_mvar [| v |] (Expr.Box.lift body))
+        [List.fold_left Pos.join Pos.void pos_binder]
+        [cell_type] m
+    in
+    let arity = List.length pos_binder in
+    match cell_type with
+    | TTuple tl, _ when arity > 1 && List.length tl = arity ->
+      (* Matching a n-uple payload to a n-ary function : we de-tuplify the payload to have a one-argument function as expected by the match construct *)
+      nary_binder_to_tuple_function cell_type
+    | TForAll _, _ when arity > 1 ->
+      assert (Type.is_universal cell_type);
+      (* Matching a polymorphic payload (ie we are in an option) to a n-ary function: we assume a n-uple and will let the typer validate it *)
+      nary_binder_to_tuple_function
+        ( TTuple (List.map Type.fresh_var pos_binder),
+          List.fold_left Pos.join Pos.void pos_binder )
+    | t ->
+      (* It's allowed to match the tuple into a single variable (TTuple but arity = 1). We will let the type-checker report the error in case of mismatch *)
+      Expr.eabs e_binder pos_binder [t] (Mark.get case_body)
   in
   let bind_match_cases (cases_d, e_uid, curr_index) (case, case_pos) =
     match case with
@@ -1227,7 +1241,7 @@ and disambiguate_match_and_build_expression
         match e_uid with
         | None -> e_uid'
         | Some e_uid ->
-          if e_uid = e_uid' then e_uid
+          if EnumName.equal e_uid e_uid' then e_uid
           else
             Message.error
               ~pos:(Mark.get case.S.match_case_pattern)
@@ -1243,18 +1257,21 @@ and disambiguate_match_and_build_expression
           ~extra_pos:["", Mark.get case.match_case_expr; "", Expr.pos e_case]
           "The constructor %a@ has@ been@ matched@ twice."
           EnumConstructor.format c_uid);
+      let binding = match binding with [] -> ["_", Pos.void] | bnd -> bnd in
       let local_vars, param_var =
-        create_var local_vars (Option.map Mark.remove binding)
+        List.fold_left_map
+          (fun local_vars b -> create_var local_vars (Some (Mark.remove b)))
+          local_vars binding
       in
       let case_body =
         translate_expr scope inside_definition_of ctxt local_vars
           case.S.match_case_expr
       in
-      let e_binder = Expr.bind [| param_var |] case_body in
+      let e_binder = Expr.bind (Array.of_list param_var) case_body in
       let pos_binder =
         match binding with
-        | None -> [Pos.void]
-        | Some binding -> [Mark.get binding]
+        | [] -> [Pos.void]
+        | binding -> List.map Mark.get binding
       in
       let case_expr =
         bind_case_body c_uid e_uid ctxt case_body e_binder pos_binder

--- a/compiler/desugared/from_surface.ml
+++ b/compiler/desugared/from_surface.ml
@@ -327,6 +327,7 @@ let rec translate_expr
     (inside_definition_of : Ast.ScopeDef.t Mark.pos option)
     (ctxt : Name_resolution.context)
     (local_vars : Ast.expr Var.t Ident.Map.t)
+    ?(no_wildcard_warning = false)
     (expr : S.expression) : Ast.expr boxed =
   let pos = Name_resolution.(translate_pos (Expression expr) (Mark.get expr)) in
   let emark = Untyped { pos } in
@@ -337,8 +338,9 @@ let rec translate_expr
     | None -> Ident.Map.empty
     | Some s -> (ScopeName.Map.find s ctxt.scopes).var_idmap
   in
-  let rec_helper ?(local_vars = local_vars) e =
-    translate_expr scope inside_definition_of ctxt local_vars e
+  let rec_helper ?(local_vars = local_vars) ?no_wildcard_warning e =
+    translate_expr scope inside_definition_of ctxt local_vars
+      ?no_wildcard_warning e
   in
   let rec detuplify_list opos names = function
     (* Where a list is expected (e.g. after [among]), as syntactic sugar, if a
@@ -424,7 +426,8 @@ let rec translate_expr
           Mark.get pattern );
       ]
     in
-    rec_helper (S.MatchWith (e1_sub, (cases, pos)), pos_e1)
+    rec_helper ~no_wildcard_warning:true
+      (S.MatchWith (e1_sub, (cases, pos)), pos_e1)
   | Binop ((((S.And | S.Or | S.Xor), _) as op), e1, e2) ->
     check_formula op e1;
     check_formula op e2;
@@ -817,7 +820,7 @@ let rec translate_expr
     let e1 = rec_helper e1 in
     let cases_d, e_uid =
       disambiguate_match_and_build_expression scope inside_definition_of ctxt
-        local_vars cases
+        local_vars ~no_wildcard_warning cases
     in
     Expr.ematch ~e:e1 ~name:e_uid ~cases:cases_d emark
   | TestMatchCase (e1, pattern) ->
@@ -838,7 +841,7 @@ let rec translate_expr
           Mark.get pattern );
       ]
     in
-    rec_helper (S.MatchWith (e1, (cases, pos)), pos)
+    rec_helper ~no_wildcard_warning:true (S.MatchWith (e1, (cases, pos)), pos)
   | ArrayLit es -> Expr.earray (List.map rec_helper es) emark
   | Tuple es -> Expr.etuple (List.map rec_helper es) emark
   | TupleAccess (e, n) ->
@@ -1170,6 +1173,7 @@ and disambiguate_match_and_build_expression
     (inside_definition_of : Ast.ScopeDef.t Mark.pos option)
     (ctxt : Name_resolution.context)
     (local_vars : Ast.expr Var.t Ident.Map.t)
+    ?(no_wildcard_warning = false)
     (cases : S.match_case Mark.pos list) :
     Ast.expr boxed EnumConstructor.Map.t * EnumName.t =
   let create_var local_vars = function
@@ -1216,8 +1220,14 @@ and disambiguate_match_and_build_expression
     in
     let arity = List.length pos_binder in
     match cell_type with
-    | TTuple tl, _ when arity > 1 && List.length tl = arity ->
+    | TTuple tl, _ when arity > 1 ->
       (* Matching a n-uple payload to a n-ary function : we de-tuplify the payload to have a one-argument function as expected by the match construct *)
+      if List.length tl <> arity then
+        Message.error
+          ~pos:(List.fold_left Pos.join Pos.void pos_binder)
+          "This pattern has %d arguments, while %d are expected by \
+           constructor@ %a."
+          arity (List.length tl) EnumConstructor.format c_uid;
       nary_binder_to_tuple_function cell_type
     | TForAll _, _ when arity > 1 ->
       assert (Type.is_universal cell_type);
@@ -1308,7 +1318,10 @@ and disambiguate_match_and_build_expression
               | Some _ -> None
               | None -> Some c_uid)
         in
-        if EnumConstructor.Map.is_empty missing_constructors then
+        if
+          EnumConstructor.Map.is_empty missing_constructors
+          && not no_wildcard_warning
+        then
           Message.warning ~pos:case_pos
             "Unreachable match case, all constructors of the enumeration@ %a@ \
              are@ already@ specified."

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -771,7 +771,8 @@ let rec evaluate_expr : type d r.
         evaluate_expr ctx lang
           (Bindlib.msubst binder (Array.of_list (List.map Mark.remove args)))
       else
-        Message.error ~pos "wrong function call, expected %d arguments, got %d"
+        Message.error ~internal:true ~pos
+          "Bad function call, expected %d arguments, got %d"
           (Bindlib.mbinder_arity binder)
           (List.length args)
     | ECustom { obj; targs; tret } ->
@@ -854,9 +855,8 @@ let rec evaluate_expr : type d r.
     match evaluate_expr ctx lang e1 with
     | ETuple es, _ when List.length es = size -> List.nth es index
     | e ->
-      Message.error ~pos:(Expr.pos e)
-        "The expression %a@ was@ expected@ to@ be@ a@ tuple@ of@ size@ %d@ \
-         (should not happen if the term was well-typed)"
+      Message.error ~internal:true ~pos:(Expr.pos e)
+        "The expression %a@ was@ expected@ to@ be@ a@ tuple@ of@ size@ %d"
         (Print.UserFacing.expr lang)
         e size)
   | EInj { e; name; cons } ->
@@ -874,23 +874,20 @@ let rec evaluate_expr : type d r.
     match Mark.remove e with
     | EInj { e = e1; cons; name = name' } ->
       if not (EnumName.equal name name') then
-        Message.error
+        Message.error ~internal:true
           ~extra_pos:["", Expr.pos e; "", Expr.pos e1]
           "%a" Format.pp_print_text
-          "Error during match: two different enums found (should not happen if \
-           the term was well-typed)";
-      let es_n =
+          "Error during match: two different enums found";
+      let f, tys =
         match EnumConstructor.Map.find_opt cons cases with
-        | Some es_n -> es_n
-        | None ->
-          Message.error ~pos:(Expr.pos e) "%a" Format.pp_print_text
-            "sum type index error (should not happen if the term was \
-             well-typed)"
+        | Some ((EAbs { tys; _ }, _) as f) -> f, tys
+        | _ ->
+          Message.error ~internal:true ~pos:(Expr.pos e) "Match branch error"
       in
-      let ty =
-        EnumConstructor.Map.find cons (EnumName.Map.find name ctx.ctx_enums)
+      let args =
+        match tys, e1 with _ :: _ :: _, (ETuple args, _) -> args | _, e -> [e]
       in
-      let new_e = Mark.add m (EApp { f = es_n; args = [e1]; tys = [ty] }) in
+      let new_e = Mark.add m (EApp { f; args; tys }) in
       evaluate_expr ctx lang new_e
     | _ ->
       Message.error ~pos:(Expr.pos e)

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -46,7 +46,7 @@ let rec colors =
   blue :: cyan :: green :: yellow :: red :: magenta :: colors
 
 let keyword (fmt : Format.formatter) (s : string) : unit =
-  pp_color_string Ocolor_types.red fmt s
+  pp_color_string Ocolor_types.hi_magenta fmt s
 
 let base_type (fmt : Format.formatter) (s : string) : unit =
   pp_color_string Ocolor_types.yellow fmt s
@@ -589,7 +589,13 @@ module ExprGen (C : EXPR_PARAM) = struct
       | EAbs { binder; pos = _; tys } ->
         let xs, body, bnd_ctx = Bindlib.unmbind_in bnd_ctx binder in
         let expr = exprb bnd_ctx in
-        let xs_tau = List.mapi (fun i tau -> xs.(i), tau) tys in
+        let xs_tau =
+          List.mapi
+            (fun i tau ->
+              ( (if i < Array.length xs then xs.(i) else Var.make "[MISSING ARG]"),
+                tau ))
+            tys
+        in
         Format.fprintf fmt "@[<hv 0>%a @[<hv 2>%a@]@ @]%a@ %a" punctuation "λ"
           (Format.pp_print_list ~pp_sep:Format.pp_print_space
              (fun fmt (x, tau) ->

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -785,7 +785,13 @@ and typecheck_expr_top_down : type a m.
     let cases =
       EnumConstructor.Map.mapi
         (fun c_name e ->
-          let c_ty = EnumConstructor.Map.find c_name cases_ty in
+          let c_ty = get_ty env e (EnumConstructor.Map.find c_name cases_ty) in
+          let e =
+            match e with
+            | EAbs ({ tys = [ty]; _ } as abs), m ->
+              EAbs { abs with tys = [union env e c_ty ty] }, m
+            | _ -> assert false
+          in
           let e_ty = TArrow ([c_ty], t_ret), Expr.pos e in
           typecheck_expr_top_down ctx env e_ty e)
         cases
@@ -800,9 +806,6 @@ and typecheck_expr_top_down : type a m.
       EnumConstructor.Map.mapi
         (fun c_name e ->
           let c_ty = EnumConstructor.Map.find c_name cases_ty in
-          (* For now our constructors are limited to zero or one argument. If
-             there is a change to allow for multiple arguments, it might be
-             easier to use tuples directly. *)
           let e_ty = TArrow ([c_ty], t_ret), Expr.pos e in
           typecheck_expr_top_down ctx env e_ty e)
         cases

--- a/compiler/surface/ast.mli
+++ b/compiler/surface/ast.mli
@@ -84,7 +84,7 @@ type enum_decl = {
   enum_decl_cases : enum_decl_case Mark.pos list;
 }
 
-type match_case_pattern = enum_constr Mark.pos list * lident Mark.pos option
+type match_case_pattern = enum_constr Mark.pos list * lident Mark.pos list
 type op_kind = KPoly | KInt | KDec | KMoney | KDate | KDuration
 
 type binop =

--- a/compiler/surface/parser.messages
+++ b/compiler/surface/parser.messages
@@ -13,7 +13,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 810.
+## Ends in an error in state: 814.
 ##
 ## option(preceded(CONTENT,posattr(typ))) -> CONTENT . list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -25,7 +25,7 @@ expected a content type
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT UIDENT YEAR
 ##
-## Ends in an error in state: 809.
+## Ends in an error in state: 813.
 ##
 ## enum_decl_line -> ALT UIDENT . option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -37,7 +37,7 @@ expected a payload for your enum case, or another case or declaration
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT COLON ALT YEAR
 ##
-## Ends in an error in state: 808.
+## Ends in an error in state: 812.
 ##
 ## enum_decl_line -> ALT . UIDENT option(preceded(CONTENT,posattr(typ))) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ALT ]
 ##
@@ -49,7 +49,7 @@ expected the name of an enum case
 
 source_file: BEGIN_CODE DECLARATION ENUM UIDENT YEAR
 ##
-## Ends in an error in state: 805.
+## Ends in an error in state: 809.
 ##
 ## code_item -> DECLARATION ENUM UIDENT . COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -61,7 +61,7 @@ expected a colon
 
 source_file: BEGIN_CODE DECLARATION ENUM YEAR
 ##
-## Ends in an error in state: 804.
+## Ends in an error in state: 808.
 ##
 ## code_item -> DECLARATION ENUM . UIDENT COLON rev_list_with_attr(enum_decl_line) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -73,7 +73,7 @@ expected the name of your enum
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON YEAR
 ##
-## Ends in an error in state: 616.
+## Ends in an error in state: 620.
 ##
 ## code_item -> DECLARATION SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(scope_decl_item) -> rev_list_with_attr(scope_decl_item) . attribute [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -87,7 +87,7 @@ expected a context item introduced by "context"
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT YEAR
 ##
-## Ends in an error in state: 614.
+## Ends in an error in state: 618.
 ##
 ## code_item -> DECLARATION SCOPE UIDENT . COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -99,7 +99,7 @@ expected a colon followed by the list of context items of this scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE YEAR
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 617.
 ##
 ## code_item -> DECLARATION SCOPE . UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -113,7 +113,7 @@ expected the name of the scope you are declaring
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 599.
+## Ends in an error in state: 603.
 ##
 ## struct_scope -> struct_scope_base DEPENDS . separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -126,7 +126,7 @@ expected the type of the parameter of this struct data function
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION LIDENT YEAR
 ##
-## Ends in an error in state: 598.
+## Ends in an error in state: 602.
 ##
 ## struct_scope -> struct_scope_base . DEPENDS separated_nonempty_list(COMMA,var_content) [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
 ## struct_scope -> struct_scope_base . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -140,7 +140,7 @@ expected a new struct data, or another declaration or scope use
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON CONDITION YEAR
 ##
-## Ends in an error in state: 596.
+## Ends in an error in state: 600.
 ##
 ## struct_scope_base -> CONDITION . lident [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -152,7 +152,7 @@ expected the name of this struct condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 579.
+## Ends in an error in state: 583.
 ##
 ## struct_scope_base -> DATA lident CONTENT . list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -164,7 +164,7 @@ expected the type of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA LIDENT YEAR
 ##
-## Ends in an error in state: 578.
+## Ends in an error in state: 582.
 ##
 ## struct_scope_base -> DATA lident . CONTENT list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -176,7 +176,7 @@ expected the type of this struct data, introduced by the content keyword
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON DATA YEAR
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 581.
 ##
 ## struct_scope_base -> DATA . lident CONTENT list(attribute) typ_data [ SCOPE END_CODE DOCSTRING DEPENDS DECLARATION DATA CONDITION ATTR_START ]
 ##
@@ -188,7 +188,7 @@ expected the name of this struct data
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 576.
+## Ends in an error in state: 580.
 ##
 ## code_item -> DECLARATION STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(struct_scope) -> rev_list_with_attr(struct_scope) . attribute [ SCOPE END_CODE DOCSTRING DECLARATION DATA CONDITION ATTR_START ]
@@ -202,7 +202,7 @@ expected struct data or condition
 
 source_file: BEGIN_CODE DECLARATION STRUCT UIDENT YEAR
 ##
-## Ends in an error in state: 574.
+## Ends in an error in state: 578.
 ##
 ## code_item -> DECLARATION STRUCT list(attribute) UIDENT . COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -214,7 +214,7 @@ expected a colon
 
 source_file: BEGIN_CODE DECLARATION STRUCT YEAR
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 576.
 ##
 ## code_item -> DECLARATION STRUCT . list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -226,7 +226,7 @@ expected the struct name
 
 source_file: BEGIN_CODE DECLARATION YEAR
 ##
-## Ends in an error in state: 567.
+## Ends in an error in state: 571.
 ##
 ## code_item -> DECLARATION . STRUCT list(attribute) UIDENT COLON rev_list_with_attr(struct_scope) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION . SCOPE UIDENT COLON rev_list_with_attr(scope_decl_item) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -244,7 +244,7 @@ expected the kind of the declaration (struct, scope or enum)
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION LIDENT THEN
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 564.
 ##
 ## assertion -> ASSERTION list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
@@ -283,7 +283,7 @@ expected a new scope use item
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION TRUE THEN
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 452.
 ##
 ## condition_consequence -> UNDER_CONDITION list(attribute) noattr_expression . CONSEQUENCE [ NOT FILLED DEFINED_AS ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS CONSEQUENCE BUT_REPLACE AND ]
@@ -315,7 +315,7 @@ expected a consequence for this definition under condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION YEAR
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 450.
 ##
 ## condition_consequence -> UNDER_CONDITION . list(attribute) noattr_expression CONSEQUENCE [ NOT FILLED DEFINED_AS ]
 ##
@@ -327,7 +327,7 @@ expected an expression for this condition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON ASSERTION YEAR
 ##
-## Ends in an error in state: 558.
+## Ends in an error in state: 562.
 ##
 ## assertion -> ASSERTION . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -339,7 +339,7 @@ expected an expression that shoud be asserted during execution
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 554.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS . list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -351,7 +351,7 @@ expected an expression for the definition
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT OF LIDENT DECREASING
 ##
-## Ends in an error in state: 459.
+## Ends in an error in state: 463.
 ##
 ## separated_nonempty_list(COMMA,lident) -> lident . [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ## separated_nonempty_list(COMMA,lident) -> lident . COMMA separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
@@ -364,7 +364,7 @@ expected an expression for defining this function, introduced by the 'equals' ke
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION YEAR
 ##
-## Ends in an error in state: 545.
+## Ends in an error in state: 549.
 ##
 ## definition -> DEFINITION . separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -376,7 +376,7 @@ expected the name of the variable you want to define
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION LIDENT YEAR
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 533.
 ##
 ## definition -> EXCEPTION lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## rule -> EXCEPTION lident . RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -389,7 +389,7 @@ expected a rule or a definition after the exception declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON EXCEPTION YEAR
 ##
-## Ends in an error in state: 513.
+## Ends in an error in state: 517.
 ##
 ## definition -> EXCEPTION . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> EXCEPTION . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -404,7 +404,7 @@ expected the label to which the exception is referring back
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL LIDENT DEFINED_AS
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 468.
 ##
 ## definition -> LABEL lident . DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> LABEL lident . EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -421,7 +421,7 @@ expected a rule or a definition after the label declaration
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON LABEL YEAR
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 467.
 ##
 ## definition -> LABEL . lident DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## definition -> LABEL . lident EXCEPTION DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -438,7 +438,7 @@ expected the name of the label
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT DOT YEAR
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 442.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT DOT . separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
 ##
@@ -450,7 +450,7 @@ expected a struct field or a sub-scope context item after the dot
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT NOT FALSE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 455.
 ##
 ## rule_consequence -> NOT . FILLED [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -462,7 +462,7 @@ expected the filled keyword the this rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT OF YEAR
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 461.
 ##
 ## definition_parameters -> OF . separated_nonempty_list(COMMA,lident) [ UNDER_CONDITION STATE NOT FILLED DEFINED_AS ]
 ##
@@ -474,7 +474,7 @@ expected the name of the parameter for this dependent variable
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT YEAR
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 441.
 ##
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
 ## separated_nonempty_list(DOT,addpos(LIDENT)) -> LIDENT . DOT separated_nonempty_list(DOT,addpos(LIDENT)) [ UNDER_CONDITION STATE OF NOT FILLED DOCSTRING DEFINED_AS ATTR_START ]
@@ -487,7 +487,7 @@ expected 'under condition' followed by a condition, 'equals' followed by the def
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE YEAR
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 439.
 ##
 ## rule -> RULE . list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -499,7 +499,7 @@ expected the name of the variable subject to the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON YEAR
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 438.
 ##
 ## code_item -> SCOPE UIDENT option(preceded(UNDER_CONDITION,expression)) COLON rev_list_with_attr(scope_item) . [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(scope_item) -> rev_list_with_attr(scope_item) . attribute [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
@@ -530,7 +530,7 @@ expected a payload for the enum case constructor, or the rest of the expression 
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT YEAR
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 316.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident . AMONG list(attribute) noattr_expression SUCH THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -555,7 +555,7 @@ expected an identifier that will designate the existential witness for the test
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT YEAR
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 329.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident . AMONG list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -593,7 +593,7 @@ expected the "all" keyword to mean the "for all" construction of the universal t
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF TRUE SEMICOLON
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 336.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH THEN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -637,7 +637,7 @@ expected an expression for the test of the conditional
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION INT_LITERAL WITH_V
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 435.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COLON BUT_REPLACE AND ]
@@ -677,7 +677,7 @@ expected a unit for this literal, or a valid operator to complete the expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LPAREN TRUE THEN
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 372.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RPAREN PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS COMMA BUT_REPLACE AND ]
@@ -722,7 +722,7 @@ expected an expression inside the parenthesis
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET TRUE THEN
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 343.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SEMICOLON RBRACKET PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -767,7 +767,7 @@ expected a list element
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH ALT YEAR
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 403.
 ##
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## nonempty_list(addpos(preceded(ALT,match_arm))) -> ALT . match_arm nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -780,7 +780,7 @@ expected the name of the constructor for the enum case in the pattern matching
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH TRUE WITH YEAR
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 402.
 ##
 ## noattr_expression -> noattr_expression WITH . constructor_binding [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> MATCH list(attribute) noattr_expression WITH . nonempty_list(addpos(preceded(ALT,match_arm))) [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -841,7 +841,7 @@ expected the name of the scope being used
 
 source_file: BEGIN_CODE YEAR
 ##
-## Ends in an error in state: 854.
+## Ends in an error in state: 858.
 ##
 ## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . attribute [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## rev_list_with_attr(code_item) -> rev_list_with_attr(code_item) . code_item [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -906,8 +906,8 @@ source_file: BEGIN_METADATA LAW_TEXT LAW_HEADING
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 1, spurious reduction of production nonempty_list(LAW_TEXT) -> LAW_TEXT
-## In state 832, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
-## In state 833, spurious reduction of production option(law_text) -> law_text
+## In state 836, spurious reduction of production law_text -> nonempty_list(LAW_TEXT)
+## In state 837, spurious reduction of production option(law_text) -> law_text
 ## In state 6, spurious reduction of production rev_list_with_attr(code_item) ->
 ##
 
@@ -1203,7 +1203,7 @@ expected 'var equals expression' after 'let'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS YEAR
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 352.
 ##
 ## noattr_expression -> LET list(attribute) lident DEFINED_AS . list(attribute) noattr_expression IN list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1215,7 +1215,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG YEAR
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 330.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident AMONG . list(attribute) noattr_expression WE_HAVE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1340,7 +1340,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 319.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SUCH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1372,7 +1372,7 @@ expected 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH YEAR
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 320.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH . THAT list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1384,7 +1384,7 @@ expected the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT YEAR
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 321.
 ##
 ## noattr_expression -> EXISTS list(attribute) lident AMONG list(attribute) noattr_expression SUCH THAT . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1396,7 +1396,7 @@ expected an expression, following the form 'such that <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION EXISTS LIDENT AMONG UIDENT SUCH THAT FALSE YEAR
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 323.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1428,7 +1428,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG FALSE YEAR
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 332.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH WE_HAVE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1460,7 +1460,7 @@ expected 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE YEAR
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 333.
 ##
 ## noattr_expression -> FOR ALL list(attribute) lident AMONG list(attribute) noattr_expression WE_HAVE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1472,7 +1472,7 @@ expected the form 'we have <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION FOR ALL LIDENT AMONG UIDENT WE_HAVE FALSE YEAR
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 335.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1504,7 +1504,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN YEAR
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 337.
 ##
 ## noattr_expression -> IF list(attribute) noattr_expression THEN . list(attribute) noattr_expression ELSE list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1516,7 +1516,7 @@ expected an expression, followed by 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN FALSE YEAR
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 339.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL ELSE DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1548,7 +1548,7 @@ expected 'else <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE YEAR
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 340.
 ##
 ## noattr_expression -> IF list(attribute) noattr_expression THEN list(attribute) noattr_expression ELSE . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1560,7 +1560,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION IF UIDENT THEN UIDENT ELSE FALSE YEAR
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 342.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1592,7 +1592,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LBRACKET UIDENT SEMICOLON YEAR
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 344.
 ##
 ## separated_nonempty_list(SEMICOLON,expression) -> list(attribute) noattr_expression SEMICOLON . separated_nonempty_list(SEMICOLON,expression) [ RBRACKET ]
 ##
@@ -1604,7 +1604,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 354.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER IN GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1636,7 +1636,7 @@ expected the keyword 'in'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN YEAR
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 355.
 ##
 ## noattr_expression -> LET list(attribute) lident DEFINED_AS list(attribute) noattr_expression IN . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1648,7 +1648,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION LET LIDENT DEFINED_AS UIDENT IN FALSE YEAR
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 357.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1680,7 +1680,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH FALSE YEAR
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 401.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ]
@@ -1712,7 +1712,7 @@ expected 'with pattern -- <pattern> : <expression> ...'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD YEAR
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 404.
 ##
 ## match_arm -> WILDCARD . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1724,7 +1724,7 @@ expected ':' followed by an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON YEAR
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 405.
 ##
 ## match_arm -> WILDCARD COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1736,7 +1736,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT WILDCARD COLON FALSE YEAR
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 407.
 ##
 ## match_arm -> WILDCARD COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1768,7 +1768,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT XOR
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 410.
 ##
 ## match_arm -> constructor_binding . COLON list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1787,7 +1787,7 @@ expected a colon followed by an expression, as in '-- Case : <expression>'
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON YEAR
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 411.
 ##
 ## match_arm -> constructor_binding COLON . list(attribute) noattr_expression [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ##
@@ -1799,7 +1799,7 @@ expected an expression
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MATCH UIDENT WITH ALT UIDENT COLON FALSE YEAR
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 413.
 ##
 ## match_arm -> constructor_binding COLON list(attribute) noattr_expression . [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1831,7 +1831,7 @@ expected a binary operator, or the next case in the form '-- NextCase : <express
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION MINUS FALSE YEAR
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 425.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1863,7 +1863,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION NOT FALSE YEAR
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 426.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1895,7 +1895,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION UIDENT LBRACE ALT LIDENT COLON FALSE YEAR
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 427.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH RBRACE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL DOT DIV CONTAINS BUT_REPLACE AND ALT ]
@@ -1927,7 +1927,7 @@ expected another field in the form '-- <var>: <expression>', or a closing '}' br
 
 source_file: BEGIN_CODE SCOPE UIDENT UNDER_CONDITION SUM UIDENT OF FALSE YEAR
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 430.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH_V WITH WE_HAVE TO THEN SUCH SEMICOLON SCOPE RULE RPAREN RBRACKET RBRACE PLUSPLUS PLUS OR_IF_LIST_EMPTY OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL IS IN GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE ELSE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS CONSEQUENCE COMMA COLON BUT_REPLACE ATTR_START ASSERTION AND ALT ]
@@ -1959,7 +1959,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 454.
 ##
 ## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) option(condition_consequence) . rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -1971,7 +1971,7 @@ expected either 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE YEAR
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 446.
 ##
 ## state -> STATE . lident [ UNDER_CONDITION SUM STATE SCOPE OUTPUT NOT LIDENT INTERNAL INPUT FILLED END_CODE DOCSTRING DEFINED_AS DECLARATION CONTEXT ATTR_START ]
 ##
@@ -1983,7 +1983,7 @@ expected an identifier defining the name of the state
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON RULE LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 449.
 ##
 ## rule -> RULE list(attribute) separated_nonempty_list(DOT,addpos(LIDENT)) option(posattr(definition_parameters)) option(state) . option(condition_consequence) rule_consequence [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -1995,7 +1995,7 @@ expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT STATE LIDENT YEAR
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 552.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) . option(condition_consequence) DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -2007,7 +2007,7 @@ expected 'equals' then an expression defining the rule
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT UNDER_CONDITION UIDENT CONSEQUENCE YEAR
 ##
-## Ends in an error in state: 549.
+## Ends in an error in state: 553.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) . DEFINED_AS list(attribute) noattr_expression [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ##
@@ -2019,7 +2019,7 @@ expected 'fulfilled' or 'not fulfilled'
 
 source_file: BEGIN_CODE SCOPE UIDENT COLON DEFINITION LIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 552.
+## Ends in an error in state: 556.
 ##
 ## definition -> DEFINITION separated_nonempty_list(DOT,addpos(LIDENT)) option(addpos(definition_parameters)) option(state) option(condition_consequence) DEFINED_AS list(attribute) noattr_expression . [ SCOPE RULE LABEL EXCEPTION END_CODE DOCSTRING DEFINITION DECLARATION DATE ATTR_START ASSERTION ]
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE RULE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER LABEL GREATER_EQUAL GREATER EXCEPTION EQUAL END_CODE DOT DOCSTRING DIV DEFINITION DECLARATION DATE CONTAINS BUT_REPLACE ATTR_START ASSERTION AND ]
@@ -2051,7 +2051,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT YEAR
 ##
-## Ends in an error in state: 734.
+## Ends in an error in state: 738.
 ##
 ## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2076,7 +2076,7 @@ expected a variable name, optionally preceded by 'output'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON INTERNAL YEAR
 ##
-## Ends in an error in state: 642.
+## Ends in an error in state: 646.
 ##
 ## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> INTERNAL . OUTPUT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2101,7 +2101,7 @@ expected a variable name
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT YEAR
 ##
-## Ends in an error in state: 758.
+## Ends in an error in state: 762.
 ##
 ## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2119,7 +2119,7 @@ expected either 'condition', or 'content' followed by the expected variable type
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 763.
+## Ends in an error in state: 767.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2132,7 +2132,7 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 764.
+## Ends in an error in state: 768.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2144,7 +2144,7 @@ expected a name and type for the dependency of this definition ('<ident> content
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 765.
+## Ends in an error in state: 769.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2157,15 +2157,15 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 36, spurious reduction of production quident -> UIDENT
 ## In state 40, spurious reduction of production primitive_typ -> quident
-## In state 590, spurious reduction of production typ_data -> primitive_typ
-## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 594, spurious reduction of production typ_data -> primitive_typ
+## In state 611, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument specification
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 766.
+## Ends in an error in state: 770.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2177,7 +2177,7 @@ expected a 'state' declaration for the preceding declaration, or the next declar
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION STATE LIDENT YEAR
 ##
-## Ends in an error in state: 627.
+## Ends in an error in state: 631.
 ##
 ## list(state) -> state . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2190,7 +2190,7 @@ declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 768.
+## Ends in an error in state: 772.
 ##
 ## scope_decl_item -> CONTEXT lident CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2203,15 +2203,15 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONTENT UI
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 36, spurious reduction of production quident -> UIDENT
 ## In state 40, spurious reduction of production primitive_typ -> quident
-## In state 590, spurious reduction of production typ_data -> primitive_typ
-## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 594, spurious reduction of production typ_data -> primitive_typ
+## In state 611, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION YEAR
 ##
-## Ends in an error in state: 771.
+## Ends in an error in state: 775.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONDITION . DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2225,7 +2225,7 @@ expected the next declaration for the scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS YEAR
 ##
-## Ends in an error in state: 772.
+## Ends in an error in state: 776.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2238,7 +2238,7 @@ expected the form 'depends on <ident> content <type>'
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 773.
+## Ends in an error in state: 777.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2250,7 +2250,7 @@ expected the form 'depends on (<ident> content <type> [, <ident> content <type> 
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT STATE
 ##
-## Ends in an error in state: 774.
+## Ends in an error in state: 778.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2263,15 +2263,15 @@ source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION 
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 36, spurious reduction of production quident -> UIDENT
 ## In state 40, spurious reduction of production primitive_typ -> quident
-## In state 590, spurious reduction of production typ_data -> primitive_typ
-## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 594, spurious reduction of production typ_data -> primitive_typ
+## In state 611, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected a closing paren, or a comma followed by another argument declaration (', <ident> content <type>')
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON CONTEXT LIDENT CONDITION DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 775.
+## Ends in an error in state: 779.
 ##
 ## scope_decl_item -> CONTEXT lident CONDITION DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2283,7 +2283,7 @@ expected the next definition in scope
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT YEAR
 ##
-## Ends in an error in state: 781.
+## Ends in an error in state: 785.
 ##
 ## scope_decl_item -> lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ## scope_decl_item -> lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN list(state) [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
@@ -2301,7 +2301,7 @@ expected the form '<ident> scope <Scope_name>', or a scope variable declaration
 
 source_file: BEGIN_CODE DECLARATION SCOPE UIDENT COLON LIDENT SCOPE YEAR
 ##
-## Ends in an error in state: 782.
+## Ends in an error in state: 786.
 ##
 ## scope_decl_item -> lident SCOPE . quident [ SUM SCOPE OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DECLARATION CONTEXT ATTR_START ]
 ##
@@ -2313,7 +2313,7 @@ expected a scope name
 
 source_file: BEGIN_CODE DECLARATION LIDENT YEAR
 ##
-## Ends in an error in state: 816.
+## Ends in an error in state: 820.
 ##
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident . CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2327,7 +2327,7 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 817.
+## Ends in an error in state: 821.
 ##
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT . typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2341,7 +2341,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS YEAR
 ##
-## Ends in an error in state: 819.
+## Ends in an error in state: 823.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . separated_nonempty_list(COMMA,var_content) option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS . LPAREN separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
@@ -2354,7 +2354,7 @@ expected a variable name, following the form 'depends on <var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN YEAR
 ##
-## Ends in an error in state: 820.
+## Ends in an error in state: 824.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN . separated_nonempty_list(COMMA,var_content) RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2366,7 +2366,7 @@ expected a variable name, following the form 'depends on (<var> content <type>, 
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT DEFINED_AS
 ##
-## Ends in an error in state: 821.
+## Ends in an error in state: 825.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) . RPAREN option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2379,8 +2379,8 @@ source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT 
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 36, spurious reduction of production quident -> UIDENT
 ## In state 40, spurious reduction of production primitive_typ -> quident
-## In state 590, spurious reduction of production typ_data -> primitive_typ
-## In state 607, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
+## In state 594, spurious reduction of production typ_data -> primitive_typ
+## In state 611, spurious reduction of production separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data
 ##
 
 expected ')', or ',' followed by another argument declaration in the form '<var>
@@ -2388,7 +2388,7 @@ content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN YEAR
 ##
-## Ends in an error in state: 822.
+## Ends in an error in state: 826.
 ##
 ## code_item -> DECLARATION lident CONTENT typ_data DEPENDS LPAREN separated_nonempty_list(COMMA,var_content) RPAREN . option(opt_def) [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2400,7 +2400,7 @@ expected 'equals <expression>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LPAREN LIDENT CONTENT UIDENT RPAREN DEFINED_AS YEAR
 ##
-## Ends in an error in state: 823.
+## Ends in an error in state: 827.
 ##
 ## option(opt_def) -> DEFINED_AS . list(attribute) noattr_expression [ SCOPE END_CODE DOCSTRING DECLARATION ATTR_START ]
 ##
@@ -2412,7 +2412,7 @@ expected an expression
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT YEAR
 ##
-## Ends in an error in state: 604.
+## Ends in an error in state: 608.
 ##
 ## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident . CONTENT list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
@@ -2425,7 +2425,7 @@ expected 'content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT YEAR
 ##
-## Ends in an error in state: 605.
+## Ends in an error in state: 609.
 ##
 ## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT . list(attribute) typ_data COMMA separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
@@ -2438,7 +2438,7 @@ expected a type
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT COMMA YEAR
 ##
-## Ends in an error in state: 608.
+## Ends in an error in state: 612.
 ##
 ## separated_nonempty_list(COMMA,var_content) -> list(attribute) lident CONTENT list(attribute) typ_data COMMA . separated_nonempty_list(COMMA,var_content) [ SUM STATE SCOPE RPAREN OUTPUT LIDENT INTERNAL INPUT END_CODE DOCSTRING DEFINED_AS DECLARATION DATA CONTEXT CONDITION ATTR_START ]
 ##
@@ -2450,7 +2450,7 @@ expected the definition of another argument in the form '<var> content <type>'
 
 source_file: BEGIN_CODE DECLARATION LIDENT CONTENT UIDENT DEPENDS LIDENT CONTENT UIDENT DEFINED_AS FALSE YEAR
 ##
-## Ends in an error in state: 825.
+## Ends in an error in state: 829.
 ##
 ## noattr_expression -> noattr_expression . DOT qlident [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL END_CODE DOT DOCSTRING DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
 ## noattr_expression -> noattr_expression . DOT INT_LITERAL [ XOR WITH SCOPE PLUSPLUS PLUS OR OF NOT_EQUAL MULT MINUS LESSER_EQUAL LESSER GREATER_EQUAL GREATER EQUAL END_CODE DOT DOCSTRING DIV DECLARATION CONTAINS BUT_REPLACE ATTR_START AND ]
@@ -2482,7 +2482,7 @@ expected a binary operator continuing the expression, or a keyword ending the ex
 
 source_file: BEGIN_DIRECTIVE YEAR
 ##
-## Ends in an error in state: 834.
+## Ends in an error in state: 838.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE . directive END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2494,7 +2494,7 @@ expected a directive, e.g. 'Include: <filename>'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE YEAR
 ##
-## Ends in an error in state: 844.
+## Ends in an error in state: 848.
 ##
 ## directive -> LAW_INCLUDE . COLON nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2506,7 +2506,7 @@ expected ':', then a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON YEAR
 ##
-## Ends in an error in state: 845.
+## Ends in an error in state: 849.
 ##
 ## directive -> LAW_INCLUDE COLON . nonempty_list(DIRECTIVE_ARG) option(AT_PAGE) [ END_DIRECTIVE ]
 ##
@@ -2518,7 +2518,7 @@ expected a file name or 'JORFTEXTNNNNNNNNNNNN'
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG YEAR
 ##
-## Ends in an error in state: 846.
+## Ends in an error in state: 850.
 ##
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . [ END_DIRECTIVE AT_PAGE ]
 ## nonempty_list(DIRECTIVE_ARG) -> DIRECTIVE_ARG . nonempty_list(DIRECTIVE_ARG) [ END_DIRECTIVE AT_PAGE ]
@@ -2531,7 +2531,7 @@ expected a page specification in the form '@p.<number>', or a newline
 
 source_file: BEGIN_DIRECTIVE LAW_INCLUDE COLON DIRECTIVE_ARG AT_PAGE YEAR
 ##
-## Ends in an error in state: 851.
+## Ends in an error in state: 855.
 ##
 ## source_file_item -> BEGIN_DIRECTIVE directive . END_DIRECTIVE [ LAW_TEXT LAW_HEADING EOF BEGIN_METADATA BEGIN_DIRECTIVE BEGIN_CODE ]
 ##
@@ -2543,7 +2543,7 @@ expected a newline
 
 source_file: LAW_HEADING YEAR
 ##
-## Ends in an error in state: 856.
+## Ends in an error in state: 860.
 ##
 ## source_file -> source_file_item . source_file [ # ]
 ##

--- a/compiler/surface/parser.mly
+++ b/compiler/surface/parser.mly
@@ -505,7 +505,7 @@ let binop ==
 | XOR ; { Xor }
 
 let constructor_binding :=
-| uid = addpos(quident) ; CONTENT ; lid = lident ; {
+| uid = addpos(quident) ; CONTENT ; id = mbinder ; {
   let constr =
     match uid with
     | ([], (id, _)), pos ->
@@ -514,7 +514,7 @@ let constructor_binding :=
         | None -> CConstr ([], (id, pos)), pos)
     | (path, uid), pos -> CConstr (path, uid), pos
   in
-  ([constr], Some lid)
+  ([constr], id)
 }
 | uid = addpos(quident) ; {
   let constr =
@@ -525,7 +525,7 @@ let constructor_binding :=
         | None -> CConstr ([], (id, pos)), pos)
     | (path, uid), pos -> CConstr (path, uid), pos
   in
-  ([constr], None)
+  ([constr], [])
 }
 
 let match_arm :=

--- a/tests/enum/bad/arity.catala_en
+++ b/tests/enum/bad/arity.catala_en
@@ -1,0 +1,103 @@
+```catala-metadata
+declaration enumeration Bob:
+  -- Zero
+  -- One content integer
+  -- Two content (money, integer)
+  -- Three content (decimal, money, integer)
+
+declaration scope S:
+  internal param content Bob
+  output o content integer
+```
+
+```catala
+scope S:
+  definition param equals Three content (12.12, $12.12, 12)
+  definition o equals
+    (match Present content (12, 13) with pattern
+     -- Absent: 0
+     -- Present content (a, b, c): a + b
+    ) +
+    (match Present content (12, 13, 14) with pattern
+     -- Absent: 0
+     -- Present content (a, b): a + b
+    )
+```
+
+```catala-test-cli
+$ catala test-scope S
+┌─[ERROR]─ 1/2 ─
+│
+│  Error during typechecking, incompatible types:
+│     (integer, integer)
+│  // (integer, integer, <any type>)
+│
+│ While typechecking the following expression:
+├─➤ tests/enum/bad/arity.catala_en:19.36-19.41:
+│    │
+│ 19 │      -- Present content (a, b, c): a + b
+│    │                                    ‾‾‾‾‾
+│
+│ Type (integer, integer) is coming from:
+├─➤ tests/enum/bad/arity.catala_en:17.28-17.36:
+│    │
+│ 17 │     (match Present content (12, 13) with pattern
+│    │                            ‾‾‾‾‾‾‾‾
+│
+│ Type (integer, integer, <any type>) is coming from:
+├─➤ tests/enum/bad/arity.catala_en:19.26-19.33:
+│    │
+│ 19 │      -- Present content (a, b, c): a + b
+│    │                          ‾‾‾‾‾‾‾
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  Error during typechecking, incompatible types:
+│     (integer, integer, integer)
+│  // (integer, integer)
+│
+│ While typechecking the following expression:
+├─➤ tests/enum/bad/arity.catala_en:23.33-23.38:
+│    │
+│ 23 │      -- Present content (a, b): a + b
+│    │                                 ‾‾‾‾‾
+│
+│ Type (integer, integer, integer) is coming from:
+├─➤ tests/enum/bad/arity.catala_en:21.28-21.40:
+│    │
+│ 21 │     (match Present content (12, 13, 14) with pattern
+│    │                            ‾‾‾‾‾‾‾‾‾‾‾‾
+│
+│ Type (integer, integer) is coming from:
+├─➤ tests/enum/bad/arity.catala_en:23.26-23.30:
+│    │
+│ 23 │      -- Present content (a, b): a + b
+│    │                          ‾‾‾‾
+└─
+#return code 123#
+```
+
+```catala
+scope S:
+  exception definition o equals
+    match param with pattern
+    -- Zero: 0
+    -- One content x: x
+    -- Two content (a, x, y): integer of a + x
+    -- Three content (a, b): integer of a + integer of b
+```
+
+
+```catala-test-cli
+$ catala test-scope S
+┌─[ERROR]─
+│
+│  This pattern has 3 arguments, while 2 are expected by constructor Two.
+│
+├─➤ tests/enum/bad/arity.catala_en:86.21-86.28:
+│    │
+│ 86 │     -- Two content (a, x, y): integer of a + x
+│    │                     ‾‾‾‾‾‾‾
+└─
+#return code 123#
+```

--- a/tests/enum/good/match_params.catala_en
+++ b/tests/enum/good/match_params.catala_en
@@ -1,0 +1,173 @@
+# Test of enums cases with multiple parameters, and matching them.
+
+## Standard enum with multiple parameters
+
+```catala-metadata
+declaration enumeration Bob:
+  -- Zero
+  -- One content integer
+  -- Two content (money, integer)
+  -- Three content (decimal, money, integer)
+
+#[test]
+declaration scope S:
+  internal param content Bob
+  output o1 content integer
+  output o2 content integer
+```
+
+```catala
+scope S:
+  definition param equals Three content (12.12, $12.12, 12)
+  definition o1 equals
+    match param with pattern
+    -- Zero: 0
+    -- One content x: x
+    -- Two content (a, x): integer of a + x
+    -- Three content (a, b, x): integer of a + integer of b + x
+
+  definition o2 equals
+    match param with pattern
+    -- Zero: 0
+    -- One content x: x
+    -- Two content t2: integer of t2.1 + t2.2
+    -- Three content t3: integer of t3.1 + integer of t3.2 + t3.3
+```
+
+```catala-test-cli
+$ catala test-scope S --disable-warnings
+┌─[RESULT]─ S ─
+│ o1 = 36
+│ o2 = 36
+└─
+```
+
+## Short match-check syntax
+
+
+```catala-metadata
+#[test]
+declaration scope S2:
+  internal param content Bob
+  output o1 content list of boolean
+```
+
+```catala
+scope S2:
+  definition param equals Three content (12.12, $12.12, 12)
+  definition o1 equals [
+    param with pattern One;
+    param with pattern Three;
+    param with pattern One content x;
+    param with pattern Three content t;
+    param with pattern Three content t and t = (12.12, $12.12, 12);
+    param with pattern Three content (x, y, z) and x = 44.44;
+    param with pattern Three content (x, y, z) and y = $12.12;
+    param with pattern Three content (x, y, z) and y = $12.12 and x = 12.12
+  ]
+```
+
+```catala-test-cli
+$ catala test-scope S2 --disable-warnings
+┌─[RESULT]─ S2 ─
+│ o1 = [false; true; false; true; true; false; true; true]
+└─
+```
+
+## Matching the polymorphic option type
+
+```catala-metadata
+#[test]
+declaration scope S3:
+  internal opt0 content optional of integer
+  internal opt1 content optional of integer
+  internal opt2 content optional of (money, integer)
+  output r0 content (integer, integer)
+  output r1 content (integer, integer)
+  output r2 content (integer, integer)
+  output r3 content (money, integer)
+```
+
+```catala
+scope S3:
+  definition opt0 equals Absent
+  definition opt1 equals Present content 86
+  definition opt2 equals Present content ($14.14, 86)
+
+  definition r0 equals (
+    (match opt0 with pattern
+     -- Absent: 0
+     -- Present content x: x),
+    (match opt0 with pattern
+     -- Absent: 0
+     -- Present: 1)
+  )
+  definition r1 equals (
+    (match opt1 with pattern
+     -- Absent: 0
+     -- Present content x: x),
+    (match opt1 with pattern
+     -- Absent: 0
+     -- Present: 1)
+  )
+  definition r2 equals (
+    (match opt2 with pattern
+     -- Absent: 0
+     -- Present content x: x.2),
+    (match opt2 with pattern
+     -- Absent: 0
+     -- Present content (x, y): integer of x + y)
+  )
+  definition r3 equals
+    match opt2 with pattern
+    -- Absent: ($99, 99)
+    -- Present content pair: pair
+```
+
+```catala-test-cli
+$ catala test-scope S3 --disable-warnings
+┌─[RESULT]─ S3 ─
+│ r0 = (0, 0)
+│ r1 = (86, 1)
+│ r2 = (86, 100)
+│ r3 = ($14.14, 86)
+└─
+```
+
+## Short match-check syntax on options
+
+
+```catala-metadata
+#[test]
+declaration scope S4:
+  output o1 content list of boolean
+```
+
+```catala
+scope S4:
+  definition o1 equals [
+    Absent with pattern Absent;
+    Absent with pattern Present;
+    (Present content 3) with pattern Absent;
+    (Present content 3) with pattern Present;
+    (Present content 3) with pattern Present content x;
+    (Present content 3) with pattern Present content x and x = 3;
+    (Present content (3, $12)) with pattern Absent;
+    (Present content (3, $12)) with pattern Present;
+    (Present content (3, $12)) with pattern Present content x;
+    (Present content (3, $12)) with pattern Present content x and x.2 = $12;
+    (Present content (3, $12)) with pattern Present content (x, y) and x = 3 and y = $12;
+    (Present content (3, $12)) with pattern Present content (x, y) and x = 3 and y = $1000
+  ]
+```
+
+```catala-test-cli
+$ catala test-scope S4 --disable-warnings
+┌─[RESULT]─ S4 ─
+│ o1 =
+│   [
+│     true; false; false; true; true; true; false; true; true; true; true;
+│     false
+│   ]
+└─
+```


### PR DESCRIPTION
i.e. `match foo with pattern -- Constructor content (a, b): a + b`

NOTE: stacked on top of #1014

## Checklist

### If this PR adds a feature or has breaking changes

* [x] Complete or update the documentation for the feature on the Catala book at https://github.com/CatalaLang/catala-book.
* [x] Update the Catala language server in case of breaking changes at https://github.com/CatalaLang/catala-language-server *(no changes needed)*

### If this PR contains syntax changes

I confirm that have have checked and updated each of the following items if this PR impacts them:

* [x] Syntax cheat sheet at `doc/syntax/syntax_*.catala_*` and `doc/syntax/catala_*.typ`.
* [x] Syntax constructions in the `tree-sitter` grammar:
  - Base grammar: https://github.com/CatalaLang/tree-sitter-catala/blob/master/grammar.js
    - [x] already merged (this is backw compatible, and actually was already supported in matches, only not in the short test-match syntax)
  - Formatting spec: https://github.com/CatalaLang/catala-format/blob/master/catala.scm
    - should be unaffected
