### PR TITLE
Normalize diacritics in JSON schema

### DIFF
--- a/compiler/shared_ast/encoding.ml
+++ b/compiler/shared_ast/encoding.ml
@@ -20,6 +20,28 @@ module Runtime = Catala_runtime
 module Val = Runtime.Value
 open Json_encoding
 
+let check_duplicate_normalized_names conv_f names =
+  let rec loop vis_map = function
+    | [] -> ()
+    | v :: t ->
+      let s = conv_f v in
+      let s' = String.to_id s in
+      let new_vis_map =
+        String.Map.update s'
+          (function
+            | None -> Some s
+            | Some prev_s ->
+              Message.error
+                "Cannot generate JSON encoder due to name clashing between \
+                 '%s' and '%s': these values would be normalized to the same \
+                 JSON name '%s'"
+                s prev_s s')
+          vis_map
+      in
+      loop new_vis_map t
+  in
+  loop String.Map.empty names |> ignore
+
 let bool_encoding : Val.t encoding =
   conv
     (function
@@ -327,27 +349,28 @@ and generate_struct_encoder (ctx : decl_ctx) (sname : StructName.t) =
   let open Val in
   let struc = StructName.Map.find sname ctx.ctx_structs in
   let bdgs = StructField.Map.bindings struc in
+  check_duplicate_normalized_names StructField.to_string (List.map fst bdgs);
   let is_input_scope_struct =
     ScopeName.Map.exists
       (fun _ { in_struct_name; _ } -> StructName.equal sname in_struct_name)
       ctx.ctx_scopes
   in
+  let struct_name_s = String.to_id (StructName.to_string sname) in
   let rename_field f =
     let field_s = StructField.to_string f in
     if
       is_input_scope_struct
       && String.ends_with ~suffix:"_in" field_s
       && String.length field_s > 3
-    then String.sub field_s 0 (String.length field_s - 3), field_s
-    else field_s, field_s
+    then
+      String.to_id (String.sub field_s 0 (String.length field_s - 3)), field_s
+    else String.to_id field_s, field_s
   in
   let empty_struct_enc =
     conv
       (fun _ -> ())
       (fun () ->
-        V
-          ( Struct { name = StructName.to_string sname; fields = (fun _ -> []) },
-            () ))
+        V (Struct { name = struct_name_s; fields = (fun _ -> []) }, ()))
       empty
   in
   let add_req_field (encoding : t encoding) (sf, typ) : t encoding =
@@ -420,7 +443,7 @@ and generate_struct_encoder (ctx : decl_ctx) (sname : StructName.t) =
         | _ -> assert false)
       bconv
   in
-  def (Format.asprintf "%a" StructName.format_shortpath sname)
+  def (String.to_id (Format.asprintf "%a" StructName.format_shortpath sname))
   @@ List.fold_left
        (fun e (sf, typ) ->
          match Mark.remove typ with
@@ -432,16 +455,20 @@ and generate_enum_encoder (ctx : decl_ctx) (ename : EnumName.t) =
   let open Val in
   let enum = EnumName.Map.find ename ctx.ctx_enums in
   let bdgs = EnumConstructor.Map.bindings enum in
-  let ename_s = EnumName.to_string ename in
+  check_duplicate_normalized_names EnumConstructor.to_string (List.map fst bdgs);
+  let ename_s = String.to_id (EnumName.to_string ename) in
+  let constr_to_string cstr = String.to_id (EnumConstructor.to_string cstr) in
   let make_constructor_case idx (cstr, typ) : t case =
-    let cstr_s = EnumConstructor.to_string cstr in
+    let cstr_s = constr_to_string cstr in
     match Mark.remove typ with
     | TLit TUnit ->
       case (constant cstr_s)
         (function
-          | V (Enum enc, rval) ->
-            let _, cstr_s', _ = enc.constr rval in
-            if cstr_s = cstr_s' then Some () else None
+          | V (Enum { name; constr }, rval) ->
+            let _, cstr_s', _ = constr rval in
+            if ename_s = String.to_id name && cstr_s = String.to_id cstr_s' then
+              Some ()
+            else None
           | v ->
             Message.error ~internal:true
               "Unexpected runtime value %a instead of enum while encoding to  \
@@ -451,29 +478,39 @@ and generate_enum_encoder (ctx : decl_ctx) (ename : EnumName.t) =
           V (Enum { name = ename_s; constr = Fun.id }, (idx, cstr_s, None)))
     | _ ->
       case
-        (obj1 (req (EnumConstructor.to_string cstr) (generate_encoder ctx typ)))
+        (obj1 (req cstr_s (generate_encoder ctx typ)))
         (function
           | V (Enum { name; constr }, rval) ->
             let _, cstr_s', v = constr rval in
-            if name = ename_s && cstr_s = cstr_s' then v else None
+            if ename_s = String.to_id name && cstr_s = String.to_id cstr_s' then
+              v
+            else None
           | _ -> None)
         (fun v ->
-          V (Enum { name = ename_s; constr = Fun.id }, (idx, cstr_s, Some v)))
+          V
+            ( Enum { name = ename_s; constr = Fun.id },
+              (idx, EnumConstructor.to_string cstr, Some v) ))
   in
   let enc =
