### PR TITLE
Draft: A backend for each file instead of having a enabled backends for all

### DIFF
--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -277,8 +277,8 @@ let build_clerk_target
     |> normalize_backends
   in
   let install_targets, all_modules_deps =
-    Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends
-      ~ninja_flags ~quiet ~autotest:false
+    Clerk_rules.run_ninja ~code_coverage:false ~config ~ninja_flags ~quiet
+      ~autotest:false
     @@ fun nin_ppf items _var_bindings ->
     let find_module_item module_name =
       try
@@ -449,7 +449,7 @@ let build_direct_targets
         direct_targets
     in
     let backends = if autotest then [Clerk_rules.OCaml] else [] in
-    let enabled_backends =
+    let _enabled_backends =
       List.fold_left
         (fun acc t ->
           match File.extension t with
@@ -459,8 +459,7 @@ let build_direct_targets
       |> normalize_backends
     in
     let ninja_targets, exec_targets, var_bindings, link_deps =
-      Clerk_rules.run_ninja ~code_coverage ~config ~enabled_backends ~quiet
-        ~ninja_flags ~autotest
+      Clerk_rules.run_ninja ~code_coverage ~config ~quiet ~ninja_flags ~autotest
       @@ fun nin_ppf items var_bindings ->
       let link_deps = linking_dependencies items in
       let build_dir = config.Cli.options.global.build_dir in
@@ -893,9 +892,8 @@ let run_cmd =
       | _ -> true
     in
     let files_or_folders = List.map config.Cli.fix_path files_or_folders in
-    Clerk_rules.run_ninja ~config ~code_coverage:false
-      ~enabled_backends:[enable_backend backend]
-      ~ninja_flags ~autotest:false ~quiet
+    Clerk_rules.run_ninja ~config ~code_coverage:false ~ninja_flags
+      ~autotest:false ~quiet
       (build_test_deps ~config ~backend ~test_only files_or_folders)
     |> fun tests ->
     if prepare_only then Cmd.Exit.ok
@@ -1175,8 +1173,8 @@ let run_clerk_test
     match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
   in
   if backend <> `Interpret then
-    Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~enabled_backends
-      ~ninja_flags ~autotest:true ~clean_up_env:true
+    Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~ninja_flags
+      ~autotest:true ~clean_up_env:true
       (build_test_deps ~config ~backend files_or_folders)
     |> run_targets ~test:true config backend "" None None
   else
@@ -1347,7 +1345,7 @@ let start_cmd =
         enabled_backends
     in
     Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet ~config
-      ~enabled_backends ~autotest:false ~ninja_flags (fun nin_ppf _ _ ->
+      ~autotest:false ~ninja_flags (fun nin_ppf _ _ ->
         Nj.format_def nin_ppf (Nj.Default (Nj.Default.make default));
         0)
   in
@@ -1495,8 +1493,8 @@ let list_vars_cmd =
 let json_schema_cmd =
   let run config ninja_flags quiet file scope =
     let file = config.Cli.fix_path file in
-    Clerk_rules.run_ninja ~config ~code_coverage:false ~enabled_backends:[OCaml]
-      ~ninja_flags ~autotest:false ~quiet
+    Clerk_rules.run_ninja ~config ~code_coverage:false ~ninja_flags
+      ~autotest:false ~quiet
       (build_test_deps ~config ~backend:`Interpret ~test_only:false [file])
     |> fun (items, _link_deps, var_bindings) ->
     let catala_exe = Var.get_var var_bindings Var.catala_exe in

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1068,30 +1068,46 @@ let check_clerk_targets_tests backend clerk_targets =
         (fun fmt t -> fprintf fmt "@{<cyan>[%s]@}" t.Config.tname))
       fmt ts
   in
