### PR TITLE
Clerk: improve reporting when the test locations specified have no valid tests

### DIFF
--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -249,11 +249,11 @@ let raw_cmd : int Cmd.t =
             else f)
           targets
       in
-      Clerk_rules.run_ninja ~code_coverage ~config ~autotest ~quiet
+      Clerk_rules.run_ninja ~code_coverage ~config ~autotest ~quiet ~default:0
         ~ninja_flags:(ninja_flags @ targets) (fun _ _ _ -> 0)
     else (
       Format.eprintf "Available targets:@.";
-      Clerk_rules.run_ninja ~code_coverage ~config ~autotest ~quiet
+      Clerk_rules.run_ninja ~code_coverage ~config ~autotest ~quiet ~default:0
         ~ninja_flags:(ninja_flags @ ["-t"; "targets"])
         (fun _ _ _ -> 0))
   in
@@ -288,7 +288,7 @@ let build_clerk_target
   let enabled_backends = normalize_backends backends in
   let install_targets, all_modules_deps =
     Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends
-      ~ninja_flags ~quiet ~autotest:false
+      ~ninja_flags ~quiet ~default:([], []) ~autotest:false
     @@ fun nin_ppf items _var_bindings ->
     let find_module_item module_name =
       try
@@ -469,6 +469,7 @@ let build_direct_targets
     in
     let ninja_targets, exec_targets, var_bindings, link_deps =
       Clerk_rules.run_ninja ~code_coverage ~config ~enabled_backends ~quiet
+        ~default:([], [], [], fun _ -> assert false)
         ~ninja_flags ~autotest
       @@ fun nin_ppf items var_bindings ->
       let link_deps = linking_dependencies items in
@@ -755,46 +756,72 @@ let backend_to_config = function
   | `Python -> Clerk_config.Python
   | `Java -> Clerk_config.Java
 
-let retrieve_target_items ?(test_only = true) items files_or_folders =
+let retrieve_target_items ~test_only items files_or_folders =
   let open File in
