### PR TITLE
Fix assert failure reports in clerk & some cosmetic fixes

### DIFF
--- a/build_system/clerk_lib/dune
+++ b/build_system/clerk_lib/dune
@@ -1,4 +1,4 @@
 (library
  (name clerk_lib)
  (public_name catala.clerk_lib)
- (libraries testo-diff catala.catala_utils catala.surface otoml))
+ (libraries catala.catala_utils catala.surface otoml))

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -167,11 +167,8 @@ let colordiff_str s1 s2 =
 let diff_command =
   lazy begin match disp_flags.diff_command with
   | None ->
-    let open Testo_diff.Make (struct
+    let open Clerk_utils.Diff.Make (struct
       include String
-
-      let pp _ = assert false
-      let show _ = assert false
     end) in
     let stringdiff ppf s1 s2 =
       let width = Message.terminal_columns () - 5 in

--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -219,14 +219,22 @@ let run_catala_test_scopes
            [
              bos;
              group ~name:"file" @@ rep1 (diff any (char ':'));
-             char ':';
-             group ~name:"line0" @@ rep1 digit;
-             char '.';
-             group ~name:"col0" @@ rep1 digit;
-             char '-';
-             group ~name:"line1" @@ rep1 digit;
-             char '.';
-             group ~name:"col1" @@ rep1 digit;
+             opt
+               (seq
+                  [
+                    char ':';
+                    group ~name:"line0" @@ rep1 digit;
+                    opt (seq [char '.'; group ~name:"col0" @@ rep1 digit]);
+                    opt
+                      (seq
+                         [
+                           char '-';
+                           group ~name:"end" @@ rep1 digit;
+                           opt
+                             (seq
+                                [char '.'; group ~name:"endcol" @@ rep1 digit]);
+                         ]);
+                  ]);
              str ": [ERROR]";
              rep (alt [set " :/"; digit]);
              group ~name:"message" @@ rep1 any;
@@ -234,15 +242,23 @@ let run_catala_test_scopes
     in
     match Re.exec_opt re_error line with
     | Some g ->
-      let gets label =
-        Re.Group.get g (List.assoc label (Re.group_names re_error))
-      in
-      let file = gets "file" in
+      let gr label = List.assoc label (Re.group_names re_error) in
+      let file = Re.Group.get g (gr "file") in
       let pos = get_pos file in
-      let geti label = int_of_string (gets label) in
-      Some
-        ( (pos (geti "line0") (geti "col0"), pos (geti "line1") (geti "col1")),
-          gets "message" )
+      let geti label =
+        Re.Group.get_opt g (gr label) |> Option.map int_of_string
+      in
+      let li0, col0, li1, col1 =
+        match geti "line0", geti "col0", geti "end", geti "endcol" with
+        | None, None, None, None -> 0, 0, -1, -1
+        | Some l, None, None, None -> l, 0, l, -1
+        | Some l, Some c, None, None -> l, c, l, c
+        | Some l, None, Some l2, None -> l, 0, l2, -1 (* listart-liend *)
+        | Some l, Some c, Some c2, None -> l, c, l, c2 (* li.colstart-colend *)
+        | Some l, Some c, Some l2, Some c2 -> l, c, l2, c2
+        | _ -> assert false
+      in
+      Some ((pos li0 col0, pos li1 col1), Re.Group.get g (gr "message"))
     | None -> None
   in
   let re_line =

--- a/build_system/clerk_utils/diff.ml
+++ b/build_system/clerk_utils/diff.ml
@@ -1,0 +1,159 @@
+(*
+   Copyright (c) 2017 Gabriel Jaldon gjaldon85@gmail.com
+
+   Permission to use, copy, modify, and distribute this software for any purpose
+   with or without fee is hereby granted, provided that the above copyright
+   notice and this permission notice appear in all copies.
+
+   https://github.com/gjaldon/simple-diff/
+
+   Edited by Martin Jambon <martin@semgrep.com>
+
+   https://github.com/mjambon/testo/tree/main/diff
+
+   "deriving" annotations removed for Catala
+*)
+
+module type Comparable = sig
+  type t
+
+  val compare : t -> t -> int
+end
+
+module type S = sig
+  type item
+
+  type diff =
+    | Deleted of item array
+    | Added of item array
+    | Equal of item array
+
+  type t = diff list
+
+  val get_diff : item array -> item array -> t
+
+  val recover_input : t -> item array * item array
+  (** Recover the original input passed to {!get_diff}. *)
+end
+
+module Make (Item : Comparable) = struct
+  type item = Item.t
+
+  type diff =
+    | Deleted of item array
+    | Added of item array
+    | Equal of item array
+
+  type t = diff list
+
+  type subsequence_info = {
+    (* Starting index of longest subsequence in the list of new values *)
+    sub_start_new : int;
+    (* Starting index of longest subsequence in the list of old values *)
+    sub_start_old : int;
+    (* The length of the longest subsequence *)
+    longest_subsequence : int;
+  }
+
+  module CounterMap = Map.Make (Item)
+
+  (* Returns a map with the line as key and a list of indices as value.
+     Represents counts of all the lines. *)
+  let map_counter keys =
+    let keys_and_indices = Array.mapi (fun index key -> index, key) keys in
+    Array.fold_left
+      (fun map (index, key) ->
+        let indices = try CounterMap.find key map with Not_found -> [] in
+        CounterMap.add key (index :: indices) map)
+      CounterMap.empty keys_and_indices
+
+  (* Computes longest subsequence and returns data on the length of longest
+     subsequence and the starting index for the longest subsequence in the old
+     and new versions. *)
+  let get_longest_subsequence old_lines new_lines =
+    let prev_overlap = ref (Hashtbl.create 0) in
+    let old_values_counter = map_counter old_lines in
+    let sub_start_old = ref 0 in
+    let sub_start_new = ref 0 in
+    let longest_subsequence = ref 0 in
+
+    Array.iteri
+      (fun new_index new_value ->
+        let indices =
+          try CounterMap.find new_value old_values_counter
+          with Not_found -> []
+        in
+        let overlap = Hashtbl.create 100 in
+        List.iter
+          (fun old_index ->
+            let prev_subsequence =
+              try Hashtbl.find !prev_overlap (old_index - 1)
+              with Not_found -> 0
+            in
+            let new_subsequence = prev_subsequence + 1 in
+            Hashtbl.add overlap old_index new_subsequence;
+
+            if new_subsequence > !longest_subsequence then (
+              sub_start_old := old_index - new_subsequence + 1;
+              sub_start_new := new_index - new_subsequence + 1;
+              longest_subsequence := new_subsequence))
+          indices;
+        prev_overlap := overlap)
+      new_lines;
+
+    {
+      sub_start_new = !sub_start_new;
+      sub_start_old = !sub_start_old;
+      longest_subsequence = !longest_subsequence;
+    }
+
+  let rec get_diff old_lines new_lines =
+    match old_lines, new_lines with
+    | [||], [||] -> []
+    | _, _ ->
+      let { sub_start_new; sub_start_old; longest_subsequence } =
+        get_longest_subsequence old_lines new_lines
+      in
+
+      if longest_subsequence == 0 then [Deleted old_lines; Added new_lines]
+      else
+        let old_lines_presubseq = Array.sub old_lines 0 sub_start_old in
+        let new_lines_presubseq = Array.sub new_lines 0 sub_start_new in
+        let old_lines_postsubseq =
+          let start_index = sub_start_old + longest_subsequence in
+          let end_index = Array.length old_lines - start_index in
+          Array.sub old_lines start_index end_index
+        in
+        let new_lines_postsubseq =
+          let start_index = sub_start_new + longest_subsequence in
+          let end_index = Array.length new_lines - start_index in
+          Array.sub new_lines start_index end_index
+        in
+        let unchanged_lines =
+          Array.sub new_lines sub_start_new longest_subsequence
+        in
+        get_diff old_lines_presubseq new_lines_presubseq
+        @ [Equal unchanged_lines]
+        @ get_diff old_lines_postsubseq new_lines_postsubseq
+
+  let recover_old_input diffs =
+    List.fold_left
+      (fun acc diff ->
+        match diff with Deleted x | Equal x -> x :: acc | Added _ -> acc)
+      [] diffs
+    |> List.rev
+    |> Array.concat
+
+  let recover_new_input diffs =
+    List.fold_left
+      (fun acc diff ->
+        match diff with Added x | Equal x -> x :: acc | Deleted _ -> acc)
+      [] diffs
+    |> List.rev
+    |> Array.concat
+
+  (* This is intended for tests, that's why we return arrays like in the
+     original input even though lists are usually more convenient for
+     the user. *)
+  let recover_input diffs = recover_old_input diffs, recover_new_input diffs
+end

--- a/build_system/clerk_utils/diff.mli
+++ b/build_system/clerk_utils/diff.mli
@@ -1,0 +1,36 @@
+(** A simple diffing algorithm
+
+    The current implementation is a copy of Gabriel Jaldon's original OCaml
+    implementation at https://github.com/gjaldon/simple-diff *)
+
+module type Comparable = sig
+  type t
+  (** The type of the items being compared *)
+
+  val compare : t -> t -> int
+  (** A way to distinguish if items are equal or unequal. It follows the OCaml
+      convention of returning an integer between -1 to 1. *)
+end
+
+module type S = sig
+  type item
+  (** The type of the item that will be compared. *)
+
+  (** Represents the change or lack of change in a line or character between the
+      old and new version. *)
+  type diff =
+    | Deleted of item array
+    | Added of item array
+    | Equal of item array
+
+  type t = diff list
+  (** List of diffs which is the return value of the main function. *)
+
+  val get_diff : item array -> item array -> t
+  (** Returns a list of diffs between two arrays *)
+
+  val recover_input : t -> item array * item array
+  (** Recover the original input passed to {!get_diff}. *)
+end
+
+module Make (Item : Comparable) : S with type item = Item.t

--- a/catala.opam
+++ b/catala.opam
@@ -47,7 +47,6 @@ depends: [
   "ninja_utils" {= "1.0.0"}
   "otoml" {>= "1.0"}
   "json-data-encoding" { >= "1.0.1" }
-  "testo-diff"
   "odoc" {with-doc}
   "ocamlformat" {?cataladevmode & cataladevmode & = "0.28.1"}
   "obelisk" {?cataladevmode & cataladevmode}

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -1461,6 +1461,7 @@ let main () =
   in
   let eval_cmd () =
     let r = Cmd.eval_value ~catch:false ~argv command in
+    (match r with Error `Term -> Plugin.check_failure argv.(1) | _ -> ());
     Message.report_delayed_errors_if_any ();
     r
   in

--- a/compiler/plugin.ml
+++ b/compiler/plugin.ml
@@ -41,12 +41,32 @@ let print_failures () =
       "@[<v>@[<v 2>Some plugins could not be loaded:@,\
        %a@]@,\
        @,\
-       @[<hov>This generally means that they were compiled against a \
-       different@ version@ of@ Catala.@]@]"
+       @[<hov>This generally means that they need to be recompiled for this \
+       version@ of@ Catala.@]@]"
       (Format.pp_print_seq (fun ppf (n, s) ->
-           Format.fprintf ppf "- @{<bold>%s@}: @[<hov>%a@]" n
-             Format.pp_print_text s))
+           Format.fprintf ppf "- @[<hv>@{<bold>%s@}" n;
+           if s <> "" then
+             Format.fprintf ppf ":@ @[<hov>%a@]" Format.pp_print_text s;
+           Format.pp_close_box ppf ()))
       (Hashtbl.to_seq load_failures)
+
+let check_failure cmd =
+  Hashtbl.iter
+    (fun f err ->
+      if
+        String.lowercase_ascii Filename.(remove_extension (basename f))
+        = String.lowercase_ascii cmd
+      then
+        Message.Content.emit
+          (Message.error
+             "@[<v>@[<hov>Plugin \"@{<bold>%s@}\" could not be loaded.@]@,\
+              It probably needs to be recompiled for this version of \
+              Catala.%t@]"
+             cmd (fun ppf ->
+               if err = "" then ()
+               else Format.fprintf ppf "@, @[<hov>%a@]" Format.pp_print_text err))
+          Error)
+    load_failures
 
 let load_file f =
   try
@@ -55,11 +75,17 @@ let load_file f =
   with
   | Dynlink.Error (Dynlink.Module_already_loaded s) ->
     Message.debug "Plugin %S (%s) was already loaded, skipping" f s
-  | Dynlink.Error err ->
+  | Dynlink.Error err -> (
     let msg = Dynlink.error_message err in
     Message.debug "Could not load plugin %S: %s" f msg;
-    Hashtbl.add load_failures f msg
-  | e -> Message.warning "Could not load plugin %S: %s" f (Printexc.to_string e)
+    match err with
+    | Dynlink.Cannot_open_dynamic_library
+        (Dynlink.Error (Dynlink.Cannot_open_dynamic_library (Failure _))) ->
+      Hashtbl.add load_failures f ""
+    | _ -> Hashtbl.add load_failures f msg)
+  | e ->
+    Message.warning "@[<hv>Could not load plugin %S:@ %s@]" f
+      (Printexc.to_string e)
 
 let load_dir d =
   Message.debug "Loading plugins from %s" d;

--- a/compiler/plugin.mli
+++ b/compiler/plugin.mli
@@ -76,3 +76,7 @@ val load_dir : string -> unit
 val print_failures : unit -> unit
 (** Dynlink errors may be silenced at startup time if not in --debug mode, this
     prints them as warnings *)
+
+val check_failure : string -> unit
+(** Checks if a missing command could be due to a failed plugin load and prints
+    the appropriate message and fails in that case *)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1,10 +1,9 @@
-DEPS = bindlib ninja_utils ocolor otoml ubase json-data-encoding testo-diff
+DEPS = bindlib ninja_utils ocolor otoml ubase json-data-encoding
 
 deps: deps-list
 	for url in $(shell cat $<); do \
 	  curl -L $$url | tar xv$$(if [ x$${url##*.} = "xtbz" ]; then echo "j"; else echo "z"; fi); \
 	done
-	echo '(lang dune 3.13)' > $$(echo testo-*/dune-project)
 
 deps-list:
 	for pkg in $(DEPS); do \

--- a/deps/deps-list
+++ b/deps/deps-list
@@ -4,4 +4,3 @@
 "https://github.com/dmbaturin/otoml/archive/refs/tags/1.0.5.tar.gz"
 "https://github.com/sanette/ubase/archive/0.20.tar.gz"
 "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v1.0.1/data-encoding-v1.0.1.tar.gz"
-"https://github.com/semgrep/testo/releases/download/0.3.4/testo-0.3.4.tbz"


### PR DESCRIPTION
This fixes a regression in Clerk that wouldn't correctly report errors in tests due to a change in the printing format.

- improves messages when trying to run a plugin that's found but outdated
- removes dependency on testo-diff by integrating the required module