-  (if backend = `Interpret then ()
-   else
-     List.filter
-       (fun t ->
-         List.map Clerk_rules.backend_from_config t.Config.backends
-         |> List.mem enabled_backend
-         |> not)
-       clerk_targets
-     |> function
-     | [] -> ()
-     | t ->
-       Message.error
-         "Backend @{<bold>%s@} is not supported by the following target(s): %a"
-         (string_of_backend backend)
-         pp_target_list t);
-  (* Check that targets have tests *)
-  List.filter (fun t -> t.Config.ttests = []) clerk_targets
-  |> function
-  | [] -> ()
-  | [t] ->
-    Message.error "Target %a has no @{<bold>tests@} attached" pp_target_list [t]
-  | ts ->
-    Message.error "Targets { %a } have no @{<bold>tests@} attached"
-      pp_target_list ts
+  if backend = `Interpret then clerk_targets
+  else
+    let clerk_targets, invalid_targets =
+      List.partition_map
+        (fun t ->
+          (* Retrieve the backends of a target and verify if the target is
+             affected by the command (the target is affected if the enabled
+             backend is supported by the target)*)
+          let backends =
+            List.map Clerk_rules.backend_from_config t.Config.backends
+          in
+          if List.mem enabled_backend backends then Either.Left t
+          else Either.right t)
+        clerk_targets
+    in
+    (match invalid_targets with
+    | [] -> ()
+    | t ->
+      (* Print a friendly warning to specify the user that among the selected
+         target some doesn't support the specified backend. *)
+      Message.warning
+        "Backend @{<bold>%s@} is not supported by the following target(s): %a"
+        (string_of_backend backend)
+        pp_target_list t);
+    (* Check that targets have tests *)
+    let clerk_targets, no_tests_target =
+      List.partition_map
+        (fun t ->
+          if t.Config.ttests <> [] then Either.Left t else Either.Right t)
+        clerk_targets
+    in
+    (match no_tests_target with
+    | [] -> ()
+    | [t] ->
+      Message.warning "Target %a has no @{<bold>tests@} attached" pp_target_list
+        [t]
+    | ts ->
+      Message.warning "Targets %a have no @{<bold>tests@} attached"
+        pp_target_list ts);
+    clerk_targets
 
 let run_clerk_test
     config
@@ -1133,9 +1149,13 @@ let run_clerk_test
          @{<yellow>interpret@} backend. Please use a backend-specific coverage \
          tool instead.";
   let { clerk_targets; others = files_or_folders } =
-    classify_targets config clerk_targets_or_files_or_folders
+    (* Check if the users gave a target in parameter, if not we assume that all
+       targets are involved. *)
+    match clerk_targets_or_files_or_folders with
+    | [] -> { clerk_targets = config.Cli.options.targets; others = [] }
+    | targets -> classify_targets config targets
   in
-  let () = check_clerk_targets_tests backend clerk_targets in
+  let clerk_targets = check_clerk_targets_tests backend clerk_targets in
   let files_or_folders =
     List.concat_map
       (fun t -> List.map File.clean_path t.Config.ttests)
@@ -1151,26 +1171,22 @@ let run_clerk_test
     ]
     |> normalize_backends
   in
+  let files_or_folders =
+    match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
+  in
   if backend <> `Interpret then
-    let files_or_folders =
-      match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
-    in
     Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~enabled_backends
       ~ninja_flags ~autotest:true ~clean_up_env:true
       (build_test_deps ~config ~backend files_or_folders)
     |> run_targets ~test:true config backend "" None None
   else
     let targets, missing =
-      let fs =
-        if files_or_folders = [] then [Filename.current_dir_name]
-        else files_or_folders
-      in
       List.partition_map
         File.(
           fun f ->
             if File.exists f then Either.Left (build_dir / f)
             else Either.Right f)
-        fs
+        files_or_folders
     in
     if missing <> [] then
       Message.error "@[<hv 2>Could not find files:@ @[<hov>%a@]@]"

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -102,9 +102,6 @@ let backend_subdir_list =
 let normalize_backends : Clerk_rules.backend list -> Clerk_rules.backend list =
   List.sort_uniq Stdlib.compare
 
-let subdir_backend_list =
-  List.map (fun (bk, dir) -> dir, bk) backend_subdir_list
-
 let backend_subdir bk = List.assoc bk backend_subdir_list
 
 let rule_subdir rule =
@@ -148,28 +145,6 @@ let linking_command ~build_dir ~backend ~var_bindings link_deps item target =
                (Var.make (String.sub s 1 (String.length s - 1)))
            else [Var.expand_vars var_bindings s])
          rule.Config.commandline
-
-let target_backend config t =
-  let aux ext =
-    try List.assoc ext extensions_backend
-    with Not_found -> (
-      if ext = "" then Message.error "Target without extension: @{<red>%S@}" t
-      else
-        match
-          List.find_opt
-            (fun rule -> List.mem ext rule.Config.out_exts)
-            config.Config.custom_rules
-        with
-        | Some rule -> Clerk_rules.backend_from_config rule.Config.backend
-        | None ->
-          Message.error
-            "Unhandled extension @{<red;bold>%s@} for target @{<red>%S@}" ext t)
-  in
-  match File.extension t with
-  | "exe" -> (
-    try List.assoc File.(basename (dirname t)) subdir_backend_list
-    with Not_found -> Clerk_rules.OCaml)
-  | ext -> aux ext
 
 let rules_backend = function
   | Clerk_rules.OCaml -> `OCaml
@@ -447,16 +422,6 @@ let build_direct_targets
           then t
           else File.(build_dir / t))
         direct_targets