-  List.concat_map
-    (fun file ->
-      let is_dir = try Sys.is_directory file with Sys_error _ -> false in
-      let filter item =
-        if is_dir then
-          String.starts_with ~prefix:(file / "") item.Scan.file_name
-          && ((not test_only) || Lazy.force item.Scan.has_scope_tests)
-        else
-          Option.map Mark.remove item.Scan.module_def
-          = Some (File.basename file)
-          || item.Scan.file_name = file
-          || File.remove_extension item.Scan.file_name = file
-      in
-      let items = List.filter filter items in
-      if items = [] then
-        Message.error
-          "@[<v>@[<hov>No source file or module matching@ %a@ found@]%t@]"
-          format file (fun ppf ->
-            if Sys.file_exists file && (not is_dir) && Scan.get_lang file = None
-            then
-              Format.fprintf ppf
-                "@,\
-                 @[<hov>@{<bold>Hint:@} the specified file exists but doesn't \
-                 have a recognised extension@]");
-      items)
-    files_or_folders
+  let items, missing =
+    List.partition_map
+      (fun file ->
+        let is_dir = try Sys.is_directory file with Sys_error _ -> false in
+        let items =
+          List.filter
+            (fun item ->
+              if is_dir then
+                String.starts_with ~prefix:(file / "") item.Scan.file_name
+              else
+                Option.map Mark.remove item.Scan.module_def
+                = Some (File.basename file)
+                || item.Scan.file_name = file
+                || File.remove_extension item.Scan.file_name = file)
+            items
+        in
+        if items = [] then
+          Message.error
+            "@[<v>@[<hov>No source file or module matching@ %a@ found@]%t@]"
+            format file (fun ppf ->
+              if
+                Sys.file_exists file
+                && (not is_dir)
+                && Scan.get_lang file = None
+              then
+                Format.fprintf ppf
+                  "@,\
+                   @[<hov>@{<bold>Hint:@} the specified file exists but \
+                   doesn't have a recognised extension@]");
+        match test_only with
+        | `No -> Left items
+        | (`Scope | `Cli_or_scope) as t -> (
+          let filter =
+            match t with
+            | `Cli_or_scope ->
+              fun it ->
+                it.Scan.has_inline_tests || Lazy.force it.Scan.has_scope_tests
+            | `Scope -> fun it -> Lazy.force it.Scan.has_scope_tests
+          in
+          match List.filter filter items with
+          | [] -> Right file
+          | items -> Left items))
+      files_or_folders
+  in
+  if missing <> [] then
+    Message.warning
+      "@[<hov 2>No tests found at the following locations, ignoring them:@ %a@]"
+      (Format.pp_print_list
+         ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+         File.format)
+      missing;
+  List.flatten items
 
 let build_test_deps
     ~config
     ~backend
-    ?(test_only = true)
+    ~test_only
     files_or_folders
     nin_ppf
     items
     var_bindings =
   let build_dir = config.Cli.options.global.build_dir in
   let target_items = retrieve_target_items ~test_only items files_or_folders in
-  if target_items = [] then Message.error "Nothing to run";
+  if target_items = [] then raise Clerk_rules.Stop_ninja;
   let base_targets =
     List.map (fun it -> it, make_target ~build_dir ~backend it) target_items
   in
@@ -848,23 +875,27 @@ let run_targets
           "Multiple targets found for a single input, please specify a single \
            target."
     in
-    let catala_flags =
-      Var.get_var var_bindings Var.catala_flags
-      @ (match scope with
-        | None -> []
-        | Some scope -> [Printf.sprintf "--scope=%s" scope])
-      @ (match scope_input with
-        | None -> []
-        | Some input ->
-          [Printf.sprintf "--input=%s" (Yojson.Safe.to_string ~std:true input)])
-      @ if whole_program then ["--whole-program"] else []
-    in
-    let exec = Var.get_var var_bindings Var.catala_exe in
-    iter_commands ~build_dir test_targets
-    @@ fun _item target ->
-    let cmd = exec @ [cmd; target] @ catala_flags in
-    Message.debug "Running command: '%s'..." (String.concat " " cmd);
-    Clerk_cli.run_command_line cmd
+    if test_targets = [] then 0
+    else
+      let catala_flags =
+        Var.get_var var_bindings Var.catala_flags
+        @ (match scope with
+          | None -> []
+          | Some scope -> [Printf.sprintf "--scope=%s" scope])
+        @ (match scope_input with
+          | None -> []
+          | Some input ->
+            [
+              Printf.sprintf "--input=%s" (Yojson.Safe.to_string ~std:true input);
+            ])
+        @ if whole_program then ["--whole-program"] else []
+      in
+      let exec = Var.get_var var_bindings Var.catala_exe in
+      iter_commands ~build_dir test_targets
+      @@ fun _item target ->
+      let cmd = exec @ [cmd; target] @ catala_flags in
+      Message.debug "Running command: '%s'..." (String.concat " " cmd);
+      Clerk_cli.run_command_line cmd
   | (`C | `OCaml | `Python | `Java) as backend -> (
     let link_cmd =
       linking_command ~build_dir ~backend ~var_bindings link_deps
@@ -892,10 +923,10 @@ let run_cmd =
       whole_program =
     let test_only =
       match scope_input, backend with
-      | Some _, `Interpret -> false
+      | Some _, `Interpret -> `No
       | Some _, _ ->
         Message.error "JSON input is only supported with the interpret backend."
-      | _ -> true
+      | _ -> `Scope
     in
     let files_or_folders = List.map config.Cli.fix_path files_or_folders in
     let enabled_backends =
@@ -903,6 +934,7 @@ let run_cmd =
     in
     Clerk_rules.run_ninja ~config ~code_coverage:false ~enabled_backends
       ~ninja_flags ~autotest:false ~quiet
+      ~default:([], (fun _ -> assert false), [])
       (build_test_deps ~config ~backend ~test_only files_or_folders)
     |> fun tests ->
     if prepare_only then Cmd.Exit.ok
@@ -995,7 +1027,8 @@ let typecheck_cmd =
     let exception Nothing_to_do in
     match
       Clerk_rules.run_ninja ~code_coverage:false ~config ~enabled_backends:[]
-        ~autotest:false ~ninja_flags ~quiet (fun nin_ppf items var_bindings ->
+        ~autotest:false ~ninja_flags ~quiet ~default:([], [])
+        (fun nin_ppf items var_bindings ->
           let target_items = retrieve_typecheck_items items files_or_folders in
           if target_items = [] then
             (* Prevents [run_ninja] to fail miserably with an obscure error *)
@@ -1178,31 +1211,24 @@ let run_clerk_test
   in
   if backend <> `Interpret then
     Clerk_rules.run_ninja ~quiet ~code_coverage ~config ~enabled_backends
+      ~default:([], (fun _ -> assert false), [])
       ~ninja_flags ~autotest:true ~clean_up_env:true
-      (build_test_deps ~config ~backend files_or_folders)
+      (build_test_deps ~config ~backend ~test_only:`Scope files_or_folders)
     |> run_targets ~test:true config backend "" None None
   else
-    let targets, missing =
-      List.partition_map
-        File.(
-          fun f ->
-            if File.exists f then Either.Left (build_dir / f)
-            else Either.Right f)
-        files_or_folders
-    in
-    if missing <> [] then
-      Message.error "@[<hv 2>Could not find files:@ @[<hov>%a@]@]"
-        (Format.pp_print_list
-           ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
-           Format.pp_print_string)
-        missing;
     let test_targets =
       Clerk_rules.run_ninja ~code_coverage ~config ~tests:true ~enabled_backends
-        ~ninja_flags ~autotest:false ~quiet ~clean_up_env:true
-        (fun nin_ppf _items _vars ->
-          (* FIXME: remove and warn about files that have no @tests rule *)
-          let test_targets = List.map (fun f -> f ^ "@test") targets in
-          Nj.format_def nin_ppf (Nj.Default (Nj.Default.make test_targets));
+        ~ninja_flags ~autotest:false ~quiet ~default:[] ~clean_up_env:true
+        (fun nin_ppf items _vars ->
+          ignore
+            (retrieve_target_items ~test_only:`Cli_or_scope items
+               files_or_folders);
+          (* the above checks for specified files with missing tests *)
+          let test_targets =
+            List.map File.(fun f -> (build_dir / f) ^ "@test") files_or_folders
+          in
+          if test_targets <> [] then
+            Nj.format_def nin_ppf (Nj.Default (Nj.Default.make test_targets));
           test_targets)
     in
     let open Clerk_report in