+    let union = List.mapi make_constructor_case bdgs |> union in
     if List.for_all (fun (_, typ) -> Mark.remove typ = TLit TUnit) bdgs then
       (* This simplifies the JSON schema *)
-      string_enum
-        (List.mapi
-           (fun idx (cstr, _) ->
-             let cstr_s = EnumConstructor.to_string cstr in
-             ( cstr_s,
-               V (Enum { name = ename_s; constr = Fun.id }, (idx, cstr_s, None))
-             ))
-           bdgs)
-    else List.mapi make_constructor_case bdgs |> union
+      let schema =
+        let specs = Json_schema.string_specs in
+        let enum =
+          List.map
+            (fun (s, _) ->
+              Json_repr.(repr_to_any (module Ezjsonm))
+                (`String (constr_to_string s)))
+            bdgs
+        in
+        Json_schema.(
+          update { (element (String specs)) with enum = Some enum } any)
+      in
+      conv Fun.id Fun.id ~schema union
+    else union
   in
-  def (Format.asprintf "%a" EnumName.format_shortpath ename) enc
+  def (String.to_id (Format.asprintf "%a" EnumName.format_shortpath ename)) enc
 
 let make_encoding (ctx : decl_ctx) (typ : typ) = generate_encoder ctx typ
 
@@ -558,7 +595,8 @@ let rec convert_to_dcalc ctx (mark : 'm mark) (typ : typ) (rval : Val.t) :
     let cons, typ_v =
       let enum = EnumName.Map.find ename ctx.ctx_enums in
       EnumConstructor.Map.bindings enum
-      |> List.find (fun (cstr', _) -> EnumConstructor.to_string cstr' = cstr)
+      |> List.find (fun (cstr', _) ->
+          String.to_id (EnumConstructor.to_string cstr') = String.to_id cstr)
     in
     let e = match v with None -> Expr.elit LUnit mark | Some v -> f typ_v v in
     Expr.einj ~name:ename ~cons ~e mark
@@ -633,7 +671,8 @@ let rec convert_to_lcalc ctx (mark : 'm mark) (typ : typ) (rval : Val.t) :
     let cons, typ_v =
       let enum = EnumName.Map.find ename ctx.ctx_enums in
       EnumConstructor.Map.bindings enum
-      |> List.find (fun (cstr', _) -> EnumConstructor.to_string cstr' = cstr)
+      |> List.find (fun (cstr', _) ->
+          String.to_id (EnumConstructor.to_string cstr') = String.to_id cstr)
     in
     let e = match v with None -> Expr.elit LUnit mark | Some v -> f typ_v v in
     Expr.einj ~name:ename ~cons ~e mark

--- a/tests/json/bad/duplicate_diacritics.catala_en
+++ b/tests/json/bad/duplicate_diacritics.catala_en
@@ -1,0 +1,48 @@
+```catala-metadata
+declaration enumeration DümmyÉnum:
+  -- Â
+  -- Ä
+
+declaration scope MŷScøpè:
+  input înpût content DümmyÉnum
+  output rèsult content DümmyÉnum
+
+scope MŷScøpè:
+  definition rèsult equals înpût
+```
+
+```catala-test-cli
+$ catala json-schema --scope MŷScøpè --disable-warnings
+[
+  {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Scope MŷScøpè input",
+    "description": "Input structure of scope MŷScøpè",
+    "$ref": "#/definitions/MŷScøpè_in",
+    "definitions": {
+      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ä" ] },
+      "MŷScøpè_in": {
+        "type": "object",
+        "properties": { "înpût": { "$ref": "#/definitions/DümmyÉnum" } },
+        "required": [ "înpût" ],
+        "additionalProperties": false
+      }
+    }
+  },
+  {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Scope MŷScøpè output",
+    "description": "Output structure of scope MŷScøpè",
+    "$ref": "#/definitions/MŷScøpè",
+    "definitions": {
+      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ä" ] },
+      "MŷScøpè": {
+        "type": "object",
+        "properties": { "rèsult": { "$ref": "#/definitions/DümmyÉnum" } },
+        "required": [ "rèsult" ],
+        "additionalProperties": false
+      }
+    }
+  }
+]
+```

--- a/tests/json/bad/duplicate_diacritics.catala_en
+++ b/tests/json/bad/duplicate_diacritics.catala_en
@@ -13,36 +13,10 @@ scope MŷScøpè:
 
 ```catala-test-cli
 $ catala json-schema --scope MŷScøpè --disable-warnings
-[
-  {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Scope MŷScøpè input",
-    "description": "Input structure of scope MŷScøpè",
-    "$ref": "#/definitions/MŷScøpè_in",
-    "definitions": {
-      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ä" ] },
-      "MŷScøpè_in": {
-        "type": "object",
-        "properties": { "înpût": { "$ref": "#/definitions/DümmyÉnum" } },
-        "required": [ "înpût" ],
-        "additionalProperties": false
-      }
-    }
-  },
-  {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "title": "Scope MŷScøpè output",
-    "description": "Output structure of scope MŷScøpè",
-    "$ref": "#/definitions/MŷScøpè",
-    "definitions": {
-      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ä" ] },
-      "MŷScøpè": {
-        "type": "object",
-        "properties": { "rèsult": { "$ref": "#/definitions/DümmyÉnum" } },
-        "required": [ "rèsult" ],
-        "additionalProperties": false
-      }
-    }
-  }
-]
+┌─[ERROR]─
+│
+│  Cannot generate JSON encoder due to name clashing between 'Ä' and 'Â': these values would be normalized to the same JSON name 'A'
+│
+└─
+#return code 123#
 ```

--- a/tests/json/good/diacritics.catala_en
+++ b/tests/json/good/diacritics.catala_en
@@ -1,0 +1,129 @@
+```catala-metadata
+declaration enumeration DümmyÉnum:
+  -- Â
+  -- Ö
+
+declaration structure MŷStruçtûre:
+  data mŷfìéld content integer
+  data mŷøtherfìéld content DümmyÉnum
+
+declaration enumeration MŷÉnum:
+  -- MÿÇase content MŷStruçtûre
+
+declaration scope MŷScøpè:
+  input înpût content MŷÉnum
+  output rèsult_enum content MŷÉnum
+  output rèsult_struct content MŷStruçtûre
+  output rèsult_int content integer
+
+scope MŷScøpè:
+  definition rèsult_enum equals înpût
+  definition rèsult_struct equals
+    match înpût with pattern -- MÿÇase content struct : struct
+  definition rèsult_int equals
+    match înpût with pattern -- MÿÇase content struct : struct.mŷfìéld
+```
+
+```catala-test-cli
+$ catala json-schema --scope MŷScøpè --disable-warnings
+[
+  {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Scope MŷScøpè input",
+    "description": "Input structure of scope MŷScøpè",
+    "$ref": "#/definitions/MŷScøpè_in",
+    "definitions": {
+      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ö" ] },
+      "MŷScøpè_in": {
+        "type": "object",
+        "properties": { "înpût": { "$ref": "#/definitions/MŷÉnum" } },
+        "required": [ "înpût" ],
+        "additionalProperties": false
+      },
+      "MŷStruçtûre": {
+        "type": "object",
+        "properties": {
+          "mŷfìéld": { "$ref": "#/definitions/integer" },
+          "mŷøtherfìéld": { "$ref": "#/definitions/DümmyÉnum" }
+        },
+        "required": [ "mŷøtherfìéld", "mŷfìéld" ],
+        "additionalProperties": false
+      },
+      "MŷÉnum": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "MÿÇase": { "$ref": "#/definitions/MŷStruçtûre" }
+            },
+            "required": [ "MÿÇase" ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "integer": {
+        "title": "Catala Integer",
+        "oneOf": [
+          {
+            "type": "integer",
+            "minimum": -9007199254740992.0,
+            "maximum": 9007199254740992.0
+          },
+          { "type": "string" }
+        ]
+      }
+    }
+  },
+  {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Scope MŷScøpè output",
+    "description": "Output structure of scope MŷScøpè",
+    "$ref": "#/definitions/MŷScøpè",
+    "definitions": {
+      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ö" ] },
+      "MŷScøpè": {
+        "type": "object",
+        "properties": {
+          "rèsult_enum": { "$ref": "#/definitions/MŷÉnum" },
+          "rèsult_struct": { "$ref": "#/definitions/MŷStruçtûre" },
+          "rèsult_int": { "$ref": "#/definitions/integer" }
+        },
+        "required": [ "rèsult_int", "rèsult_struct", "rèsult_enum" ],
+        "additionalProperties": false
+      },
+      "MŷStruçtûre": {
+        "type": "object",
+        "properties": {
+          "mŷfìéld": { "$ref": "#/definitions/integer" },
+          "mŷøtherfìéld": { "$ref": "#/definitions/DümmyÉnum" }
+        },
+        "required": [ "mŷøtherfìéld", "mŷfìéld" ],
+        "additionalProperties": false
+      },
+      "MŷÉnum": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "MÿÇase": { "$ref": "#/definitions/MŷStruçtûre" }
+            },
+            "required": [ "MÿÇase" ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "integer": {
+        "title": "Catala Integer",
+        "oneOf": [
+          {
+            "type": "integer",
+            "minimum": -9007199254740992.0,
+            "maximum": 9007199254740992.0
+          },
+          { "type": "string" }
+        ]
+      }
+    }
+  }
+]
+```

--- a/tests/json/good/diacritics.catala_en
+++ b/tests/json/good/diacritics.catala_en
@@ -25,41 +25,60 @@ scope MŷScøpè:
 ```
 
 ```catala-test-cli
+$ catala test-scope MŷScøpè --input {"input":{"MyCase":{"myfield":3,"myotherfield":"A"}}} -F json --disable-warnings
+{
+  "result_enum": { "MyCase": { "myfield": 3.0, "myotherfield": "A" } },
+  "result_struct": { "myfield": 3.0, "myotherfield": "A" },
+  "result_int": 3.0
+}
+```
+
+```catala-test-cli
+$ catala test-scope MŷScøpè --input {"input":{"MyCase":{"myfield":3,"myotherfield":"A"}}} -F human --disable-warnings
+┌─[RESULT]─ MŷScøpè ─
+│ rèsult_enum =
+│   MÿÇase content MŷStruçtûre { -- mŷfìéld: 3 -- mŷøtherfìéld: Â }
+│ rèsult_int = 3
+│ rèsult_struct = MŷStruçtûre { -- mŷfìéld: 3 -- mŷøtherfìéld: Â }
+└─
+```
+
+```catala-test-cli
 $ catala json-schema --scope MŷScøpè --disable-warnings
 [
   {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Scope MŷScøpè input",
     "description": "Input structure of scope MŷScøpè",
-    "$ref": "#/definitions/MŷScøpè_in",
+    "$ref": "#/definitions/MyScope_in",
     "definitions": {
-      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ö" ] },
-      "MŷScøpè_in": {
-        "type": "object",
-        "properties": { "înpût": { "$ref": "#/definitions/MŷÉnum" } },
-        "required": [ "înpût" ],
-        "additionalProperties": false
-      },
-      "MŷStruçtûre": {
-        "type": "object",
-        "properties": {
-          "mŷfìéld": { "$ref": "#/definitions/integer" },
-          "mŷøtherfìéld": { "$ref": "#/definitions/DümmyÉnum" }
-        },
-        "required": [ "mŷøtherfìéld", "mŷfìéld" ],
-        "additionalProperties": false
-      },
-      "MŷÉnum": {
+      "DummyEnum": { "type": "string", "enum": [ "A", "O" ] },
+      "MyEnum": {
         "oneOf": [
           {
             "type": "object",
             "properties": {
-              "MÿÇase": { "$ref": "#/definitions/MŷStruçtûre" }
+              "MyCase": { "$ref": "#/definitions/MyStructure" }
             },
-            "required": [ "MÿÇase" ],
+            "required": [ "MyCase" ],
             "additionalProperties": false
           }
         ]
+      },
+      "MyScope_in": {
+        "type": "object",
+        "properties": { "input": { "$ref": "#/definitions/MyEnum" } },
+        "required": [ "input" ],
+        "additionalProperties": false
+      },
+      "MyStructure": {
+        "type": "object",
+        "properties": {
+          "myfield": { "$ref": "#/definitions/integer" },
+          "myotherfield": { "$ref": "#/definitions/DummyEnum" }
+        },
+        "required": [ "myotherfield", "myfield" ],
+        "additionalProperties": false
       },
       "integer": {
         "title": "Catala Integer",
@@ -78,39 +97,39 @@ $ catala json-schema --scope MŷScøpè --disable-warnings
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Scope MŷScøpè output",
     "description": "Output structure of scope MŷScøpè",
-    "$ref": "#/definitions/MŷScøpè",
+    "$ref": "#/definitions/MyScope",
     "definitions": {
-      "DümmyÉnum": { "type": "string", "enum": [ "Â", "Ö" ] },
-      "MŷScøpè": {
-        "type": "object",
-        "properties": {
-          "rèsult_enum": { "$ref": "#/definitions/MŷÉnum" },
-          "rèsult_struct": { "$ref": "#/definitions/MŷStruçtûre" },
-          "rèsult_int": { "$ref": "#/definitions/integer" }
-        },
-        "required": [ "rèsult_int", "rèsult_struct", "rèsult_enum" ],
-        "additionalProperties": false
-      },
-      "MŷStruçtûre": {
-        "type": "object",
-        "properties": {
-          "mŷfìéld": { "$ref": "#/definitions/integer" },
-          "mŷøtherfìéld": { "$ref": "#/definitions/DümmyÉnum" }
-        },
-        "required": [ "mŷøtherfìéld", "mŷfìéld" ],
-        "additionalProperties": false
-      },
-      "MŷÉnum": {
+      "DummyEnum": { "type": "string", "enum": [ "A", "O" ] },
+      "MyEnum": {
         "oneOf": [
           {
             "type": "object",
             "properties": {
-              "MÿÇase": { "$ref": "#/definitions/MŷStruçtûre" }
+              "MyCase": { "$ref": "#/definitions/MyStructure" }
             },
-            "required": [ "MÿÇase" ],
+            "required": [ "MyCase" ],
             "additionalProperties": false
           }
         ]
+      },
+      "MyScope": {
+        "type": "object",
+        "properties": {
+          "result_enum": { "$ref": "#/definitions/MyEnum" },
+          "result_struct": { "$ref": "#/definitions/MyStructure" },
+          "result_int": { "$ref": "#/definitions/integer" }
+        },
+        "required": [ "result_int", "result_struct", "result_enum" ],
+        "additionalProperties": false
+      },
+      "MyStructure": {
+        "type": "object",
+        "properties": {
+          "myfield": { "$ref": "#/definitions/integer" },
+          "myotherfield": { "$ref": "#/definitions/DummyEnum" }
+        },
+        "required": [ "myotherfield", "myfield" ],
+        "additionalProperties": false
       },
       "integer": {
         "title": "Catala Integer",


### PR DESCRIPTION
Fixes https://github.com/CatalaLang/catala/issues/1017

Currently, this fails if two fields/cases would be normalized to the same string. Should we would rename those to fresh identifiers instead? This would complexifies the logic by quite a lot.

ALSO, while working on that the generated JSON values from the different backends are not consistent with this new schema. Incidentally, this was also not previously the case (even for the outputs). This needs a bit of future work to achieve this.