-    in
-    let backends = if autotest then [Clerk_rules.OCaml] else [] in
-    let _enabled_backends =
-      List.fold_left
-        (fun acc t ->
-          match File.extension t with
-          | "" -> Clerk_rules.OCaml :: acc
-          | _ -> target_backend config.options t :: acc)
-        backends direct_targets
-      |> normalize_backends
     in
     let ninja_targets, exec_targets, var_bindings, link_deps =
       Clerk_rules.run_ninja ~code_coverage ~config ~quiet ~ninja_flags ~autotest
@@ -985,8 +950,8 @@ let typecheck_cmd =
     in
     let exception Nothing_to_do in
     match
-      Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends:[]
-        ~autotest:false ~ninja_flags ~quiet (fun nin_ppf items var_bindings ->
+      Clerk_rules.run_ninja ~code_coverage:false ~config ~autotest:false
+        ~ninja_flags ~quiet (fun nin_ppf items var_bindings ->
           let target_items = retrieve_typecheck_items items files_or_folders in
           if target_items = [] then
             (* Prevents [run_ninja] to fail miserably with an obscure error *)
@@ -1161,14 +1126,6 @@ let run_clerk_test
     @ List.map config.Cli.fix_path files_or_folders
     |> List.sort_uniq String.compare
   in
-  let enabled_backends =
-    [
-      enable_backend backend
-      (* Clerk_rules.OCaml backend is required as autotest flag is true *);
-      Clerk_rules.OCaml;
-    ]
-    |> normalize_backends
-  in
   let files_or_folders =
     match files_or_folders with [] -> [Filename.current_dir_name] | fs -> fs
   in
@@ -1193,9 +1150,8 @@ let run_clerk_test
            Format.pp_print_string)
         missing;
     let test_targets =
-      Clerk_rules.run_ninja ~code_coverage ~config ~tests:true ~enabled_backends
-        ~ninja_flags ~autotest:false ~quiet ~clean_up_env:true
-        (fun nin_ppf _items _vars ->
+      Clerk_rules.run_ninja ~code_coverage ~config ~tests:true ~ninja_flags
+        ~autotest:false ~quiet ~clean_up_env:true (fun nin_ppf _items _vars ->
           (* FIXME: remove and warn about files that have no @tests rule *)
           let test_targets = List.map (fun f -> f ^ "@test") targets in
           Nj.format_def nin_ppf (Nj.Default (Nj.Default.make test_targets));

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -681,6 +681,7 @@ let run_ninja
           (fun target ->
             List.map backend_from_config target.Clerk_config.backends)
           config.options.targets
+        |> List.sort_uniq Stdlib.compare
       in
       let stdlib_dir = Lazy.force Poll.stdlib_dir in
       let stdlib_tree =

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -602,7 +602,8 @@ let backends_per_item (targets : Clerk_config.target list) items =
           (fun it ->
             ( it,
               List.map backend_from_config
-              @@ String.Map.find it.Scan.file_name backends ))
+                (Option.value ~default:[]
+                @@ String.Map.find_opt it.Scan.file_name backends) ))
           items
       in
       dir, sub_dir, items)

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -583,6 +583,7 @@ let backends_per_item (targets : Clerk_config.target list) items =
   let backends =
     List.fold_left
       (fun acc (target, backends) ->
+        let acc = String.Map.add target.Scan.file_name backends acc in
         let deps = get_deps target in
         List.fold_left
           (fun acc dep ->
@@ -612,25 +613,15 @@ let backends_per_item (targets : Clerk_config.target list) items =
 let run_ninja
     ?(include_dir = true)
     ~config
-    ?(tests = false)
-    ?(enabled_backends = all_backends)
     ~quiet
+    ?(tests = false)
     ~code_coverage
     ~autotest
     ?(clean_up_env = false)
     ?(ninja_flags = [])
     callback =
-  let var_bindings =
-    base_bindings ~code_coverage ~config ~enabled_backends ~autotest
-  in
   with_ninja_process ~config ~clean_up_env ~ninja_flags ~quiet (fun nin_ppf ->
       let insource = Lazy.force Poll.catala_source_tree_root <> None in
-      let stdlib_dir = Lazy.force Poll.stdlib_dir in
-      let stdlib_tree =
-        Scan.tree stdlib_dir
-        |> Seq.map (fun (f, fl, items) ->
-            f, fl, List.map (fun it -> it, enabled_backends) items)
-      in
       let item_tree = if include_dir then Scan.tree "." else Seq.empty in
       let item_tree =
         item_tree
@@ -685,6 +676,22 @@ let run_ninja
               Some (f, fl, items))
       in
       let item_tree = backends_per_item config.options.targets item_tree in
+      let enabled_backends =
+        List.concat_map
+          (fun target ->
+            List.map backend_from_config target.Clerk_config.backends)
+          config.options.targets
+      in
+      let stdlib_dir = Lazy.force Poll.stdlib_dir in
+      let stdlib_tree =
+        Scan.tree stdlib_dir
+        |> Seq.map (fun (f, fl, items) ->
+            f, fl, List.map (fun it -> it, enabled_backends) items)
+      in
+
+      let var_bindings =
+        base_bindings ~code_coverage ~config ~enabled_backends ~autotest
+      in
       let items =
         output_ninja_file nin_ppf ~config ~tests ~enabled_backends ~autotest
           ~var_bindings stdlib_tree item_tree

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -268,12 +268,11 @@ let gen_build_statements_dir
     (dir : string)
     (include_dirs : string list)
     ~(tests : bool)
-    (enabled_backends : backend list)
     (autotest : bool)
-    (items : Scan.item list) : Nj.ninja =
+    (items : (Scan.item * backend list) list) : Nj.ninja =
   let same_dir_modules =
     List.filter_map
-      (fun item ->
+      (fun (item, _) ->
         Option.map
           (fun name -> Mark.remove name, item.Scan.file_name)
           item.Scan.module_def)
@@ -291,7 +290,11 @@ let gen_build_statements_dir
         File.format (File.basename s)
     | None -> String.Map.add s fname seen
   in
-  let _names = List.fold_left check_conflicts String.Map.empty items in
+  let _names =
+    List.fold_left
+      (fun acc (item, _) -> check_conflicts acc item)
+      String.Map.empty items
+  in
   let dir =
     if Filename.is_relative dir (* Detect stdlib modules *) then dir
     else Scan.libcatala
@@ -303,8 +306,9 @@ let gen_build_statements_dir
   @@ Seq.cons (Nj.comment "")
   @@ Seq.cons (Nj.binding Var.tdir [!Var.builddir / dir])
   @@ Seq.flat_map
-       (gen_build_statements ~tests ~is_stdlib include_dirs enabled_backends
-          autotest same_dir_modules)
+       (fun (item, enabled_backends) ->
+         gen_build_statements ~tests ~is_stdlib include_dirs enabled_backends
+           autotest same_dir_modules item)
        (List.to_seq items)
 
 let dir_test_rules dir subdirs items =
@@ -320,7 +324,7 @@ let dir_test_rules dir subdirs items =
     List.rev_append
       (List.rev_map (fun s -> (Var.(!builddir) / s) ^ "@test") subdirs)
       (List.filter_map
-         (fun item ->
+         (fun (item, _) ->
            if
              not
                (item.Scan.has_inline_tests
@@ -364,7 +368,6 @@ let output_ninja_file_item_statements
     nin_ppf
     ~config
     ~tests
-    ~enabled_backends
     ~autotest
     ~is_stdlib
     item_tree
@@ -374,8 +377,7 @@ let output_ninja_file_item_statements
     | Seq.Cons ((dir, subdirs, items), seq) ->
       Nj.format nin_ppf
       @@ gen_build_statements_dir dir ~tests ~is_stdlib
-           config.Clerk_cli.options.global.include_dirs enabled_backends
-           autotest items;
+           config.Clerk_cli.options.global.include_dirs autotest items;
       if (not is_stdlib) && tests then
         Nj.format nin_ppf @@ dir_test_rules dir subdirs items;
       Seq.append (List.to_seq items) (print_and_get_items seq) ()
@@ -399,13 +401,13 @@ let output_ninja_file
   output_ninja_file_header pp ~config ~tests ~enabled_backends ~var_bindings;
   pp (Nj.Comment "\n- Standard library build statements - #");
   Seq.memoize
-  @@ output_ninja_file_item_statements nin_ppf ~config ~tests ~enabled_backends
-       ~autotest ~is_stdlib:true stdlib_tree
+  @@ output_ninja_file_item_statements nin_ppf ~config ~tests ~autotest
+       ~is_stdlib:true stdlib_tree
   @@ Seq.append (fun () ->
       pp (Nj.Comment "\n- Project-specific build statements - #");
       Seq.Nil)
-  @@ output_ninja_file_item_statements nin_ppf ~config ~tests ~enabled_backends
-       ~autotest ~is_stdlib:false project_tree
+  @@ output_ninja_file_item_statements nin_ppf ~config ~tests ~autotest
+       ~is_stdlib:false project_tree
   @@ fun () ->
   pp (Nj.Comment "\n- Global rules and defaults - #\n");
   if tests then
@@ -538,6 +540,74 @@ let with_ninja_process
     wait ();
     callback_ret
 
+let backends_per_item (targets : Clerk_config.target list) items =
+  let modules =
+    Seq.fold_left
+      (fun acc (_dir, _sub_dirs, it_list) ->
+        List.fold_left
+          (fun acc it ->
+            match it.Scan.module_def with
+            | Some m -> String.Map.add (Mark.remove m) it acc
+            | None -> acc)
+          acc it_list)
+      String.Map.empty items
+  in
+  let targets =
+    List.concat_map
+      (fun t ->
+        List.map
+          (fun mname -> String.Map.find mname modules, t.Clerk_config.backends)
+          t.Clerk_config.tmodules)
+      targets
+  in
+  let rem_dups l =
+    let rec aux seen = function
+      | it :: r ->
+        if String.Set.mem it.Scan.file_name seen then aux seen r
+        else it :: aux (String.Set.add it.Scan.file_name seen) r
+      | [] -> []
+    in
+    aux String.Set.empty l
+  in
+  let get_deps item =
+    let rec traverse acc item =
+      List.fold_left
+        (fun acc m ->
+          match String.Map.find_opt (Mark.remove m) modules with
+          | None -> acc
+          | Some it -> traverse (it :: acc) it)
+        acc item.Scan.used_modules
+    in
+    rem_dups (traverse [] item)
+  in
+  let backends =
+    List.fold_left
+      (fun acc (target, backends) ->
+        let deps = get_deps target in
+        List.fold_left
+          (fun acc dep ->
+            match String.Map.find_opt dep.Scan.file_name acc with
+            | None -> String.Map.add dep.Scan.file_name backends acc
+            | Some b ->
+              String.Map.add dep.Scan.file_name
+                (List.sort_uniq Stdlib.compare (backends @ b))
+                acc)
+          acc deps)
+      String.Map.empty targets
+  in
+  Seq.map
+    (fun (dir, sub_dir, items) ->
+      let items =
+        List.map
+          (fun it ->
+            ( it,
+              List.map backend_from_config
+              @@ String.Map.find it.Scan.file_name backends ))
+          items
+      in
+      dir, sub_dir, items)
+    items
+
 let run_ninja
     ?(include_dir = true)
     ~config
@@ -556,7 +626,9 @@ let run_ninja
       let insource = Lazy.force Poll.catala_source_tree_root <> None in
       let stdlib_dir = Lazy.force Poll.stdlib_dir in
       let stdlib_tree =
-        Scan.tree stdlib_dir |> Seq.map (fun (f, fl, items) -> f, fl, items)
+        Scan.tree stdlib_dir
+        |> Seq.map (fun (f, fl, items) ->
+            f, fl, List.map (fun it -> it, enabled_backends) items)
       in
       let item_tree = if include_dir then Scan.tree "." else Seq.empty in
       let item_tree =
@@ -611,10 +683,13 @@ let run_ninja
               in
               Some (f, fl, items))
       in
+      let item_tree = backends_per_item config.options.targets item_tree in
       let items =
         output_ninja_file nin_ppf ~config ~tests ~enabled_backends ~autotest
           ~var_bindings stdlib_tree item_tree
       in
-      let ret = callback nin_ppf (List.of_seq items) var_bindings in
+      let ret =
+        callback nin_ppf (List.map fst (List.of_seq items)) var_bindings
+      in
       Format.pp_print_newline nin_ppf ();
       ret)

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -32,9 +32,8 @@ val base_bindings :
 val run_ninja :
   ?include_dir:bool ->
   config:Clerk_cli.config ->
-  ?tests:bool ->
-  ?enabled_backends:backend list ->
   quiet:bool ->
+  ?tests:bool ->
   code_coverage:bool ->
   autotest:bool ->
   ?clean_up_env:bool ->


### PR DESCRIPTION
When creating the clerk.ninja file to execute commands, clerk_rules retrieve the enabled backend by concatenation of all possible bakcends for all backends.

But this lead to an issue on external file for example, if I create a target A in OCaml with an external file (written in OCaml) and a target B in Java, Clerk will expect my external file from the target A to have an implementation in Java because the enabled_backends are OCaml and Java for all the files.

This is an attempt not finished to fix that (this is clearly not optimal the way I did it for now)
