### PR TITLE
fix missing parentheses in the ocaml printer

### DIFF
--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -317,7 +317,7 @@ let rec needs_parens ?context (e : 'm expr) : bool =
   match Mark.remove e with
   | EApp { f = EAbs { binder; _ }, _; _ } -> (
     match context with
-    | Some ((EInj _ | EArray _), _) -> true
+    | Some ((EInj _ | EArray _ | EApp _), _) -> true
     | _ ->
       let _, body = Bindlib.unmbind binder in
       needs_parens ?context body)


### PR DESCRIPTION
Fix missing case where parenthesizing was needed, thanks @AltGr for the fix