### PR TITLE
List of 1st class module instead of dispatching in pattern matching

### DIFF
--- a/build_system/backend/backend.ml
+++ b/build_system/backend/backend.ml
@@ -21,7 +21,6 @@ open Catala_utils
 module type S = sig
   val name : string
   val module_ext : string
-  val subdir : string
   val src_extensions : string list
   val obj_extensions : string list
   val runtime_targets : only_source:bool -> string list

--- a/build_system/backend/backend.ml
+++ b/build_system/backend/backend.ml
@@ -19,6 +19,9 @@ open Clerk_utils
 open Catala_utils
 
 module type S = sig
+  val name : string
+  val module_ext : string
+
   module Flags : sig
     val default :
       variables:(string * string list) list ->

--- a/build_system/backend/backend.ml
+++ b/build_system/backend/backend.ml
@@ -21,6 +21,10 @@ open Catala_utils
 module type S = sig
   val name : string
   val module_ext : string
+  val subdir : string
+  val src_extensions : string list
+  val obj_extensions : string list
+  val runtime_targets : only_source:bool -> string list
 
   module Flags : sig
     val default :

--- a/build_system/backend/c.ml
+++ b/build_system/backend/c.ml
@@ -55,13 +55,12 @@ module Backend = struct
   module Nj = Ninja_utils
 
   let name = "c"
-  let module_ext = "@c-module"
-  let subdir = "c"
+  let module_ext = "@" ^ name ^ "-module"
   let src_extensions = ["c"; "h"]
   let obj_extensions = ["o"]
 
   let runtime_targets ~only_source =
-    [(if only_source then "@runtime-c-src" else "@runtime-c")]
+    [(if only_source then "@runtime-" ^ name ^ "-src" else "@runtime-" ^ name)]
 
   module Flags = struct
     let default
