### PR TITLE
Stdlib/dates: add primitives for explicit rounding mode

### DIFF
--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -108,8 +108,8 @@ let formatter_of_out_channel ?(nocolor = false) oc =
   let ppf =
     lazy
       (if
-         Global.options.color = Always
-         || (Lazy.force tty && Sys.getenv_opt "TERM" <> Some "dumb")
+         (Global.options.color = Always || Lazy.force tty)
+         && Sys.getenv_opt "TERM" <> Some "dumb"
        then add_link_tags (Lazy.force ppf)
        else Lazy.force ppf)
   in

--- a/compiler/catala_utils/string.mli
+++ b/compiler/catala_utils/string.mli
@@ -45,12 +45,12 @@ val begins_with_uppercase : string -> bool
     Handles utf8. [false] if [s] is empty. *)
 
 val to_snake_case : string -> string
-(** Converts CamlCase into snake_case after removing Remove all diacritics on
-    Latin letters. *)
+(** Converts CamlCase into snake_case after removing all diacritics on Latin
+    letters. *)
 
 val to_camel_case : ?capitalize:bool -> string -> string
-(** Converts snake_case into CamlCase after removing Remove all diacritics on
-    Latin letters.
+(** Converts snake_case into CamlCase after removing all diacritics on Latin
+    letters.
 
     If [capitalize] is [false], the first letter is lowercase. Defaults to true.
 *)

--- a/stdlib/date_en.catala_en
+++ b/stdlib/date_en.catala_en
@@ -25,6 +25,55 @@ declaration max
     d2 content date
   equals
     if d1 >= d2 then d1 else d2
+
+## Adds a duration to a date, rounding to the previous day when ambiguous.
+## Note: this is the behaviour of "`+`" in scopes where `date round down` is set
+## **Examples:**
+## - `add_round_down of |2026-05-31|, 1 month = |2026-06-30|`
+## - `add_round_down of |2000-02-29|, 1 year = |2001-02-28|`
+declaration add_round_down content date
+  depends on
+    t content date,
+    dt content duration
+  equals
+  D.add_rounded_down of t, dt
+
+## Adds a duration to a date, rounding to the next day when ambiguous.
+## Note: this is the behaviour of "`+`" in scopes where `date round up` is set
+## **Examples:**
+## - `add_round_up of |2026-05-31|, 1 month = |2026-07-01|`
+## - `add_round_up of |2000-02-29|, 1 year = |2001-03-01|`
+declaration add_round_up content date
+  depends on
+    t content date,
+    dt content duration
+  equals
+  D.add_rounded_up of t, dt
+
+## Subtracts a duration from a date, rounding to the previous day when
+## ambiguous.
+## Note: this is the behaviour of "`-`" in scopes where `date round down` is set
+## **Examples:**
+## - `sub_round_down of |2026-05-31|, 1 month = |2026-04-30|`
+## - `sub_round_down of |2000-02-29|, 1 year = |1999-02-28|`
+declaration sub_round_down content date
+  depends on
+    t content date,
+    dt content duration
+  equals
+  D.add_rounded_down of t, -dt
+
+## Subtracts a duration from a date, rounding to the next day when ambiguous.
+## Note: this is the behaviour of "`-`" in scopes where `date round up` is set
+## **Examples:**
+## - `sub_round_up of |2026-05-31|, 1 month = |2026-05-01|`
+## - `sub_round_up of |2000-02-29|, 1 year = |1999-03-01|`
+declaration sub_round_up content date
+  depends on
+    t content date,
+    dt content duration
+  equals
+  D.add_rounded_up of t, -dt
 ```
 
 ## Dates and years, months and days

--- a/stdlib/date_fr.catala_fr
+++ b/stdlib/date_fr.catala_fr
@@ -25,6 +25,62 @@ déclaration max
     d2 contenu date
   égal à
     si d1 >= d2 alors d1 sinon d2
+
+## Ajoute une durée à une date, en arrondissant au jour précédent en cas
+## d'ambiguïté.
+## Note: Cela correspond au comportement de "`+`" dans les champs d'application
+## où `date arrondi inférieur` a été sélectionné.
+## **Exemples:**
+## - `ajout_arrondi_inférieur de |2026-05-31|, 1 mois = |2026-06-30|`
+## - `ajout_arrondi_inférieur de |2000-02-29|, 1 an = |2001-02-28|`
+déclaration ajout_arrondi_inférieur contenu date
+  dépend de
+    t contenu date,
+    dt contenu durée
+  égal à
+  D.add_rounded_down de t, dt
+
+## Ajoute une durée à une date, en arrondissant au jour suivant en cas
+## d'ambiguïté.
+## Note: Cela correspond au comportement de "`+`" dans les champs d'application
+## où `date arrondi supérieur` a été sélectionné.
+## **Exemples:**
+## - `ajout_arrondi_supérieur de |2026-05-31|, 1 mois = |2026-07-01|`
+## - `ajout_arrondi_supérieur de |2000-02-29|, 1 an = |2001-03-01|`
+déclaration ajout_arrondi_supérieur contenu date
+  dépend de
+    t contenu date,
+    dt contenu durée
+  égal à
+  D.add_rounded_up de t, dt
+
+## Retire une durée d'une date, en arrondissant au jour précédent en cas
+## d'ambiguïté.
+## Note: Cela correspond au comportement de "`-`" dans les champs d'application
+## où `date arrondi inférieur` a été sélectionné.
+## **Exemples:**
+## - `soustraction_arrondi_inférieur de |2026-05-31|, 1 mois = |2026-04-30|`
+## - `soustraction_arrondi_inférieur de |2000-02-29|, 1 an = |1999-02-28|`
+déclaration soustraction_arrondi_inférieur contenu date
+  dépend de
+    t contenu date,
+    dt contenu durée
+  égal à
+  D.add_rounded_down de t, -dt
+
+## Soustrait une durée d'une date, en arrondissant au jour suivant en cas
+## d'ambiguïté.
+## Note: Cela correspond au comportement de "`-`" dans les champs d'application
+## où `date arrondi supérieur` a été sélectionné.
+## **Exemples:**
+## - `soustraction_arrondi_supérieur de |2026-05-31|, 1 mois = |2026-05-01|`
+## - `soustraction_arrondi_supérieur de |2000-02-29|, 1 an = |1999-03-01|`
+déclaration soustraction_arrondi_supérieur contenu date
+  dépend de
+    t contenu date,
+    dt contenu durée
+  égal à
+  D.add_rounded_up de t, -dt
 ```
 
 ## Dates et années, mois et jours

--- a/tests/stdlib/date.catala_en
+++ b/tests/stdlib/date.catala_en
@@ -16,6 +16,16 @@ scope Tunit:
   assertion Date.min of d1, d2 = d1 and Date.min of d2, d3 = d2
   assertion Date.max of d1, d2 = d2 and Date.max of d2, d3 = d3
 
+  # add/sub
+  assertion Date.add_round_down of |2026-05-31|, 1 month = |2026-06-30|
+  assertion Date.add_round_down of |2000-02-29|, 1 year = |2001-02-28|
+  assertion Date.add_round_up of |2026-05-31|, 1 month = |2026-07-01|
+  assertion Date.add_round_up of |2000-02-29|, 1 year = |2001-03-01|
+  assertion Date.sub_round_down of |2026-05-31|, 1 month = |2026-04-30|
+  assertion Date.sub_round_down of |2000-02-29|, 1 year = |1999-02-28|
+  assertion Date.sub_round_up of |2026-05-31|, 1 month = |2026-05-01|
+  assertion Date.sub_round_up of |2000-02-29|, 1 year = |1999-03-01|
+
   # to_ymd/get_(year|month|day)
   assertion
     Date.to_year_month_day of d1 = (2000, 01, 01)


### PR DESCRIPTION
This is required when using date operations from top-level functions at the moment, as those don't have a way to select the rounding mode.

The function names have been chosen to match the existing `date round up·down` / `date arrondi inf·supérieur` scope-level constructs.

This is needed at the moment, but hopefully at some point we can propagate rounding options in a better way like in scopes. Nevertheless, it's sufficient to close #986.