### PR TITLE
Add a DebugPrint op, print relevant vars on failed assert

### DIFF
--- a/compiler/dcalc/autotest.ml
+++ b/compiler/dcalc/autotest.ml
@@ -85,8 +85,8 @@ let test_scope_outs ctx lang acc env name scope =
     | exception e ->
       if e <> Exit then
         Message.warning
-          "Failed to interpret scope %a: cannot add autotests, will generate \
-           an always-failing test program."
+          "Failed to interpret scope %a: not adding autotests. The generated \
+           test program should be expected to always fail."
           ScopeName.format name;
       acc
     | output_expr -> ScopeName.Map.add name output_expr acc

--- a/compiler/lcalc/from_dcalc.ml
+++ b/compiler/lcalc/from_dcalc.ml
@@ -169,13 +169,29 @@ and translate_expr (e : 'm D.expr) : 'm A.expr boxed =
   | EAssert pred, m ->
     let pos = Expr.mark_pos m in
     let tbool = TLit TBool, pos in
+    let pred = translate_expr pred in
+    let vars = Expr.free_vars (Expr.unbox pred) in
+    let debug_vars =
+      List.map
+        (fun v ->
+          let ty = Type.fresh_var pos in
+          Expr.eappop
+            ~op:(Op.DebugPrint (Bindlib.name_of v), pos)
+            ~args:[Expr.evar v (Expr.with_ty m ty)]
+            ~tys:[ty]
+            (Expr.with_ty m (TLit TUnit, pos)))
+        (Var.Set.elements vars)
+    in
     Expr.eifthenelse
-      (Expr.eappop ~op:(Op.Not, pos)
-         ~args:[translate_expr pred]
-         ~tys:[tbool] (Expr.with_ty m tbool))
-      (Expr.efatalerror_pos ~error:AssertionFailed
-         ~pos_expr:(Expr.make_pos (Expr.mark_pos m) m)
-         m)
+      (Expr.eappop ~op:(Op.Not, pos) ~args:[pred] ~tys:[tbool]
+         (Expr.with_ty m tbool))
+      (Expr.make_seq
+         (debug_vars
+         @ [
+             Expr.efatalerror_pos ~error:AssertionFailed
+               ~pos_expr:(Expr.make_pos (Expr.mark_pos m) m)
+               m;
+           ]))
       (Expr.elit LUnit m) m
   | ( ( ELit _ | EArray _ | EVar _ | EApp _ | EAbs _ | EExternal _
       | EIfThenElse _ | ETuple _ | ETupleAccess _ | EInj _ | EStruct _

--- a/compiler/lcalc/from_dcalc.mli
+++ b/compiler/lcalc/from_dcalc.mli
@@ -14,9 +14,6 @@
    License for the specific language governing permissions and limitations under
    the License. *)
 
-(** Translation from the default calculus to the lambda calculus. This
-    translation uses an option monad to handle empty defaults terms. This
-    transformation is one piece to permit to compile toward legacy languages
-    that does not contains exceptions. *)
+(** Translation from the default calculus to the lambda calculus. *)
 
 val translate_program : 'm Dcalc.Ast.program -> 'm Ast.program

--- a/compiler/lcalc/to_ocaml.ml
+++ b/compiler/lcalc/to_ocaml.ml
@@ -528,6 +528,11 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
     format_expr fmt (EAppOp { op; args = e1 :: args; tys }, m)
   | EAppOp { op = ArrayAccess i, _; args = [a]; _ } ->
     Format.fprintf fmt "%a.(%d)" format_with_parens a i
+  | EAppOp { op = DebugPrint name, _; args = [a]; _ } ->
+    Format.fprintf fmt
+      "Format.eprintf \"@@[<hv 2>%s = %%a@@]@@.\" Value.format (Value.embed \
+       (%a) %a)"
+      (String.escaped name) format_rtyp (Expr.ty a) format_with_parens a
   | EAppOp
       {
         op = ValueFromJson (ty, json), _;
@@ -545,6 +550,7 @@ let rec format_expr (ctx : decl_ctx) (fmt : Format.formatter) (e : 'm expr) :
       | TLit TUnit, _ -> ""
       | _ -> " _")
   | EAppOp { op = ((Eq | Lt | Lte | Gt | Gte) as op), _; args = [a1; a2]; _ } ->
+    (* [op_needs_pos] is fine-tuned so that this applies only to primitive types where it's safe to use OCaml polymorphic comparisons *)
     Format.fprintf fmt "@[<hov 2>%a@ %s %a@]" format_with_parens a1
       (Print.operator_to_string op)
       format_with_parens a2

--- a/compiler/plugins/explain.ml
+++ b/compiler/plugins/explain.ml
@@ -1285,6 +1285,7 @@ let expr_to_dot_label0 : type a.
           | HandleExceptions -> ""
           | ToClosureEnv -> ""
           | FromClosureEnv -> ""
+          | DebugPrint _ -> ""
         in
         Format.pp_print_string ppf str
 

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -531,6 +531,12 @@ let rec format_expression
       Format.fprintf fmt "catala_new_bool((%a)->code == %s)" format_expression
         arg
         (EnumConstructor.to_string constr)
+  | EAppOp { op = DebugPrint str, _; args = [a]; tys = [ty] } ->
+    Format.fprintf fmt "@[<v>fputs(\"%s = \", stderr);@," str;
+    Format.fprintf fmt "catala_errbuf.indent += 2;@,";
+    Format.fprintf fmt "catala_print (catala_errbuf, embed(%a, %a));@,"
+      format_rtyp ty format_expression a;
+    Format.fprintf fmt "catala_errbuf.indent -= 2;@,fputc('\\n', stderr)@]"
   | EAppOp { op = ((Map | Filter), _) as op; args = [arg1; arg2]; _ } ->
     Format.fprintf fmt "%a(%a,@ %a)" format_op op format_expression arg1
       format_expression arg2
@@ -810,6 +816,8 @@ let rec format_statement
       typ
       (format_expression ctx env)
       e
+  | SLocalDef { expr = e; typ = TLit TUnit, _; _ } ->
+    Format.fprintf fmt "@,@[<hov 2>%a;@]" (format_expression ctx env) e
   | SLocalDef { name = v; expr = e; _ } ->
     Format.fprintf fmt "@,@[<hov 2>%a = %a;@]" VarName.format (Mark.remove v)
       (format_expression ctx env)

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -195,6 +195,9 @@ let format_op (ppf : formatter) (op : operator Mark.pos) : unit =
   | ValueFromJson _ ->
     (* Handled in format_expression call *)
     Message.error ~internal:true "ValueFromJSON incorrectly reached"
+  | DebugPrint _ ->
+    (* Handled in format_expression call *)
+    Message.error ~internal:true "DebugPrint incorrectly reached"
   | FromClosureEnv | ToClosureEnv -> failwith "unimplemented"
 
 let format_visibility ppf = function
@@ -417,6 +420,9 @@ let rec format_expression ctx (ppf : formatter) (e : expr) : unit =
     fprintf ppf "%a.fromJSONString(%a ,%s)"
       (format_typ ~wildcard:false ~diamond:false ctx)
       ty (format_expression ctx) (EPosLit, p) encoded_string
+  | EAppOp { op = DebugPrint str, _; args = [e]; _ } ->
+    fprintf ppf "System.err.println(\"%s = \" + %a.toString())" str
+      (format_expression ctx) e
   | EAppOp
       {
         op = (HandleExceptions, _) as op;
@@ -557,6 +563,9 @@ and format_currified_args ctx ppf = function
 
 let rec format_stmt ~toplevel (ctx : context) ppf (stmt : Ast.stmt Mark.pos) =
   match Mark.remove stmt with
+  | SLocalDecl { typ = TLit TUnit, _; _ } -> ()
+  | SLocalDef { expr = e; typ = TLit TUnit, _; _ } ->
+    Format.fprintf ppf "@[<hov 4>%a;@]" (format_expression ctx) e
   | SLocalDecl { name; typ } ->
     fprintf ppf "@[<hov 4>final %a@ %a;@]" (format_typ ctx) typ VarName.format
       (Mark.remove name)
@@ -734,6 +743,13 @@ and format_block ?(toplevel = false) ctx ppf (block : Ast.block) =
   let rec format_stmts ~toplevel = function
     | [] -> ()
     | [stmt] -> format_stmt ~toplevel ctx ppf stmt
+    | (SLocalDecl { name = n, _; typ = TLit TUnit, _ }, _)
+      :: (SLocalDef { name = n2, _; expr; _ }, _)
+      :: r
+      when VarName.equal n n2 ->
+      fprintf ppf "@[<hov 4>%a;@]" (format_expression ctx) expr;
+      pp_print_space ppf ();
+      format_stmts ~toplevel r
     | (SLocalDecl { name = n, _; typ }, _)
       :: (SLocalDef { name = n2, _; expr; _ }, _)
       :: r

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -86,7 +86,7 @@ let format_op (fmt : Format.formatter) (op : operator Mark.pos) : unit =
   | HandleExceptions -> Format.pp_print_string fmt "handle_exceptions"
   | ValueFromJson (_ty, str) ->
     Format.fprintf fmt ".from_json(%s" (String.quote str)
-  | ArrayAccess _ | ConstructorCheck _ -> assert false
+  | ArrayAccess _ | ConstructorCheck _ | DebugPrint _ -> assert false
   | FromClosureEnv | ToClosureEnv -> failwith "unimplemented"
 
 let format_uid_list (fmt : Format.formatter) (uids : Uid.MarkedString.info list)
@@ -372,6 +372,9 @@ let rec format_expression ctx (fmt : Format.formatter) (e : expr) : unit =
     else
       Format.fprintf fmt "%a.code == %a.Code.%a" (format_expression ctx) a
         EnumName.format enum EnumConstructor.format case
+  | EAppOp { op = DebugPrint str, _; args = [a]; _ } ->
+    Format.fprintf fmt "print(f\"%s = {%a.__str__(indent=2)}\")" str
+      (format_expression ctx) a
   | EAppOp
       { op = ((Eq | Lt | Lte | Gt | Gte), _) as op; args = [pos; a1; a2]; _ } ->
     Format.fprintf fmt "%a.%a(@[<hv>%a,@ %a)@]" (format_expression ctx) a1
@@ -490,6 +493,9 @@ let rec format_statement ctx (fmt : Format.formatter) (s : stmt Mark.pos) : unit
       VarName.format (Mark.remove name)
   | SLocalDecl _ ->
     assert false (* We don't need to declare variables in Python *)
+  | SLocalDef { expr = e; typ = TLit TUnit, _; _ }
+  | SLocalInit { expr = e; typ = TLit TUnit, _; _ } ->
+    Format.fprintf fmt "@[<hv 4>%a@]" (format_expression ctx) e
   | SLocalDef { name = v; expr = e; _ } | SLocalInit { name = v; expr = e; _ }
     ->
     Format.fprintf fmt "@[<hv 4>%a = (%a)@]" VarName.format (Mark.remove v)

--- a/compiler/shared_ast/definitions.ml
+++ b/compiler/shared_ast/definitions.ml
@@ -355,6 +355,7 @@ module Op = struct
     | ConstructorCheck :
         (EnumName.t * EnumConstructor.t)
         -> < polymorphic ; .. > t
+    | DebugPrint : string -> < polymorphic ; .. > t
     (* * overloaded *)
     | Minus : < overloaded ; .. > t
     | Minus_int : < resolved ; .. > t

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -1051,6 +1051,18 @@ let rec make_seq = function
     let e2 = make_seq es in
     make_let_in v (TLit TUnit, pos e1) e1 e2 (pos e2)
 
+let rec seq_last_element = function
+  | ( EApp
+        {
+          args = [_];
+          tys = [(TLit TUnit, _)];
+          f = EAbs { binder; tys = [(TLit TUnit, _)]; pos = _ }, _;
+        },
+      _ ) ->
+    let _, body = Bindlib.unmbind binder in
+    seq_last_element body
+  | e -> e
+
 let make_puredefault e =
   let mark =
     map_mark

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -1043,6 +1043,14 @@ let make_let_in x tau e1 e2 mpos =
 let make_multiple_let_in xs taus e1s e2 mpos =
   make_app (make_abs xs e2 taus mpos) e1s taus (pos e2)
 
+let rec make_seq = function
+  | [] -> invalid_arg "Expr.make_seq"
+  | [e] -> e
+  | e1 :: es ->
+    let v = Var.make "_", pos e1 in
+    let e2 = make_seq es in
+    make_let_in v (TLit TUnit, pos e1) e1 e2 (pos e2)
+
 let make_puredefault e =
   let mark =
     map_mark

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -434,6 +434,8 @@ val make_multiple_let_in :
   Pos.t ->
   ('a any, 'm) boxed_gexpr
 
+val make_seq : ('a, 'm) boxed_gexpr list -> ('a any, 'm) boxed_gexpr
+
 val make_tuple :
   ('a any, 'm) boxed_gexpr list -> 'm mark -> ('a, 'm) boxed_gexpr
 (** Builds a tuple; the mark argument is only used as witness and for position

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -436,6 +436,10 @@ val make_multiple_let_in :
 
 val make_seq : ('a, 'm) boxed_gexpr list -> ('a any, 'm) boxed_gexpr
 
+val seq_last_element : ('a, 'm) gexpr -> ('a any, 'm) gexpr
+(** Retrieves the "return value" [z] in a sequence [x; y; z]. More exactly, (λ
+    (). z) ((λ (). y) x) --> z *)
+
 val make_tuple :
   ('a any, 'm) boxed_gexpr list -> 'm mark -> ('a, 'm) boxed_gexpr
 (** Builds a tuple; the mark argument is only used as witness and for position

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -758,11 +758,11 @@ let rec evaluate_expr : type d r.
     | None -> fun r -> r
     | Some label_opt ->
       fun r ->
-        Message.debug "%a%a @{<grey>(at %s)@}"
+        Message.debug "%a%a @{<grey>(at %a)@}"
           (fun ppf -> function
             | Some s -> Format.fprintf ppf "@{<bold;yellow>%s@} = " s
             | None -> ())
-          label_opt (Print.expr ()) r (Pos.to_string_short pos);
+          label_opt (Print.expr ()) r Message.pp_pos pos;
         r)
   @@
   match Mark.remove e with
@@ -932,10 +932,17 @@ let rec evaluate_expr : type d r.
       {
         cond = EAppOp { op = Not, _; args = [pred]; _ }, _;
         efalse = ELit LUnit, _;
-        etrue =
-          EFatalError_pos { error = AssertionFailed; pos_expr = EPos pos, _ }, _;
-      } ->
+        etrue = seq;
+      }
+    when match Expr.seq_last_element seq with
+         | EFatalError_pos { error = AssertionFailed; _ }, _ -> true
+         | _ -> false ->
     (* For lcalc's already compiled assertions *)
+    let pos =
+      match Expr.seq_last_element seq with
+      | EFatalError_pos { pos_expr = EPos pos, _; _ }, _ -> pos
+      | _ -> assert false
+    in
     handle_assert ~eval_expr:(evaluate_expr ctx lang) ~lang pred m pos
   | EAssert pred ->
     handle_assert ~eval_expr:(evaluate_expr ctx lang) ~lang pred m pos

--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -359,6 +359,9 @@ let rec evaluate_operator
           cons = Expr.some_constr;
           e = ETuple [e; EPos p, Expr.with_pos p m], m;
         })
+  | DebugPrint s, [v] ->
+    Format.fprintf (Message.err_ppf ()) "@{<blue>%s@} = %a@," s Expr.format v;
+    ELit LUnit
   | ValueFromJson (((TAbstract tid, _) as ty), str), [(ELit LUnit, _)] ->
     let module E = (val Type.lookup_external tid) in
     runtime_to_val ctx m ty
@@ -375,7 +378,7 @@ let rec evaluate_operator
       | Sub_dat_dur _ | Sub_dur_dur | Mult_int_int | Mult_rat_rat | Mult_mon_int
       | Mult_mon_rat | Mult_dur_int | Div_int_int | Div_rat_rat | Div_mon_mon
       | Div_mon_int | Div_mon_rat | Div_dur_dur | Lt | Lte | Gt | Gte
-      | HandleExceptions ),
+      | HandleExceptions | DebugPrint _ ),
       _ ) ->
     err ()
 

--- a/compiler/shared_ast/operator.ml
+++ b/compiler/shared_ast/operator.ml
@@ -100,6 +100,7 @@ let name : type a. a t -> string = function
     Printf.sprintf "o_is(%s.%s)" (EnumName.to_string e)
       (EnumConstructor.to_string c)
   | ValueFromJson (_ty, str) -> Printf.sprintf "from_json(%s)" str
+  | DebugPrint str -> Printf.sprintf "debug_print(%s)" str
 
 let compare_log_entries l1 l2 =
   match l1, l2 with
@@ -199,11 +200,14 @@ let compare (type a1 a2) (t1 : a1 t) (t2 : a2 t) =
   | FromClosureEnv, FromClosureEnv | ToClosureEnv, ToClosureEnv -> 0
   | ArrayAccess n1, ArrayAccess n2 -> compare n1 n2
   | ConstructorCheck (_, c1), ConstructorCheck (_, c2) -> EnumConstructor.compare c1 c2
+  | Sort o1, Sort o2 -> (match o1, o2 with
+      | `Asc, `Asc | `Desc, `Desc -> 0
+      | `Desc, `Asc -> -1 | `Asc, `Desc -> 1)
+  | DebugPrint s1, DebugPrint s2 -> String.compare s1 s2
   | ValueFromJson (ty1, j1), ValueFromJson (ty2, j2) ->
     (match Type.compare ty1 ty2 with
      | 0 -> String.compare j1 j2
      | n -> n)
-  | Sort o1, Sort o2 -> (match o1, o2 with `Asc, `Asc | `Desc, `Desc -> 0 | `Desc, `Asc -> -1 | `Asc, `Desc -> 1)
   | Not, _ -> -1 | _, Not -> 1
   | Length, _ -> -1 | _, Length -> 1
   | Log _, _ -> -1 | _, Log _ -> 1
@@ -271,6 +275,7 @@ let compare (type a1 a2) (t1 : a1 t) (t2 : a2 t) =
   | ToClosureEnv, _ -> -1 | _, ToClosureEnv -> 1
   | ArrayAccess _, _ -> -1 | _, ArrayAccess _ -> 1
   | ConstructorCheck _, _ -> -1 | _, ConstructorCheck _  -> 1
+  | DebugPrint _, _ -> -1 | _, DebugPrint _ -> 1
   | ValueFromJson _, _ | _, ValueFromJson _ -> .
 
 let equal t1 t2 = compare t1 t2 = 0
@@ -290,7 +295,7 @@ let kind_dispatch : type a.
   | ((Not | And | Or | Xor | ValueFromJson _), _) as op -> monomorphic op
   | ( ( Log _ | Length | Eq | Concat | Map | Filter | Find | Reduce | Sort _
       | Map2 | Fold | Lt | Lte | Gt | Gte | HandleExceptions | FromClosureEnv
-      | ToClosureEnv | ArrayAccess _ | ConstructorCheck _ ),
+      | ToClosureEnv | ArrayAccess _ | ConstructorCheck _ | DebugPrint _ ),
       _ ) as op ->
     polymorphic op
   | ((Minus | ToInt | ToRat | ToMoney | Round | Add | Sub | Mult | Div), _) as
@@ -326,7 +331,7 @@ let translate (t : 'a no_overloads t Mark.pos) : 'b no_overloads t Mark.pos =
       | Sub_dat_dur _ | Sub_dur_dur | Mult_int_int | Mult_rat_rat | Mult_mon_int
       | Mult_mon_rat | Mult_dur_int | Div_int_int | Div_rat_rat | Div_mon_mon
       | Div_mon_int | Div_mon_rat | Div_dur_dur | FromClosureEnv | ToClosureEnv
-      | ArrayAccess _ | ConstructorCheck _ | ValueFromJson _ ),
+      | ArrayAccess _ | ConstructorCheck _ | ValueFromJson _ | DebugPrint _ ),
       _ ) as op ->
     op
 