@@ -94,17 +93,17 @@ module Backend = struct
             ]);
         def c_include
           (lazy
-            (["-I"; File.(Var.(!builddir) / Scan.libcatala / "c")]
-            @ Common.Flags.includes ~backend:"c" include_dirs));
+            (["-I"; File.(Var.(!builddir) / Scan.libcatala / name)]
+            @ Common.Flags.includes ~backend:name include_dirs));
       ]
   end
 
   let[@ocamlformat "disable"] static_base_rules =
   [
     Nj.rule "catala-c"
-      ~command:[!catala_exe; "c"; !catala_flags; !catala_flags_c;
+      ~command:[!catala_exe; name; !catala_flags; !catala_flags_c;
                 "-o"; !output; "--"; !input]
-      ~description:["<catala>"; "c"; "⇒"; !output];
+      ~description:["<catala>"; name; "⇒"; !output];
     Nj.rule "c-object"
       ~command:
         [!cc_exe; !input; !c_flags; !c_include; !includes; "-c"; "-o"; !output]
@@ -114,26 +113,26 @@ module Backend = struct
   let external_copy item =
     let catala_src = !Var.tdir / !Var.src in
     let c, missing =
-      Ninja.extern_src ~backend:"c" ~ext:"c" ~missing:[]
+      Ninja.extern_src ~backend:name ~ext:"c" ~missing:[]
         ~filename:item.Scan.file_name
     in
     let h, missing =
-      Ninja.extern_src ~backend:"c" ~ext:"h" ~missing
+      Ninja.extern_src ~backend:name ~ext:"h" ~missing
         ~filename:item.Scan.file_name
     in
-    Ninja.check_missing ~backend:"c" ~module_def:item.Scan.module_def ~missing
+    Ninja.check_missing ~backend:name ~module_def:item.Scan.module_def ~missing
       ~filename:item.Scan.file_name;
     List.to_seq
       [
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[c]
-          ~outputs:[Ninja.target ~backend:"c" "c"];
+          ~outputs:[Ninja.target ~backend:name "c"];
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[h]
-          ~outputs:[Ninja.target ~backend:"c" "h"];
+          ~outputs:[Ninja.target ~backend:name "h"];
       ]
 
   let runtime_build_statements ~options:_ ~stdbase =
-    let c_base = stdbase / "c" / "catala_runtime" in
-    let c_src = Var.(!runtime) / "c" in
+    let c_base = stdbase / name / "catala_runtime" in
+    let c_src = Var.(!runtime) / name in
     [
       Nj.build "phony"
         ~inputs:
@@ -143,7 +142,7 @@ module Backend = struct
             (c_base /../ "dates_calc") -.- "c";
             (c_base /../ "dates_calc") -.- "h";
           ]
-        ~outputs:["@runtime-c-src"];
+        ~outputs:["@runtime-" ^ name ^ "-src"];
       Nj.build "phony"
         ~inputs:
           [
@@ -153,7 +152,7 @@ module Backend = struct
             (c_base /../ "dates_calc") -.- "h";
             Var.(!catala_exe);
           ]
-        ~outputs:["@runtime-c"];
+        ~outputs:["@runtime-" ^ name];
       Nj.build "copy"
         ~inputs:[c_src / "catala_runtime.h"]
         ~outputs:[c_base -.- "h"];
@@ -178,19 +177,19 @@ module Backend = struct
 
   let catala ?vars ~is_stdlib:_ ~inputs ~implicit_in has_scope_tests =
     let implicit_out =
-      if has_scope_tests then [Ninja.target ~backend:"c" "+main.c"] else []
+      if has_scope_tests then [Ninja.target ~backend:name "+main.c"] else []
     in
     Seq.return
       (Nj.build "catala-c" ?vars ~inputs ~implicit_in
-         ~outputs:[Ninja.target ~backend:"c" "c"]
-         ~implicit_out:(Ninja.target ~backend:"c" "h" :: implicit_out))
+         ~outputs:[Ninja.target ~backend:name "c"]
+         ~implicit_out:(Ninja.target ~backend:name "h" :: implicit_out))
 
-  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:"c"
+  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:name
 
   let module_target same_dir_modules =
-    Ninja.modfile ~backend:"c" same_dir_modules "@c-module"
+    Ninja.modfile ~backend:name same_dir_modules module_ext
 
-  let includes = Common.Flags.include_flags ~backend:"c"
+  let includes = Common.Flags.include_flags ~backend:name
 
   let build_object ~include_dirs ~same_dir_modules ~item has_scope_tests =
     let open Scan in
@@ -198,21 +197,23 @@ module Backend = struct
     let implicit_modules = List.map (module_target same_dir_modules) modules in
     let obj =
       Nj.build "c-object"
-        ~inputs:[Ninja.target ~backend:"c" "c"]
+        ~inputs:[Ninja.target ~backend:name "c"]
         ~implicit_in:
-          (Ninja.target ~backend:"c" "h" :: "@runtime-c" :: implicit_modules)
-        ~outputs:[Ninja.target ~backend:"c" "o"]
+          (Ninja.target ~backend:name "h"
+          :: ("@runtime-" ^ name)
+          :: implicit_modules)
+        ~outputs:[Ninja.target ~backend:name "o"]
         ~vars:[Var.includes, includes include_dirs]
       ::
       (if has_scope_tests then
          [
            Nj.build "c-object"
-             ~inputs:[Ninja.target ~backend:"c" "+main.c"]
+             ~inputs:[Ninja.target ~backend:name "+main.c"]
              ~implicit_in:
-               (Ninja.target ~backend:"c" "h"
-               :: "@runtime-c"
+               (Ninja.target ~backend:name "h"
+               :: ("@runtime-" ^ name)
                :: implicit_modules)
-             ~outputs:[Ninja.target ~backend:"c" "+main.o"]
+             ~outputs:[Ninja.target ~backend:name "+main.o"]
              ~vars:[Var.includes, includes include_dirs];
          ]
        else [])
@@ -222,11 +223,11 @@ module Backend = struct
   let expose_module ~same_dir_modules ~used_modules =
     [
       Nj.build "phony"
-        ~inputs:[Ninja.target ~backend:"c" "h"]
+        ~inputs:[Ninja.target ~backend:name "h"]
         ~implicit_in:(List.map (module_target same_dir_modules) used_modules)
-        ~outputs:[Ninja.target ~backend:"c" "@c-module"];
+        ~outputs:[Ninja.target ~backend:name module_ext];
     ]
 
   let runtime_dir : File.t Lazy.t =
-    lazy File.(Lazy.force Poll.runtime_dir / "c")
+    lazy File.(Lazy.force Poll.runtime_dir / name)
 end

--- a/build_system/backend/c.ml
+++ b/build_system/backend/c.ml
@@ -54,6 +54,9 @@ module Backend = struct
   open File
   module Nj = Ninja_utils
 
+  let name = "c"
+  let module_ext = "@c-module"
+
   module Flags = struct
     let default
         ~variables

--- a/build_system/backend/c.ml
+++ b/build_system/backend/c.ml
@@ -56,6 +56,12 @@ module Backend = struct
 
   let name = "c"
   let module_ext = "@c-module"
+  let subdir = "c"
+  let src_extensions = ["c"; "h"]
+  let obj_extensions = ["o"]
+
+  let runtime_targets ~only_source =
+    [(if only_source then "@runtime-c-src" else "@runtime-c")]
 
   module Flags = struct
     let default

--- a/build_system/backend/java.ml
+++ b/build_system/backend/java.ml
@@ -105,6 +105,9 @@ module Backend = struct
   open Var
   module Nj = Ninja_utils
 
+  let name = "java"
+  let module_ext = ".class"
+
   let stdlib_target ext =
     let ext =
       match ext.[0] with

--- a/build_system/backend/java.ml
+++ b/build_system/backend/java.ml
@@ -107,12 +107,11 @@ module Backend = struct
 
   let name = "java"
   let module_ext = ".class"
-  let subdir = "java"
   let src_extensions = ["java"]
   let obj_extensions = ["class"]
 
   let runtime_targets ~only_source =
-    [(if only_source then "@runtime-java-src" else "@runtime-java")]
+    [(if only_source then "@runtime-" ^ name ^ "-src" else "@runtime-" ^ name)]
 
   let stdlib_target ext =
     let ext =
@@ -120,15 +119,14 @@ module Backend = struct
       | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> "." ^ ext
       | _ -> ext
     in
-    let bdir f = ("java" / "catala" / "stdlib" / f) ^ ext in
+    let bdir f = (name / "catala" / "stdlib" / f) ^ ext in
     !Var.tdir / bdir !Var.dst
 
   let modfile ~is_stdlib same_dir_modules ext modname =
-    let backend = "java" in
     match List.assoc_opt modname same_dir_modules with
     | Some _ when is_stdlib ->
-      (!Var.tdir / backend / "catala" / "stdlib" / String.to_id modname) ^ ext
-    | _ -> Ninja.modfile ~backend same_dir_modules ext modname
+      (!Var.tdir / name / "catala" / "stdlib" / String.to_id modname) ^ ext
+    | _ -> Ninja.modfile ~backend:name same_dir_modules ext modname
 
   module Flags = struct
     let default
@@ -154,35 +152,35 @@ module Backend = struct
   let[@ocamlformat "disable"] static_base_rules =
     [
       Nj.rule "catala-java"
-        ~command:[!catala_exe; "java"; !catala_flags; !catala_flags_java;
+        ~command:[!catala_exe; name; !catala_flags; !catala_flags_java;
                   "-o"; !output; "--"; !input]
-        ~description:["<catala>"; "java"; "⇒"; !output];
+        ~description:["<catala>"; name; "⇒"; !output];
       Nj.rule "java-class"
-        ~command:[!javac; "-cp"; File.(Var.(!builddir) / Scan.libcatala / "java")^":" ^ !class_path; !javac_flags; !input]
-        ~description:["<catala>"; "java"; "⇒"; !output];
+        ~command:[!javac; "-cp"; File.(Var.(!builddir) / Scan.libcatala / name)^":" ^ !class_path; !javac_flags; !input]
+        ~description:["<catala>"; name; "⇒"; !output];
     ]
 
   let external_copy item =
     let catala_src = !Var.tdir / !Var.src in
     let java, missing =
-      Ninja.extern_src ~filename:item.Scan.file_name ~backend:"java" ~ext:"java"
+      Ninja.extern_src ~filename:item.Scan.file_name ~backend:name ~ext:"java"
         ~missing:[]
     in
-    Ninja.check_missing ~backend:"java" ~module_def:item.Scan.module_def
-      ~missing ~filename:item.Scan.file_name;
+    Ninja.check_missing ~backend:name ~module_def:item.Scan.module_def ~missing
+      ~filename:item.Scan.file_name;
     List.to_seq
       [
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[java]
           ~outputs:
             [
               (if item.is_stdlib then stdlib_target "java"
-               else Ninja.target ~backend:"java" "java");
+               else Ninja.target ~backend:name "java");
             ];
       ]
 
   let runtime_build_statements ~options ~stdbase =
-    let java_base = stdbase / "java" in
-    let java_src = Var.(!runtime) / "java" in
+    let java_base = stdbase / name in
+    let java_src = Var.(!runtime) / name in
     let runtime_orig =
       match
         List.assoc_opt
@@ -192,7 +190,7 @@ module Backend = struct
       | Some r -> lazy (String.concat " " r)
       | None -> Poll.runtime_dir
     in
-    let java_orig_prefix = Lazy.force runtime_orig / "java" in
+    let java_orig_prefix = Lazy.force runtime_orig / name in
     let java_files =
       File.scan_tree
         (fun f ->
@@ -208,17 +206,19 @@ module Backend = struct
       |> List.of_seq
     in
     let java_list_file =
-      let base = options.global.build_dir / Scan.libcatala / "java" in
-      File.with_out_channel ~bin:false (base / "java.files") (fun oc ->
+      let base = options.global.build_dir / Scan.libcatala / name in
+      File.with_out_channel ~bin:false
+        (base / (name ^ ".files"))
+        (fun oc ->
           List.iter (fun s -> output_string oc ((base / s) ^ "\n")) java_files);
-      java_base / "java.files"
+      java_base / (name ^ ".files")
     in
     Nj.build "phony"
       ~inputs:(List.map (fun f -> (java_base / f) -.- "java") java_files)
-      ~outputs:["@runtime-java-src"]
+      ~outputs:["@runtime-" ^ name ^ "-src"]
     :: Nj.build "phony"
          ~inputs:(List.map (fun f -> (java_base / f) -.- "class") java_files)
-         ~outputs:["@runtime-java"]
+         ~outputs:["@runtime-" ^ name]
     :: Nj.build "java-class" ~inputs:[]
          ~implicit_in:
            (java_list_file :: List.map (fun f -> java_base / f) java_files)
@@ -235,18 +235,17 @@ module Backend = struct
          ~outputs:
            [
              (if is_stdlib then stdlib_target "java"
-              else Ninja.target ~backend:"java" "java");
+              else Ninja.target ~backend:name "java");
            ])
 
   let build_object ~include_dirs ~same_dir_modules ~item _has_scope_tests =
     let modules = List.rev_map Mark.remove item.Scan.used_modules in
     let java_class_path =
       String.concat ":"
-        ((!Var.tdir / "java")
+        ((!Var.tdir / name)
         :: List.map
              (fun d ->
-               (if Filename.is_relative d then !Var.builddir / d else d)
-               / "java")
+               (if Filename.is_relative d then !Var.builddir / d else d) / name)
              include_dirs)
     in
     let module_target =
@@ -257,18 +256,18 @@ module Backend = struct
          ~inputs:
            [
              (if item.is_stdlib then stdlib_target "java"
-              else Ninja.target ~backend:"java" "java");
+              else Ninja.target ~backend:name "java");
            ]
-         ~implicit_in:("@runtime-java" :: List.map module_target modules)
+         ~implicit_in:(("@runtime-" ^ name) :: List.map module_target modules)
          ~outputs:
            [
              (if item.is_stdlib then stdlib_target "class"
-              else Ninja.target ~backend:"java" "class");
+              else Ninja.target ~backend:name "class");
            ]
          ~vars:[Var.class_path, [java_class_path]])
 
   let expose_module ~same_dir_modules:_ ~used_modules:_ = []
 
   let runtime_dir : File.t Lazy.t =
-    lazy File.(Lazy.force Poll.runtime_dir / "java")
+    lazy File.(Lazy.force Poll.runtime_dir / name)
 end

--- a/build_system/backend/java.ml
+++ b/build_system/backend/java.ml
@@ -107,6 +107,12 @@ module Backend = struct
 
   let name = "java"
   let module_ext = ".class"
+  let subdir = "java"
+  let src_extensions = ["java"]
+  let obj_extensions = ["class"]
+
+  let runtime_targets ~only_source =
+    [(if only_source then "@runtime-java-src" else "@runtime-java")]
 
   let stdlib_target ext =
     let ext =

--- a/build_system/backend/ocaml.ml
+++ b/build_system/backend/ocaml.ml
@@ -19,6 +19,7 @@ open Clerk_utils
 open Catala_utils
 open Clerk_lib
 
+let backend_name = "ocaml"
 let catala_flags_ocaml = Var.make "CATALA_FLAGS_OCAML"
 let ocamlc_exe = Var.make "OCAMLC_EXE"
 let ocamlopt_exe = Var.make "OCAMLOPT_EXE"