@@ -1345,8 +1371,9 @@ let start_cmd =
         ["Stdlib_fr@src"; "Stdlib_en@src"]
         enabled_backends
     in
-    Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet ~config
-      ~enabled_backends ~autotest:false ~ninja_flags (fun nin_ppf _ _ ->
+    Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet
+      ~default:0 ~config ~enabled_backends ~autotest:false ~ninja_flags
+      (fun nin_ppf _ _ ->
         Nj.format_def nin_ppf (Nj.Default (Nj.Default.make default));
         0)
   in
@@ -1496,7 +1523,8 @@ let json_schema_cmd =
     Clerk_rules.run_ninja ~config ~code_coverage:false
       ~enabled_backends:[(module Clerk_backends.Ocaml.Backend)]
       ~ninja_flags ~autotest:false ~quiet
-      (build_test_deps ~config ~backend:`Interpret ~test_only:false [file])
+      ~default:([], (fun _ -> assert false), [])
+      (build_test_deps ~config ~backend:`Interpret ~test_only:`No [file])
     |> fun (items, _link_deps, var_bindings) ->
     let catala_exe = Var.get_var var_bindings Var.catala_exe in
     let catala_flags = Var.get_var var_bindings Var.catala_flags in

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1220,10 +1220,12 @@ let run_clerk_test
       Clerk_rules.run_ninja ~code_coverage ~config ~tests:true ~enabled_backends
         ~ninja_flags ~autotest:false ~quiet ~default:[] ~clean_up_env:true
         (fun nin_ppf items _vars ->
-          ignore
-            (retrieve_target_items ~test_only:`Cli_or_scope items
-               files_or_folders);
-          (* the above checks for specified files with missing tests *)
+          (* Check for targets without tests *)
+          if
+            retrieve_target_items ~test_only:`Cli_or_scope items
+              files_or_folders
+            = []
+          then raise Clerk_rules.Stop_ninja;
           let test_targets =
             List.map File.(fun f -> (build_dir / f) ^ "@test") files_or_folders
           in

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -413,11 +413,14 @@ let ninja_version =
        |> List.map int_of_string
      with Exit | Failure _ -> [])
 
+exception Stop_ninja
+
 let with_ninja_process
     ~config
     ~clean_up_env
     ~ninja_flags
     ~quiet
+    ~default
     (callback : Format.formatter -> 'a) =
   let env = if clean_up_env then cleaned_up_env () else Unix.environment () in
   let fname =
@@ -449,7 +452,8 @@ let with_ninja_process
         else Unix.stdout
       in
       Fun.protect
-        ~finally:(fun () -> if quiet then Unix.close out)
+        ~finally:(fun () ->
+          if quiet then try Unix.close out with Unix.Unix_error _ -> ())
         (fun () ->
           Unix.create_process_env ninja_exec (Array.of_list cmdline) env nin_fd
             out Unix.stderr)
@@ -459,46 +463,53 @@ let with_ninja_process
       | _, Unix.WEXITED n -> n
       | _, (Unix.WSIGNALED n | Unix.WSTOPPED n) -> 128 - n
       | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+      | exception Unix.Unix_error (Unix.ECHILD, _, _) -> 130
     in
     ( npid,
       fun () ->
         match wait () with 0 -> () | n -> raise (Catala_utils.Cli.Exit_with n) )
   in
   match fname with
-  | Some fname ->
-    let ret = File.with_formatter_of_file fname callback in
-    let _, wait = ninja_process fname Unix.stdin in
-    wait ();
-    ret
+  | Some fname -> (
+    match File.with_formatter_of_file fname callback with
+    | ret ->
+      let _, wait = ninja_process fname Unix.stdin in
+      wait ();
+      ret
+    | exception Stop_ninja -> default)
   | None when Sys.os_type = "Win32" ->
     (* ninja requires the name of the file on the cli. No /dev/stdin on
        Windows *)
-    File.with_temp_file "clerk_build_" ".ninja"
-    @@ fun fname ->
-    let ret = File.with_formatter_of_file fname callback in
-    let _, wait = ninja_process fname Unix.stdin in
-    wait ();
-    ret
-  | None ->
+    File.with_temp_file "clerk_build_" ".ninja" (fun fname ->
+        match File.with_formatter_of_file fname callback with
+        | ret ->
+          let _, wait = ninja_process fname Unix.stdin in
+          wait ();
+          ret
+        | exception Stop_ninja -> default)
+  | None -> (
     let ninja_in, clerk_out = Unix.pipe ~cloexec:true () in
     let npid, wait = ninja_process "/dev/stdin" ninja_in in
-    let callback_ret =
-      try
-        Unix.close ninja_in;
-        File.with_formatter_of_out_channel
-          (Unix.out_channel_of_descr clerk_out)
-          callback
-      with e ->
-        let bt = Printexc.get_raw_backtrace () in
-        Message.debug "Exception caught, killing the ninja sub-process";
-        Unix.kill npid Sys.sigkill;
-        (try wait () with _ -> ());
-        Unix.close clerk_out;
-        Printexc.raise_with_backtrace e bt
-    in
-    Unix.close clerk_out;
-    wait ();
-    callback_ret
+    Unix.close ninja_in;
+    match
+      File.with_formatter_of_out_channel
+        (Unix.out_channel_of_descr clerk_out)
+        callback
+    with
+    | exception Stop_ninja ->
+      Unix.kill npid Sys.sigkill;
+      (try wait () with _ -> ());
+      default
+    | exception e ->
+      let bt = Printexc.get_raw_backtrace () in
+      Message.debug "Exception caught, killing the ninja sub-process";
+      Unix.kill npid Sys.sigkill;
+      (try wait () with _ -> ());
+      Printexc.raise_with_backtrace e bt
+    | callback_ret ->
+      Unix.close clerk_out;
+      wait ();
+      callback_ret)
 
 let run_ninja
     ?(include_dir = true)
@@ -506,6 +517,7 @@ let run_ninja
     ?(tests = false)
     ?(enabled_backends = all_backends)
     ~quiet
+    ~default
     ~code_coverage
     ~autotest
     ?(clean_up_env = false)
@@ -514,7 +526,8 @@ let run_ninja
   let var_bindings =
     base_bindings ~code_coverage ~config ~enabled_backends ~autotest
   in
-  with_ninja_process ~config ~clean_up_env ~ninja_flags ~quiet (fun nin_ppf ->
+  with_ninja_process ~config ~clean_up_env ~ninja_flags ~quiet ~default
+    (fun nin_ppf ->
       let insource = Lazy.force Poll.catala_source_tree_root <> None in
       let stdlib_dir = Lazy.force Poll.stdlib_dir in
       let stdlib_tree =

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -29,12 +29,15 @@ val base_bindings :
   config:Clerk_cli.config ->
   (Var.t * string list) list
 
+exception Stop_ninja
+
 val run_ninja :
   ?include_dir:bool ->
   config:Clerk_cli.config ->
   ?tests:bool ->
   ?enabled_backends:backend list ->
   quiet:bool ->
+  default:'a ->
   code_coverage:bool ->
   autotest:bool ->
   ?clean_up_env:bool ->
@@ -50,4 +53,6 @@ val run_ninja :
     the corresponding build dir.
 
     By default, all backends are enabled, the env is not cleaned of CATALA_*
-    variables *)
+    variables.
+
+    [default] is returned if the callback aborts with exception [Stop_ninja]. *)


### PR DESCRIPTION
This preemptively detects missing tests, and avoid running Clerk without tergets which was yielding a very poor error message.