@@ -497,7 +502,7 @@ let is_pure : type a. a t -> bool = function
     (* basically, operators that take a position in the backends, and their
        overloaded counterparts: those are the ones that can raise *)
     false
-  | Log _ -> false
+  | Log _ | DebugPrint _ -> false
   | Not | Length | ToClosureEnv | FromClosureEnv | ArrayAccess _
   | ConstructorCheck _ | Minus | Minus_int | Minus_rat | Minus_mon | Minus_dur
   | ToInt | ToInt_mon | ToInt_rat | ToRat | ToRat_int | ToRat_mon | ToMoney

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -295,6 +295,7 @@ let operator_to_string : type a. a Op.t -> string =
     Printf.sprintf "o_is(%s.%s)" (EnumName.to_string e)
       (EnumConstructor.to_string c)
   | ValueFromJson (_ty, json) -> Printf.sprintf "json[%s]" json
+  | DebugPrint s -> Printf.sprintf "debug_print(\"%s\")" s
 
 let operator_to_shorter_string : type a. a Op.t -> string =
   let open Op in
@@ -343,6 +344,7 @@ let operator_to_shorter_string : type a. a Op.t -> string =
   | ConstructorCheck (_, c) ->
     Printf.sprintf "is_%s" (EnumConstructor.to_string c)
   | ValueFromJson (_ty, json) -> Printf.sprintf "json[%s]" json