@@ -72,7 +73,7 @@ module Flags = struct
       def ocaml_include
         (lazy
           (Lazy.force ocaml_include_value
-          @ Common.Flags.includes ~backend:"ocaml" include_dirs));
+          @ Common.Flags.includes ~backend:backend_name include_dirs));
     ]
 end
 
@@ -80,14 +81,14 @@ let linking_command ~build_dir ~var_bindings link_deps item target =
   let open File in
   Var.get_var var_bindings ocamlopt_exe
   @ List.map (Var.expand_vars var_bindings) (Lazy.force Flags.ocaml_link)
-  @ [build_dir / Scan.libcatala / "ocaml" / "dates_calc.cmx"]
-  @ [build_dir / Scan.libcatala / "ocaml" / "catala_runtime.cmx"]
+  @ [build_dir / Scan.libcatala / backend_name / "dates_calc.cmx"]
+  @ [build_dir / Scan.libcatala / backend_name / "catala_runtime.cmx"]
   @ Var.get_var var_bindings ocaml_flags
   @ Var.get_var var_bindings ocaml_include
   @ List.map
       (fun it ->
         let f = Scan.target_file_name it in
-        (build_dir / dirname f / "ocaml" / basename f) ^ ".cmx")
+        (build_dir / dirname f / backend_name / basename f) ^ ".cmx")
       (link_deps item)
   @ [
       target -.- "cmx";
@@ -105,76 +106,73 @@ let run_artifact ?scope src =
 module Backend = struct
   open Var
   module Nj = Ninja_utils
+  module Flags = Flags
 
-  let name = "ocaml"
-  let module_ext = "@ocaml-module"
-  let subdir = "ocaml"
+  let name = backend_name
+  let module_ext = "@" ^ name ^ "-module"
   let src_extensions = ["ml"; "mli"]
   let obj_extensions = ["cmi"; "cmo"; "cmx"; "o"; "cmxs"]
 
   let runtime_targets ~only_source =
-    [(if only_source then "@runtime-ocaml-src" else "@runtime-ocaml")]
-
-  module Flags = Flags
+    [(if only_source then "@runtime-" ^ name ^ "-src" else "@runtime-" ^ name)]
 
   let[@ocamlformat "disable"] static_base_rules =
-    let runtime_include = File.(Var.(!builddir) / Scan.libcatala / "ocaml") in
+    let runtime_include = File.(Var.(!builddir) / Scan.libcatala / name) in
          [
       Nj.rule "catala-ocaml"
-        ~command:[!catala_exe; "ocaml"; !catala_flags; !catala_flags_ocaml;
+        ~command:[!catala_exe; name; !catala_flags; !catala_flags_ocaml;
                   "-o"; !output; "--"; !input]
-        ~description:["<catala>"; "ocaml"; "⇒"; !output];
+        ~description:["<catala>"; name; "⇒"; !output];
       Nj.rule "ocaml-bytobject"
         ~command:[
           !ocamlc_exe; "-c"; !ocaml_flags; !ocaml_include; "-I"; runtime_include; !includes; !input
         ]
-        ~description:["<ocaml>"; "⇒"; !output];
+        ~description:["<" ^ name ^ ">"; "⇒"; !output];
 
       Nj.rule "ocaml-natobject"
         ~command:[
           !ocamlopt_exe; "-c"; !ocaml_flags; !ocaml_include; "-I"; runtime_include; !includes; !input
         ]
-        ~description:["<ocaml>"; "⇒"; !output];
+        ~description:["<" ^ name ^ ">"; "⇒"; !output];
 
       Nj.rule "ocaml-module"
         ~command:
           [!ocamlopt_exe; "-shared"; !ocaml_flags; !ocaml_include; "-I"; runtime_include; !input;
            "-o"; !output]
-        ~description:["<ocaml>"; "⇒"; !output];
+        ~description:["<" ^ name ^ ">"; "⇒"; !output];
     ]
 
   let runtime_dir : File.t Lazy.t =
-    lazy File.(Lazy.force Poll.runtime_dir / "ocaml")
+    lazy File.(Lazy.force Poll.runtime_dir / name)
 
-  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:"ocaml"
+  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:name
 
   let external_copy item =
-    let open Var in
     let open File in
     let catala_src = !Var.tdir / !Var.src in
     let ml, missing =
-      Ninja.extern_src ~filename:item.Scan.file_name ~backend:"ocaml" ~ext:"ml"
+      Ninja.extern_src ~filename:item.Scan.file_name ~backend:name ~ext:"ml"
         ~missing:[]
     in
     let mli, missing =
-      Ninja.extern_src ~filename:item.Scan.file_name ~backend:"ocaml" ~ext:"mli"
+      Ninja.extern_src ~filename:item.Scan.file_name ~backend:name ~ext:"mli"
         ~missing
     in
-    Ninja.check_missing ~backend:"ocaml" ~module_def:item.Scan.module_def
-      ~missing ~filename:item.file_name;
+    Ninja.check_missing ~backend:name ~module_def:item.Scan.module_def ~missing
+      ~filename:item.file_name;
     List.to_seq
       [
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[ml]
-          ~outputs:[Ninja.target ~backend:"ocaml" "ml"];
+          ~outputs:[Ninja.target ~backend:name "ml"];
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[mli]
-          ~outputs:[Ninja.target ~backend:"ocaml" "mli"];
+          ~outputs:[Ninja.target ~backend:name "mli"];
       ]
 
   let runtime_build_statements ~options:_ ~stdbase =
     let open File in
-    let ocaml_src = Var.(!runtime) / "ocaml" in
-    let dates_base = stdbase / "ocaml" / "dates_calc" in
-    let ocaml_base = stdbase / "ocaml" / "catala_runtime" in
+    let ocaml_src = Var.(!runtime) / name in
+    let dates_base = stdbase / name / "dates_calc" in
+    let ocaml_base = stdbase / name / "catala_runtime" in
     let runtime_cmi, dates_cmi =
       (* This one is tricky: in order for the catala interpreter to be able to
          dynlink compiled Catala modules, we need to be sure that they have been
@@ -188,13 +186,13 @@ module Backend = struct
           /../ "_build"
           / "default"
           / "runtimes"
-          / "ocaml"
+          / name
           / "catala_runtime.cmi",
           Lazy.force Poll.runtime_dir
           /../ "_build"
           / "default"
           / "runtimes"
-          / "ocaml"
+          / name
           / "dates_calc.cmi" )
       (* This won't work if dune is not in its standard configuration and
          "default" profile, but that won't affect anything outside of running
@@ -219,11 +217,11 @@ module Backend = struct
             ocaml_base -.- "ml";
             ocaml_base -.- "mli";
           ]
-        ~outputs:["@runtime-ocaml-src"];
+        ~outputs:["@runtime-" ^ name ^ "-src"];
       Nj.build "phony"
         ~inputs:[ocaml_base -.- "cmx"]
         ~implicit_in:[dates_base -.- "cmi"]
-        ~outputs:["@runtime-ocaml"];
+        ~outputs:["@runtime-" ^ name];
       Nj.build "copy"
         ~inputs:[ocaml_src / "catala_runtime.mli"]
         ~outputs:[ocaml_base -.- "mli"];
@@ -246,17 +244,17 @@ module Backend = struct
 
   let catala ?vars ~is_stdlib:_ ~inputs ~implicit_in has_scope_tests =
     let implicit_out =
-      if has_scope_tests then [Ninja.target ~backend:"ocaml" "+main.ml"] else []
+      if has_scope_tests then [Ninja.target ~backend:name "+main.ml"] else []
     in
     Seq.return
       (Nj.build "catala-ocaml" ?vars ~inputs ~implicit_in
-         ~outputs:[Ninja.target ~backend:"ocaml" "ml"]
-         ~implicit_out:(Ninja.target ~backend:"ocaml" "mli" :: implicit_out))
+         ~outputs:[Ninja.target ~backend:name "ml"]
+         ~implicit_out:(Ninja.target ~backend:name "mli" :: implicit_out))
 
   let module_target same_dir_modules =
-    Ninja.modfile ~backend:"ocaml" same_dir_modules "@ocaml-module"
+    Ninja.modfile ~backend:name same_dir_modules module_ext
 
-  let includes = Common.Flags.include_flags ~backend:"ocaml"
+  let includes = Common.Flags.include_flags ~backend:name
 
   let build_object ~include_dirs ~same_dir_modules ~item has_scope_tests =
     let open Ninja in
@@ -266,9 +264,9 @@ module Backend = struct
     let obj =
       [
         Nj.build "ocaml-bytobject"
-          ~inputs:[target ~backend:"ocaml" "mli"; target ~backend:"ocaml" "ml"]
+          ~inputs:[target ~backend:name "mli"; target ~backend:name "ml"]
           ~implicit_in:(implicit_modules @ ["@runtime-cmi"])
-          ~outputs:(List.map (target ~backend:"ocaml") ["cmi"; "cmo"])
+          ~outputs:(List.map (target ~backend:name) ["cmi"; "cmo"])
           ~vars:
             [
               Var.includes, includes include_dirs;
@@ -291,11 +289,10 @@ module Backend = struct
                 ] );
             ];
         Nj.build "ocaml-natobject"
