### PR TITLE
Turn the 'No plugin registered' warning into debug

### DIFF
--- a/compiler/desugared/name_resolution.ml
+++ b/compiler/desugared/name_resolution.ml
@@ -130,7 +130,7 @@ let register_attribute ~plugin ~path ~contexts callback =
 let handle_extra_attributes context plugin path value pos =
   match List.find_all (fun (n, _, _, _) -> plugin = n) !attribute_parsers with
   | [] ->
-    Message.warning ~pos
+    Message.debug ~pos
       "No plugin registered to handle attribute @{<magenta>#[%s.%s]@}" plugin
       (String.concat "." path);
     None

--- a/tests/attributes/good/parser_conflict.catala_en
+++ b/tests/attributes/good/parser_conflict.catala_en
@@ -20,24 +20,6 @@ declaration enumeration F:
 $ catala scopelang
 ┌─[WARNING]─
 │
-│  No plugin registered to handle attribute #[attr.enumdecl]
-│
-├─➤ tests/attributes/good/parser_conflict.catala_en:14.3-16:
-│    │
-│ 14 │ #[attr.enumdecl]
-│    │   ‾‾‾‾‾‾‾‾‾‾‾‾‾
-└─
-┌─[WARNING]─
-│
-│  No plugin registered to handle attribute #[attr.field]
-│
-├─➤ tests/attributes/good/parser_conflict.catala_en:12.5-15:
-│    │
-│ 12 │   #[attr.field] -- Constr
-│    │     ‾‾‾‾‾‾‾‾‾‾
-└─
-┌─[WARNING]─
-│
 │  Unrecognised attribute "attr_exp"
 │
 ├─➤ tests/attributes/good/parser_conflict.catala_en:7.23-34:

--- a/tests/attributes/good/simple.catala_en
+++ b/tests/attributes/good/simple.catala_en
@@ -57,36 +57,6 @@ $ catala scopelang
    └─ First tests
 ┌─[WARNING]─
 │
-│  No plugin registered to handle attribute #[attr.unit]
-│
-├─➤ tests/attributes/good/simple.catala_en:15.5-26:
-│    │
-│ 15 │   #[passthrough.attr.unit]
-│    │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-└─ Some simple attribute tests
-   └─ First tests
-┌─[WARNING]─
-│
-│  No plugin registered to handle attribute #[attr.multi]
-│
-├─➤ tests/attributes/good/simple.catala_en:19.5-27:
-│    │
-│ 19 │   #[passthrough.attr.multi = "string"]
-│    │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-└─ Some simple attribute tests
-   └─ First tests
-┌─[WARNING]─
-│
-│  No plugin registered to handle attribute #[attr.expr]
-│
-├─➤ tests/attributes/good/simple.catala_en:18.5-26:
-│    │
-│ 18 │   #[passthrough.attr.expr = false]
-│    │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-└─ Some simple attribute tests
-   └─ First tests
-┌─[WARNING]─
-│
 │  In scope "S", the variable "x" is declared but never defined;
 │  did you forget something?
 │


### PR DESCRIPTION
This is too verbose, and it's legit to have attributes intended for a third-party plugin but ignored by Catala