+  | DebugPrint s -> Printf.sprintf "debug_print(\"%s\")" s
 
 let negated_op_to_string : type a. a Op.t -> string = function
   | Xor -> "="
@@ -424,7 +426,7 @@ module Precedence = struct
         Op Div
       | HandleExceptions | Map | Map2 | Concat | Filter | Find | Reduce | Fold
       | Sort _ | ToClosureEnv | FromClosureEnv | ArrayAccess _
-      | ConstructorCheck _ ->
+      | ConstructorCheck _ | DebugPrint _ ->
         App
       | ValueFromJson _ -> Contained)
     | EApp _ -> App

--- a/compiler/shared_ast/typing.ml
+++ b/compiler/shared_ast/typing.ml
@@ -382,6 +382,7 @@ let polymorphic_op_type (op : Operator.polymorphic operator Mark.pos) : typ =
   let any3 = lazy (Type.fresh_var pos) in
   let bt = lazy (TLit TBool, pos) in
   let it = lazy (TLit TInt, pos) in
+  let ut = lazy (TLit TUnit, pos) in
   let cet = lazy (TClosureEnv, pos) in
   let array a = lazy (TArray (Lazy.force a), pos) in
   let option a = lazy (TOption (Lazy.force a), pos) in
@@ -413,6 +414,7 @@ let polymorphic_op_type (op : Operator.polymorphic operator Mark.pos) : typ =
     | FromClosureEnv -> [cet] @-> any
     | ArrayAccess _ -> [array any] @-> any
     | ConstructorCheck _ -> [any] @-> bt