-          ~inputs:[target ~backend:"ocaml" "ml"]
+          ~inputs:[target ~backend:name "ml"]
           ~implicit_in:
-            ((target ~backend:"ocaml" "cmi" :: implicit_modules)
-            @ ["@runtime-cmi"])
-          ~outputs:(List.map (target ~backend:"ocaml") ["cmx"; "o"])
+            ((target ~backend:name "cmi" :: implicit_modules) @ ["@runtime-cmi"])
+          ~outputs:(List.map (target ~backend:name) ["cmx"; "o"])
           ~vars:[Var.includes, includes include_dirs];
       ]
     in
@@ -305,20 +302,20 @@ module Backend = struct
           obj
           @ [
               Nj.build "ocaml-module"
-                ~inputs:[target ~backend:"ocaml" "cmx"]
-                ~outputs:[target ~backend:"ocaml" "cmxs"];
+                ~inputs:[target ~backend:name "cmx"]
+                ~outputs:[target ~backend:name "cmxs"];
             ]
         | None -> obj)
       @
       if has_scope_tests then
         [
           Nj.build "ocaml-natobject"
-            ~inputs:[target ~backend:"ocaml" "+main.ml"]
+            ~inputs:[target ~backend:name "+main.ml"]
             ~implicit_in:
-              [target ~backend:"ocaml" "cmi"; target ~backend:"ocaml" "cmx"]
+              [target ~backend:name "cmi"; target ~backend:name "cmx"]
             ~outputs:
               (List.map
-                 (fun ext -> target ~backend:"ocaml" ("+main." ^ ext))
+                 (fun ext -> target ~backend:name ("+main." ^ ext))
                  ["cmx"; "o"])
             ~vars:[Var.includes, includes include_dirs @ ["-w"; "-24"]];
         ]
@@ -330,11 +327,8 @@ module Backend = struct
     [
       Nj.build "phony"
         ~inputs:
-          [
-            Ninja.target ~backend:"ocaml" "cmi";
-            Ninja.target ~backend:"ocaml" "cmxs";
-          ]
+          [Ninja.target ~backend:name "cmi"; Ninja.target ~backend:name "cmxs"]
         ~implicit_in:(List.map (module_target same_dir_modules) used_modules)
-        ~outputs:[Ninja.target ~backend:"ocaml" "@ocaml-module"];
+        ~outputs:[Ninja.target ~backend:name module_ext];
     ]
 end

--- a/build_system/backend/ocaml.ml
+++ b/build_system/backend/ocaml.ml
@@ -108,6 +108,12 @@ module Backend = struct
 
   let name = "ocaml"
   let module_ext = "@ocaml-module"
+  let subdir = "ocaml"
+  let src_extensions = ["ml"; "mli"]
+  let obj_extensions = ["cmi"; "cmo"; "cmx"; "o"; "cmxs"]
+
+  let runtime_targets ~only_source =
+    [(if only_source then "@runtime-ocaml-src" else "@runtime-ocaml")]
 
   module Flags = Flags
 

--- a/build_system/backend/ocaml.ml
+++ b/build_system/backend/ocaml.ml
@@ -105,6 +105,10 @@ let run_artifact ?scope src =
 module Backend = struct
   open Var
   module Nj = Ninja_utils
+
+  let name = "ocaml"
+  let module_ext = "@ocaml-module"
+
   module Flags = Flags
 
   let[@ocamlformat "disable"] static_base_rules =

--- a/build_system/backend/python.ml
+++ b/build_system/backend/python.ml
@@ -68,6 +68,10 @@ module Backend = struct
 
   let name = "python"
   let module_ext = ".py"
+  let subdir = "python"
+  let src_extensions = ["py"]
+  let obj_extensions = []
+  let runtime_targets ~only_source:_ = ["@runtime-python"]
 
   module Flags = struct
     let default

--- a/build_system/backend/python.ml
+++ b/build_system/backend/python.ml
@@ -66,6 +66,9 @@ module Backend = struct
   open File
   module Nj = Ninja_utils
 
+  let name = "python"
+  let module_ext = ".py"
+
   module Flags = struct
     let default
         ~variables

--- a/build_system/backend/python.ml
+++ b/build_system/backend/python.ml
@@ -68,10 +68,9 @@ module Backend = struct
 
   let name = "python"
   let module_ext = ".py"
-  let subdir = "python"
   let src_extensions = ["py"]
   let obj_extensions = []
-  let runtime_targets ~only_source:_ = ["@runtime-python"]
+  let runtime_targets ~only_source:_ = ["@runtime-" ^ name]
 
   module Flags = struct
     let default
@@ -94,35 +93,35 @@ module Backend = struct
   let[@ocamlformat "disable"] static_base_rules =
     [
       Nj.rule "catala-python"
-        ~command:[!catala_exe; "python"; !catala_flags; !catala_flags_python;
+        ~command:[!catala_exe; name; !catala_flags; !catala_flags_python;
                   "-o"; !output; "--"; !input]
-        ~description:["<catala>"; "python"; "⇒"; !output];
+        ~description:["<catala>"; name; "⇒"; !output];
     ]
 
   let external_copy item =
     let catala_src = !Var.tdir / !Var.src in
     let py, missing =
-      Ninja.extern_src ~filename:item.Scan.file_name ~backend:"python" ~ext:"py"
+      Ninja.extern_src ~filename:item.Scan.file_name ~backend:name ~ext:"py"
         ~missing:[]
     in
-    Ninja.check_missing ~backend:"python" ~module_def:item.Scan.module_def
-      ~missing ~filename:item.Scan.file_name;
+    Ninja.check_missing ~backend:name ~module_def:item.Scan.module_def ~missing
+      ~filename:item.Scan.file_name;
     List.to_seq
       [
         Nj.build "copy" ~implicit_in:[catala_src] ~inputs:[py]
-          ~outputs:[Ninja.target ~backend:"python" "py"];
+          ~outputs:[Ninja.target ~backend:name "py"];
       ]
 
-  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:"python"
+  let modfile ~is_stdlib:_ = Ninja.modfile ~backend:name
 
   let runtime_build_statements ~options:_ ~stdbase =
-    let python_base = stdbase / "python" / "catala_runtime" in
-    let python_src = Var.(!runtime) / "python" / "src" / "catala" in
+    let python_base = stdbase / name / "catala_runtime" in
+    let python_src = Var.(!runtime) / name / "src" / "catala" in
     [
       Nj.build "phony"
         ~inputs:
           [python_base -.- "py"; python_base /../ "dates.py"; Var.(!catala_exe)]
-        ~outputs:["@runtime-python"];
+        ~outputs:["@runtime-" ^ name];
       Nj.build "copy"
         ~inputs:[python_src / "dates.py"]
         ~outputs:[python_base /../ "dates.py"];
@@ -134,7 +133,7 @@ module Backend = struct
   let catala ?vars ~is_stdlib:_ ~inputs ~implicit_in _has_scope_tests =
     Seq.return
       (Nj.build "catala-python" ?vars ~inputs ~implicit_in
-         ~outputs:[Ninja.target ~backend:"python" "py"])
+         ~outputs:[Ninja.target ~backend:name "py"])
 
   let build_object ~include_dirs:_ ~same_dir_modules:_ ~item:_ _has_scope_tests
       =
@@ -143,5 +142,5 @@ module Backend = struct
   let expose_module ~same_dir_modules:_ ~used_modules:_ = []
 
   let runtime_dir : File.t Lazy.t =
-    lazy File.(Lazy.force Poll.runtime_dir / "python" / "src" / "catala")
+    lazy File.(Lazy.force Poll.runtime_dir / name / "src" / "catala")
 end

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -99,8 +99,9 @@ let backend_subdir_list =
     Clerk_rules.OCaml, "ocaml";
   ]
 
-let normalize_backends : Clerk_rules.backend list -> Clerk_rules.backend list =
-  List.sort_uniq Stdlib.compare
+let normalize_backends backends =
+  List.sort_uniq Stdlib.compare backends
+  |> List.map Clerk_rules.backend_module_from_backend
 
 let subdir_backend_list =
   List.map (fun (bk, dir) -> dir, bk) backend_subdir_list
@@ -272,10 +273,8 @@ let build_clerk_target
   let local_runtime_dir bk =
     File.(build_dir / Scan.libcatala / backend_subdir bk)
   in
-  let enabled_backends =
-    List.map Clerk_rules.backend_from_config target.backends
-    |> normalize_backends
-  in
+  let backends = List.map Clerk_rules.backend_from_config target.backends in
+  let enabled_backends = normalize_backends backends in
   let install_targets, all_modules_deps =
     Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends
       ~ninja_flags ~quiet ~autotest:false
@@ -333,7 +332,7 @@ let build_clerk_target
                 (fun ext -> (module_item, target, bk), base -.- ext)
                 extensions)
             all_modules_deps)
-        enabled_backends
+        backends
       |> List.sort_uniq (fun ((_, _, _), l) ((_, _, _), r) ->
           String.compare l r)
     in
@@ -363,7 +362,7 @@ let build_clerk_target
           targets @ acc)
         (backend_runtime_targets
            ~only_source:(not target.Config.include_objects)
-           enabled_backends)
+           backends)
         all_target_files
       |> List.rev
     in
@@ -739,6 +738,13 @@ let run_artifact config ~backend ~var_bindings ?scope ~test src =
   | `Python -> Clerk_backends.Python.run_artifact config ~var_bindings src
   | `Java -> Clerk_backends.Java.run_artifact ~var_bindings ~test src
 
+let enable_backend_module backend : (module Clerk_backends.Backend.S) =
+  match backend with
+  | `Interpret | `OCaml -> (module Clerk_backends.Ocaml.Backend)
+  | `C -> (module Clerk_backends.C.Backend)
+  | `Python -> (module Clerk_backends.Python.Backend)
+  | `Java -> (module Clerk_backends.Ocaml.Backend)
+
 let enable_backend =
   let open Clerk_rules in
   function
@@ -894,7 +900,7 @@ let run_cmd =
     in
     let files_or_folders = List.map config.Cli.fix_path files_or_folders in
     Clerk_rules.run_ninja ~config ~code_coverage:false
-      ~enabled_backends:[enable_backend backend]
+      ~enabled_backends:[enable_backend_module backend]
       ~ninja_flags ~autotest:false ~quiet
       (build_test_deps ~config ~backend ~test_only files_or_folders)
     |> fun tests ->
@@ -1155,8 +1161,8 @@ let run_clerk_test
     let files_or_folders =
       match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
     in
-    Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~enabled_backends
-      ~ninja_flags ~autotest:true ~clean_up_env:true
+    Clerk_rules.run_ninja ~quiet ~code_coverage ~tests:(backend = `Interpret)
+      ~config ~enabled_backends ~ninja_flags ~autotest:true ~clean_up_env:true
       (build_test_deps ~config ~backend files_or_folders)
     |> run_targets ~test:true config backend "" None None
   else
@@ -1317,15 +1323,14 @@ let start_cmd =
       List.concat_map
         (fun target -> List.map Clerk_rules.backend_from_config target.backends)
         targets
-      |> List.sort_uniq compare
+      |> normalize_backends
     in
     let default =
       List.fold_left