+    | DebugPrint _ -> [any] @-> ut
   in
   Lazy.force ty
 
@@ -454,6 +456,7 @@ let polymorphic_op_return_type
   | ArrayAccess _, [tarr] -> element_type tarr
   | Find, [_; tarr] -> TOption (element_type tarr), pos
   | Sort _, [_; t] -> t
+  | DebugPrint _, _ -> TLit TUnit, pos
   | ( (( Fold | Reduce | Map | Map2 | Filter | Concat | Log _ | HandleExceptions
        | ArrayAccess _ | Find | Sort _ ) as op),
       targs ) ->

--- a/runtimes/c/catala_runtime.c
+++ b/runtimes/c/catala_runtime.c
@@ -585,7 +585,20 @@ void stdprintf(const char * fmt, ...) {
   gmp_vprintf(fmt, args);
   va_end(args);
 }
-const struct catala_buf catala_stdbuf = { &stdprintf, 0, &stdflush };
+struct catala_buf catala_stdbuf = { &stdprintf, 0, &stdflush };
+
+const void* errflush() {
+  fputs("", stderr);
+  fflush(stderr);
+  return NULL;
+}
+void errprintf(const char * fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  gmp_vfprintf(stderr, fmt, args);
+  va_end(args);
+}
+struct catala_buf catala_errbuf = { &errprintf, 0, &errflush };
 
 __thread char* strbuf = NULL;
 __thread int strbufsize = 0;
@@ -614,7 +627,7 @@ void strprintf(const char * fmt, ...) {
     strbufsize += size;
   }
 }
-const struct catala_buf catala_strbuf = { &strprintf, 0, &strflush };
+struct catala_buf catala_strbuf = { &strprintf, 0, &strflush };
 
 void catala_print (struct catala_buf buf, const catala_value x) {
   int i;

--- a/runtimes/c/catala_runtime.h
+++ b/runtimes/c/catala_runtime.h
@@ -183,8 +183,9 @@ struct catala_buf {
   /* return NULL if printing is to a device, return the final result of the
      printings if it is to an object */
 };
-extern const struct catala_buf catala_stdbuf;
-extern const struct catala_buf catala_strbuf;
+extern struct catala_buf catala_stdbuf;
+extern struct catala_buf catala_errbuf;
+extern struct catala_buf catala_strbuf;
 
 enum catala_type_kind {
   UNINITIALIZED,

--- a/runtimes/ocaml/catala_runtime.ml
+++ b/runtimes/ocaml/catala_runtime.ml
@@ -488,7 +488,7 @@ module Value = struct
            format)
         (destr v)
     | V (Position, pos) ->
-      Format.fprintf ppf "@[<h><%s:%d.%d-%d-%d@]" pos.filename pos.start_line
+      Format.fprintf ppf "@[<h>%s:%d.%d-%d-%d@]" pos.filename pos.start_line
         pos.start_column pos.end_line pos.end_column
     | V (Function, _) -> Format.fprintf ppf "<function>"
     | V (Polymorphic, _) -> Format.fprintf ppf "<poly>"

--- a/tests/backends/python_enum.catala_en
+++ b/tests/backends/python_enum.catala_en
@@ -224,6 +224,7 @@ def s(s_in:SIn) -> S:
     else:
         raise NoValue(loc[1])
     if o.not_().not_():
+        print(f"o = {o.__str__(indent=2)}")
         raise AssertionFailed(loc[3])
     return S(o = o)
 


### PR DESCRIPTION
This makes assertion failures in the backends much nicer and easier to debug, by giving the expected insight into what is wrong and how.

Basically, for asserts of the form `assert var = 42`, the assertion failure message giving the source code position will be preceded by `var = 43` on the previous stderr line, and this for all backends. In addition, this scales for all forms of assertions.

**Note:** while the new Op.DebugPrint could be used to translate the #[debug.print] attrs, this is **not** done at the moment.