-        (fun default_rules backend ->
-          let name = rules_backend backend |> string_of_backend in
-          let rule_stdlib_fr = Format.sprintf "Stdlib_fr@%s-module" name in
-          let rule_stdlib_en = Format.sprintf "Stdlib_en@%s-module" name in
-          let runtime_rule = Format.sprintf "@runtime-%s" name in
+        (fun default_rules (module B : Clerk_backends.Backend.S) ->
+          let rule_stdlib_fr = Format.sprintf "Stdlib_fr@%s-module" B.name in
+          let rule_stdlib_en = Format.sprintf "Stdlib_en@%s-module" B.name in
+          let runtime_rule = Format.sprintf "@runtime-%s" B.name in
           runtime_rule :: rule_stdlib_fr :: rule_stdlib_en :: default_rules)
         ["Stdlib_fr@src"; "Stdlib_en@src"]
         enabled_backends
@@ -1458,7 +1463,7 @@ let list_vars_cmd =
   let run config =
     let var_bindings =
       Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
-        ~enabled_backends:Clerk_rules.all_backends ~config
+        ~enabled_backends:Clerk_rules.all_backends_module ~config
     in
     Format.eprintf "Defined variables:@.";
     Format.open_vbox 0;
@@ -1479,7 +1484,8 @@ let list_vars_cmd =
 let json_schema_cmd =
   let run config ninja_flags quiet file scope =
     let file = config.Cli.fix_path file in
-    Clerk_rules.run_ninja ~config ~code_coverage:false ~enabled_backends:[OCaml]
+    Clerk_rules.run_ninja ~config ~code_coverage:false
+      ~enabled_backends:[(module Clerk_backends.Ocaml.Backend)]
       ~ninja_flags ~autotest:false ~quiet
       (build_test_deps ~config ~backend:`Interpret ~test_only:false [file])
     |> fun (items, _link_deps, var_bindings) ->

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -63,21 +63,24 @@ let linking_dependencies items =
     in
     rem_dups (traverse [] item)
 
-let backend_src_extensions =
+let all_backends_with_config :
+    (Clerk_config.backend * (module Clerk_backends.Backend.S)) list =
   [
-    Clerk_config.C, ["c"; "h"];
-    Clerk_config.OCaml, ["ml"; "mli"];
-    Clerk_config.Python, ["py"];
-    Clerk_config.Java, ["java"];
+    Clerk_config.OCaml, (module Clerk_backends.Ocaml.Backend);
+    Clerk_config.C, (module Clerk_backends.C.Backend);
+    Clerk_config.Python, (module Clerk_backends.Python.Backend);
+    Clerk_config.Java, (module Clerk_backends.Java.Backend);
   ]
 
+let backend_src_extensions =
+  List.map
+    (fun (bk, (module B : Clerk_backends.Backend.S)) -> bk, B.src_extensions)
+    all_backends_with_config
+
 let backend_obj_extensions =
-  [
-    Clerk_config.C, ["o"];
-    Clerk_config.OCaml, ["cmi"; "cmo"; "cmx"; "o"; "cmxs"];
-    Clerk_config.Python, [];
-    Clerk_config.Java, ["class"];
-  ]
+  List.map
+    (fun (bk, (module B : Clerk_backends.Backend.S)) -> bk, B.obj_extensions)
+    all_backends_with_config
 
 let backend_extensions =
   List.map
@@ -92,12 +95,9 @@ let extensions_backend =
           backend_extensions)
 
 let backend_subdir_list =
-  [
-    Clerk_config.C, "c";
-    Clerk_config.Python, "python";
-    Clerk_config.Java, "java";
-    Clerk_config.OCaml, "ocaml";
-  ]
+  List.map
+    (fun (bk, (module B : Clerk_backends.Backend.S)) -> bk, B.subdir)
+    all_backends_with_config
 
 let normalize_backends backends =
   List.sort_uniq Stdlib.compare backends
@@ -221,15 +221,13 @@ let make_target ~build_dir ~backend item =
   build_dir / base
 
 let backend_runtime_targets ?(only_source = false) enabled_backends =
-  let src s = if only_source then s ^ "-src" else s in
-  (if List.mem Clerk_config.OCaml enabled_backends then [src "@runtime-ocaml"]
-   else [])
-  @ (if List.mem Clerk_config.C enabled_backends then [src "@runtime-c"] else [])
-  @ (if List.mem Clerk_config.Python enabled_backends then ["@runtime-python"]
-     else [])
-  @
-  if List.mem Clerk_config.Java enabled_backends then [src "@runtime-java"]
-  else []
+  List.concat_map
+    (fun bk ->
+      let (module B : Clerk_backends.Backend.S) =
+        Clerk_rules.backend_from_config bk
+      in
+      B.runtime_targets ~only_source)
+    enabled_backends
 
 open Cmdliner
 

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -65,18 +65,18 @@ let linking_dependencies items =
 
 let backend_src_extensions =
   [
-    Clerk_rules.C, ["c"; "h"];
-    Clerk_rules.OCaml, ["ml"; "mli"];
-    Clerk_rules.Python, ["py"];
-    Clerk_rules.Java, ["java"];
+    Clerk_config.C, ["c"; "h"];
+    Clerk_config.OCaml, ["ml"; "mli"];
+    Clerk_config.Python, ["py"];
+    Clerk_config.Java, ["java"];
   ]
 
 let backend_obj_extensions =
   [
-    Clerk_rules.C, ["o"];
-    Clerk_rules.OCaml, ["cmi"; "cmo"; "cmx"; "o"; "cmxs"];
-    Clerk_rules.Python, [];
-    Clerk_rules.Java, ["class"];
+    Clerk_config.C, ["o"];
+    Clerk_config.OCaml, ["cmi"; "cmo"; "cmx"; "o"; "cmxs"];
+    Clerk_config.Python, [];
+    Clerk_config.Java, ["class"];
   ]
 
 let backend_extensions =
@@ -85,7 +85,7 @@ let backend_extensions =
     backend_src_extensions
 
 let extensions_backend =
-  ("cmxa", Clerk_rules.OCaml)
+  ("cmxa", Clerk_config.OCaml)
   :: List.flatten
        (List.map
           (fun (bk, exts) -> List.map (fun e -> e, bk) exts)
@@ -93,23 +93,21 @@ let extensions_backend =
 
 let backend_subdir_list =
   [
-    Clerk_rules.C, "c";
-    Clerk_rules.Python, "python";
-    Clerk_rules.Java, "java";
-    Clerk_rules.OCaml, "ocaml";
+    Clerk_config.C, "c";
+    Clerk_config.Python, "python";
+    Clerk_config.Java, "java";
+    Clerk_config.OCaml, "ocaml";
   ]
 
 let normalize_backends backends =
   List.sort_uniq Stdlib.compare backends
-  |> List.map Clerk_rules.backend_module_from_backend
+  |> List.map Clerk_rules.backend_from_config
 
 let subdir_backend_list =
   List.map (fun (bk, dir) -> dir, bk) backend_subdir_list
 
 let backend_subdir bk = List.assoc bk backend_subdir_list
-
-let rule_subdir rule =
-  backend_subdir (Clerk_rules.backend_from_config rule.Config.backend)
+let rule_subdir rule = backend_subdir rule.Config.backend
 
 let linking_command ~build_dir ~backend ~var_bindings link_deps item target =
   let open File in
@@ -161,7 +159,7 @@ let target_backend config t =
             (fun rule -> List.mem ext rule.Config.out_exts)
             config.Config.custom_rules
         with
-        | Some rule -> Clerk_rules.backend_from_config rule.Config.backend
+        | Some rule -> rule.Config.backend
         | None ->
           Message.error
             "Unhandled extension @{<red;bold>%s@} for target @{<red>%S@}" ext t)
@@ -169,14 +167,29 @@ let target_backend config t =
   match File.extension t with
   | "exe" -> (
     try List.assoc File.(basename (dirname t)) subdir_backend_list
-    with Not_found -> Clerk_rules.OCaml)
+    with Not_found -> Clerk_config.OCaml)
   | ext -> aux ext
 
-let rules_backend = function
-  | Clerk_rules.OCaml -> `OCaml
-  | Clerk_rules.C -> `C
-  | Clerk_rules.Python -> `Python
-  | Clerk_rules.Java -> `Java
+let config_backend = function
+  | Clerk_config.OCaml -> `OCaml
+  | Clerk_config.C -> `C
+  | Clerk_config.Python -> `Python
+  | Clerk_config.Java -> `Java
+  | _ -> invalid_arg __FUNCTION__
+
+let string_of_config_backend = function
+  | Clerk_config.OCaml -> "ocaml"
+  | Clerk_config.C -> "c"
+  | Clerk_config.Python -> "python"
+  | Clerk_config.Java -> "java"
+  | backend ->
+    let backends = Clerk_config.registered_backends () in
+    let backend_name =
+      List.find_map
+        (fun (name, bckd) -> if backend = bckd then Some name else None)
+        backends
+    in
+    Option.value ~default:"" backend_name
 
 let string_of_backend = function
   | `OCaml -> "ocaml"
@@ -209,13 +222,13 @@ let make_target ~build_dir ~backend item =
 
 let backend_runtime_targets ?(only_source = false) enabled_backends =
   let src s = if only_source then s ^ "-src" else s in
-  (if List.mem Clerk_rules.OCaml enabled_backends then [src "@runtime-ocaml"]
+  (if List.mem Clerk_config.OCaml enabled_backends then [src "@runtime-ocaml"]
    else [])
-  @ (if List.mem Clerk_rules.C enabled_backends then [src "@runtime-c"] else [])
-  @ (if List.mem Clerk_rules.Python enabled_backends then ["@runtime-python"]
+  @ (if List.mem Clerk_config.C enabled_backends then [src "@runtime-c"] else [])
+  @ (if List.mem Clerk_config.Python enabled_backends then ["@runtime-python"]
      else [])
   @
-  if List.mem Clerk_rules.Java enabled_backends then [src "@runtime-java"]
+  if List.mem Clerk_config.Java enabled_backends then [src "@runtime-java"]
   else []
 
 open Cmdliner
@@ -273,7 +286,7 @@ let build_clerk_target
   let local_runtime_dir bk =
     File.(build_dir / Scan.libcatala / backend_subdir bk)
   in
-  let backends = List.map Clerk_rules.backend_from_config target.backends in
+  let backends = target.backends in
   let enabled_backends = normalize_backends backends in
   let install_targets, all_modules_deps =
     Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends
@@ -348,7 +361,7 @@ let build_clerk_target
               let backend_subdir =
                 build_dir / dirname f / backend_subdir backend
               in
-              if backend = Clerk_rules.Java && item.is_stdlib then
+              if backend = Clerk_config.Java && item.is_stdlib then
                 backend_subdir / "catala" / "stdlib" / basename f
               else backend_subdir / basename f
             in
@@ -385,14 +398,13 @@ let build_clerk_target
     install_targets;
   target.Config.backends
   |> List.iter (fun bk ->
-      let bk = Clerk_rules.backend_from_config bk in
       let dir = prefix_dir / backend_subdir bk in
       let extensions =
         if target.include_objects then List.assoc bk backend_extensions
         else List.assoc bk backend_src_extensions
       in
       match bk with
-      | Clerk_rules.Java ->
+      | Clerk_config.Java ->
         List.iter
           (fun subdir ->
             copy_dir ()
@@ -447,12 +459,12 @@ let build_direct_targets
           else File.(build_dir / t))
         direct_targets
     in
-    let backends = if autotest then [Clerk_rules.OCaml] else [] in
+    let backends = if autotest then [Clerk_config.OCaml] else [] in
     let enabled_backends =
       List.fold_left
         (fun acc t ->
           match File.extension t with
-          | "" -> Clerk_rules.OCaml :: acc
+          | "" -> Clerk_config.OCaml :: acc
           | _ -> target_backend config.options t :: acc)
         backends direct_targets
       |> normalize_backends
@@ -738,20 +750,11 @@ let run_artifact config ~backend ~var_bindings ?scope ~test src =
   | `Python -> Clerk_backends.Python.run_artifact config ~var_bindings src
   | `Java -> Clerk_backends.Java.run_artifact ~var_bindings ~test src
 
-let enable_backend_module backend : (module Clerk_backends.Backend.S) =
-  match backend with
-  | `Interpret | `OCaml -> (module Clerk_backends.Ocaml.Backend)
-  | `C -> (module Clerk_backends.C.Backend)
-  | `Python -> (module Clerk_backends.Python.Backend)
-  | `Java -> (module Clerk_backends.Ocaml.Backend)
-
-let enable_backend =
-  let open Clerk_rules in
-  function
-  | `Interpret | `OCaml -> OCaml
-  | `C -> C
-  | `Python -> Python
-  | `Java -> Java
+let backend_to_config = function
+  | `Interpret | `OCaml -> Clerk_config.OCaml
+  | `C -> Clerk_config.C
+  | `Python -> Clerk_config.Python
+  | `Java -> Clerk_config.Java
 
 let retrieve_target_items ?(test_only = true) items files_or_folders =
   let open File in
@@ -797,7 +800,7 @@ let build_test_deps
     List.map (fun it -> it, make_target ~build_dir ~backend it) target_items
   in
   let link_deps = linking_dependencies items in
-  let runtime_targets = backend_runtime_targets [enable_backend backend] in
+  let runtime_targets = backend_runtime_targets [backend_to_config backend] in
   let ninja_targets =
     let backend =
       match backend with
@@ -899,8 +902,10 @@ let run_cmd =
       | _ -> true
     in
     let files_or_folders = List.map config.Cli.fix_path files_or_folders in
-    Clerk_rules.run_ninja ~config ~code_coverage:false
-      ~enabled_backends:[enable_backend_module backend]
+    let enabled_backends =
+      [Clerk_rules.backend_from_config (backend_to_config backend)]
+    in
+    Clerk_rules.run_ninja ~config ~code_coverage:false ~enabled_backends
       ~ninja_flags ~autotest:false ~quiet
       (build_test_deps ~config ~backend ~test_only files_or_folders)
     |> fun tests ->
@@ -1066,7 +1071,7 @@ let clean_cmd =
 
 let check_clerk_targets_tests backend clerk_targets =
   (* Check targets specific backend support *)
-  let enabled_backend = enable_backend backend in
+  let enabled_backend = backend_to_config backend in
   let pp_target_list fmt ts =
     Format.(
       pp_print_list
@@ -1077,10 +1082,7 @@ let check_clerk_targets_tests backend clerk_targets =
   (if backend = `Interpret then ()
    else
      List.filter
-       (fun t ->
-         List.map Clerk_rules.backend_from_config t.Config.backends
-         |> List.mem enabled_backend
-         |> not)
+       (fun t -> t.Config.backends |> List.mem enabled_backend |> not)
        clerk_targets
      |> function
      | [] -> ()
@@ -1151,9 +1153,9 @@ let run_clerk_test
   in
   let enabled_backends =
     [
-      enable_backend backend
+      backend_to_config backend
       (* Clerk_rules.OCaml backend is required as autotest flag is true *);
-      Clerk_rules.OCaml;
+      Clerk_config.OCaml;
     ]
     |> normalize_backends
   in
@@ -1161,8 +1163,8 @@ let run_clerk_test
     let files_or_folders =
       match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
     in
-    Clerk_rules.run_ninja ~quiet ~code_coverage ~tests:(backend = `Interpret)
-      ~config ~enabled_backends ~ninja_flags ~autotest:true ~clean_up_env:true
+    Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~enabled_backends
+      ~ninja_flags ~autotest:true ~clean_up_env:true
       (build_test_deps ~config ~backend files_or_folders)
     |> run_targets ~test:true config backend "" None None
   else
@@ -1320,9 +1322,7 @@ let start_cmd =
     let targets = config.Cli.options.targets in
     let enabled_backends =
       let open Clerk_config in
-      List.concat_map
-        (fun target -> List.map Clerk_rules.backend_from_config target.backends)
-        targets
+      List.concat_map (fun target -> target.backends) targets
       |> normalize_backends
     in
     let default =
@@ -1386,15 +1386,14 @@ let ci_cmd =
         let _ = build_clerk_target ~quiet ~config ~ninja_flags:[] t in
         List.iter
           (fun bk ->
-            let bk_rule = rules_backend (Clerk_rules.backend_from_config bk) in
             stop_on_failure
             @@ fun () ->
             Message.debug
               "Running @{<yellow>%s@} backend tests for @{<cyan>[%s]@} target"
               t.tname
-              (string_of_backend bk_rule);
-            run_clerk_test config quiet [t.tname] bk_rule false verbosity
-              report_format code_coverage diff_command [])
+              (string_of_config_backend bk);
+            run_clerk_test config quiet [t.tname] (config_backend bk) false
+              verbosity report_format code_coverage diff_command [])
           t.backends)
       targets;
     raise (Catala_utils.Cli.Exit_with 0)
@@ -1463,7 +1462,7 @@ let list_vars_cmd =
   let run config =
     let var_bindings =
       Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
-        ~enabled_backends:Clerk_rules.all_backends_module ~config
+        ~enabled_backends:Clerk_rules.all_backends ~config
     in
     Format.eprintf "Defined variables:@.";
     Format.open_vbox 0;

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -96,7 +96,7 @@ let extensions_backend =
 
 let backend_subdir_list =
   List.map
-    (fun (bk, (module B : Clerk_backends.Backend.S)) -> bk, B.subdir)
+    (fun (bk, (module B : Clerk_backends.Backend.S)) -> bk, B.name)
     all_backends_with_config
 
 let normalize_backends backends =

--- a/build_system/clerk_lib/clerk_config.mli
+++ b/build_system/clerk_lib/clerk_config.mli
@@ -20,6 +20,7 @@ type backend = ..
 type backend += C | OCaml | Java | Python
 
 val register_backend : name:string -> backend -> unit
+val registered_backends : unit -> (string * backend) list
 
 type doc_backend = Html | Latex
 

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -22,12 +22,9 @@ module Nj = Ninja_utils
 
 (**{1 Building rules}*)
 
-type backend = OCaml | Python | C | Java (* | JS *)
-type backend_module = (module Clerk_backends.Backend.S)
+type backend = (module Clerk_backends.Backend.S)
 
-let all_backends = [OCaml; Python; C; Java]
-
-let all_backends_module : backend_module list =
+let all_backends : backend list =
   [
     (module Clerk_backends.Ocaml.Backend);
     (module Clerk_backends.C.Backend);
@@ -35,17 +32,15 @@ let all_backends_module : backend_module list =
     (module Clerk_backends.Python.Backend);
   ]
 
-let backend_module_from_backend = function
-  | OCaml -> (module Clerk_backends.Ocaml.Backend : Clerk_backends.Backend.S)
-  | Python -> (module Clerk_backends.Python.Backend : Clerk_backends.Backend.S)
-  | C -> (module Clerk_backends.C.Backend : Clerk_backends.Backend.S)
-  | Java -> (module Clerk_backends.Java.Backend : Clerk_backends.Backend.S)
-
 let backend_from_config = function
-  | Clerk_config.OCaml -> OCaml
-  | Clerk_config.Python -> Python
-  | Clerk_config.C -> C
-  | Clerk_config.Java -> Java
+  | Clerk_config.OCaml ->
+    (module Clerk_backends.Ocaml.Backend : Clerk_backends.Backend.S)
+  | Clerk_config.Python ->
+    (module Clerk_backends.Python.Backend : Clerk_backends.Backend.S)
+  | Clerk_config.C ->
+    (module Clerk_backends.C.Backend : Clerk_backends.Backend.S)
+  | Clerk_config.Java ->
+    (module Clerk_backends.Java.Backend : Clerk_backends.Backend.S)
   | _ -> invalid_arg __FUNCTION__
 
 let base_bindings ~code_coverage ~autotest ~enabled_backends ~config =
@@ -509,7 +504,7 @@ let run_ninja
     ?(include_dir = true)
     ~config
     ?(tests = false)
-    ?(enabled_backends = all_backends_module)
+    ?(enabled_backends = all_backends)
     ~quiet
     ~code_coverage
     ~autotest

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -23,8 +23,23 @@ module Nj = Ninja_utils
 (**{1 Building rules}*)
 
 type backend = OCaml | Python | C | Java (* | JS *)
+type backend_module = (module Clerk_backends.Backend.S)
 
 let all_backends = [OCaml; Python; C; Java]
+
+let all_backends_module : backend_module list =
+  [
+    (module Clerk_backends.Ocaml.Backend);
+    (module Clerk_backends.C.Backend);
+    (module Clerk_backends.Java.Backend);
+    (module Clerk_backends.Python.Backend);
+  ]
+
+let backend_module_from_backend = function
+  | OCaml -> (module Clerk_backends.Ocaml.Backend : Clerk_backends.Backend.S)
+  | Python -> (module Clerk_backends.Python.Backend : Clerk_backends.Backend.S)
+  | C -> (module Clerk_backends.C.Backend : Clerk_backends.Backend.S)
+  | Java -> (module Clerk_backends.Java.Backend : Clerk_backends.Backend.S)
 
 let backend_from_config = function
   | Clerk_config.OCaml -> OCaml
@@ -33,66 +48,6 @@ let backend_from_config = function
   | Clerk_config.Java -> Java
   | _ -> invalid_arg __FUNCTION__
 
-let name = function
-  | OCaml -> "ocaml"
-  | Python -> "python"
-  | C -> "c"
-  | Java -> "java"
-
-let module_extension = function
-  | OCaml -> "@ocaml-module"
-  | Python -> ".py"
-  | C -> "@c-module"
-  | Java -> ".class"
-
-let backend_modfile = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.modfile
-  | Python -> Clerk_backends.Python.Backend.modfile
-  | C -> Clerk_backends.C.Backend.modfile
-  | Java -> Clerk_backends.Java.Backend.modfile
-
-let backend_flags = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.Flags.default
-  | C -> Clerk_backends.C.Backend.Flags.default
-  | Python -> Clerk_backends.Python.Backend.Flags.default
-  | Java -> Clerk_backends.Java.Backend.Flags.default
-
-let static_base_rules = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.static_base_rules
-  | C -> Clerk_backends.C.Backend.static_base_rules
-  | Python -> Clerk_backends.Python.Backend.static_base_rules
-  | Java -> Clerk_backends.Java.Backend.static_base_rules
-
-let external_copy = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.external_copy
-  | C -> Clerk_backends.C.Backend.external_copy
-  | Python -> Clerk_backends.Python.Backend.external_copy
-  | Java -> Clerk_backends.Java.Backend.external_copy
-
-let catala = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.catala
-  | C -> Clerk_backends.C.Backend.catala
-  | Python -> Clerk_backends.Python.Backend.catala
-  | Java -> Clerk_backends.Java.Backend.catala
-
-let build_object = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.build_object
-  | C -> Clerk_backends.C.Backend.build_object
-  | Python -> Clerk_backends.Python.Backend.build_object
-  | Java -> Clerk_backends.Java.Backend.build_object
-
-let runtime_build_statements = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.runtime_build_statements
-  | C -> Clerk_backends.C.Backend.runtime_build_statements
-  | Python -> Clerk_backends.Python.Backend.runtime_build_statements
-  | Java -> Clerk_backends.Java.Backend.runtime_build_statements
-
-let expose_module = function
-  | OCaml -> Clerk_backends.Ocaml.Backend.expose_module
-  | C -> Clerk_backends.C.Backend.expose_module
-  | Python -> Clerk_backends.Python.Backend.expose_module
-  | Java -> Clerk_backends.Java.Backend.expose_module
-
 let base_bindings ~code_coverage ~autotest ~enabled_backends ~config =
   let options = config.Clerk_cli.options in
   let test_flags = config.Clerk_cli.test_flags in
@@ -100,8 +55,10 @@ let base_bindings ~code_coverage ~autotest ~enabled_backends ~config =
   let default_flags = Backend_common.Flags.default ~code_coverage ~config in
   let backend_flags =
     List.concat_map
-      (backend_flags ~variables:options.variables ~autotest ~use_default_flags
-         ~test_flags ~include_dirs:options.global.include_dirs)
+      (fun (module Backend : Clerk_backends.Backend.S) ->
+        Backend.Flags.default ~variables:options.variables ~autotest
+          ~use_default_flags ~test_flags
+          ~include_dirs:options.global.include_dirs)
       enabled_backends
   in
   default_flags @ backend_flags
@@ -125,14 +82,17 @@ let static_base_rules ~tests enabled_backends =
     else []
   in
   let backend_static_rules =
-    List.concat_map static_base_rules enabled_backends
+    List.concat_map
+      (fun (module Backend : Clerk_backends.Backend.S) ->
+        Backend.static_base_rules)
+      enabled_backends
   in
   Backend_common.Ninja.static_base_rules @ backend_static_rules @ test_rules
 
 let gen_build_statements
     (include_dirs : string list)
     ~(tests : bool)
-    (enabled_backends : backend list)
+    (enabled_backends : (module Clerk_backends.Backend.S) list)
     (autotest : bool)
     (same_dir_modules : (string * File.t) list)
     ~is_stdlib
@@ -173,13 +133,17 @@ let gen_build_statements
     | None -> []
     | Some _ ->
       List.concat_map
-        (expose_module ~same_dir_modules ~used_modules:modules)
+        (fun (module Backend : Clerk_backends.Backend.S) ->
+          Backend.expose_module ~same_dir_modules ~used_modules:modules)
         enabled_backends
   in
   let has_scope_tests = Lazy.force item.has_scope_tests in
   let backend_sources =
     if item.extrnal then
-      List.map (fun backend -> external_copy backend item) enabled_backends
+      List.map
+        (fun (module Backend : Clerk_backends.Backend.S) ->
+          Backend.external_copy item)
+        enabled_backends
     else
       let inputs = [catala_src] in
       let implicit_in =
@@ -194,14 +158,14 @@ let gen_build_statements
         else None
       in
       List.map
-        (fun backend ->
-          catala ?vars ~is_stdlib ~inputs ~implicit_in backend has_scope_tests)
+        (fun (module Backend : Clerk_backends.Backend.S) ->
+          Backend.catala ?vars ~is_stdlib ~inputs ~implicit_in has_scope_tests)
         enabled_backends
   in
   let backend_objects =
     List.map
-      (fun backend ->
-        build_object ~include_dirs ~same_dir_modules ~item backend
+      (fun (module Backend : Clerk_backends.Backend.S) ->
+        Backend.build_object ~include_dirs ~same_dir_modules ~item
           has_scope_tests)
       enabled_backends
   in
@@ -220,13 +184,13 @@ let gen_build_statements
       let modname = Mark.remove m in
       let backends_module =
         List.map
-          (fun backend ->
+          (fun (module Backend : Clerk_backends.Backend.S) ->
             Nj.build "phony"
-              ~outputs:[Format.sprintf "%s@%s-module" modname (name backend)]
+              ~outputs:[Format.sprintf "%s@%s-module" modname Backend.name]
               ~inputs:
                 [
-                  backend_modfile backend ~is_stdlib:item.is_stdlib
-                    same_dir_modules (module_extension backend) modname;
+                  Backend.modfile ~is_stdlib same_dir_modules Backend.module_ext
+                    modname;
                 ])
           enabled_backends
       in
@@ -268,7 +232,7 @@ let gen_build_statements_dir
     (dir : string)
     (include_dirs : string list)
     ~(tests : bool)
-    (enabled_backends : backend list)
+    (enabled_backends : (module Clerk_backends.Backend.S) list)
     (autotest : bool)
     (items : Scan.item list) : Nj.ninja =
   let same_dir_modules =
@@ -347,7 +311,10 @@ let runtime_build_statements ~config enabled_backends =
   let open File in
   let stdbase = Var.(!builddir) / Scan.libcatala in
   let options = config.Clerk_lib.Clerk_cli.options in
-  List.concat_map (runtime_build_statements ~options ~stdbase) enabled_backends
+  List.concat_map
+    (fun (module Backend : Clerk_backends.Backend.S) ->
+      Backend.runtime_build_statements ~options ~stdbase)
+    enabled_backends
 
 let output_ninja_file_header pp ~config ~tests ~enabled_backends ~var_bindings =
   pp
@@ -373,7 +340,7 @@ let output_ninja_file_item_statements
     match seq () with
     | Seq.Cons ((dir, subdirs, items), seq) ->
       Nj.format nin_ppf
-      @@ gen_build_statements_dir dir ~tests ~is_stdlib
+      @@ gen_build_statements_dir dir ~is_stdlib ~tests
            config.Clerk_cli.options.global.include_dirs enabled_backends
            autotest items;
       if (not is_stdlib) && tests then
@@ -542,7 +509,7 @@ let run_ninja
     ?(include_dir = true)
     ~config
     ?(tests = false)
-    ?(enabled_backends = all_backends)
+    ?(enabled_backends = all_backends_module)
     ~quiet
     ~code_coverage
     ~autotest

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -17,27 +17,23 @@
 
 open Clerk_utils
 
-type backend = OCaml | Python | C | Java
-type backend_module = (module Clerk_backends.Backend.S)
+type backend = (module Clerk_backends.Backend.S)
 
 val all_backends : backend list
-val all_backends_module : backend_module list
 val backend_from_config : Clerk_config.backend -> backend
 
 val base_bindings :
   code_coverage:bool ->
   autotest:bool ->
-  enabled_backends:backend_module list ->
+  enabled_backends:backend list ->
   config:Clerk_cli.config ->
   (Var.t * string list) list
-
-val backend_module_from_backend : backend -> backend_module
 
 val run_ninja :
   ?include_dir:bool ->
   config:Clerk_cli.config ->
   ?tests:bool ->
-  ?enabled_backends:backend_module list ->
+  ?enabled_backends:backend list ->
   quiet:bool ->
   code_coverage:bool ->
   autotest:bool ->

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -18,22 +18,26 @@
 open Clerk_utils
 
 type backend = OCaml | Python | C | Java
+type backend_module = (module Clerk_backends.Backend.S)
 
 val all_backends : backend list
+val all_backends_module : backend_module list
 val backend_from_config : Clerk_config.backend -> backend
 
 val base_bindings :
   code_coverage:bool ->
   autotest:bool ->
-  enabled_backends:backend list ->
+  enabled_backends:backend_module list ->
   config:Clerk_cli.config ->
   (Var.t * string list) list
+
+val backend_module_from_backend : backend -> backend_module
 
 val run_ninja :
   ?include_dir:bool ->
   config:Clerk_cli.config ->
   ?tests:bool ->
-  ?enabled_backends:backend list ->
+  ?enabled_backends:backend_module list ->
   quiet:bool ->
   code_coverage:bool ->
   autotest:bool ->


### PR DESCRIPTION
Remove the clerk_rules backend type as it's the exact same as the one from Clerk_config now that the Test backend has been removed.

Instead of dispatching the functions with a pattern matching use 1st class module list