### PR TITLE
Improve clerk handling of the exception-tree building

### DIFF
--- a/build_system/backend/common.ml
+++ b/build_system/backend/common.ml
@@ -76,7 +76,13 @@ module Flags = struct
       if inplace then
         {
           options with
-          global = { options.global with build_dir = Filename.current_dir_name };
+          global =
+            {
+              options.global with
+              build_dir =
+                File.make_relative_to ~dir:File.original_cwd
+                  Filename.current_dir_name;
+            };
         }
       else options
     in

--- a/build_system/backend/common.ml
+++ b/build_system/backend/common.ml
@@ -69,13 +69,24 @@ module Flags = struct
            ])
          include_dirs
 
-  let default ~code_coverage ~config =
+  let default ~code_coverage ~inplace ~config =
     let options = config.Clerk_cli.options in
     let open Clerk_config in
+    let options =
+      if inplace then
+        {
+          options with
+          global = { options.global with build_dir = Filename.current_dir_name };
+        }
+      else options
+    in
     let catala_flags =
-      ("--stdlib=" ^ File.(Var.(!builddir) / Scan.libcatala))
-      :: ("--directory=" ^ Var.(!builddir))
-      :: options.global.catala_opts
+      if inplace then
+        ("--stdlib=" ^ Lazy.force Poll.stdlib_dir) :: options.global.catala_opts
+      else
+        ("--stdlib=" ^ File.(Var.(!builddir) / Scan.libcatala))
+        :: ("--directory=" ^ Var.(!builddir))
+        :: options.global.catala_opts
     in
     let includes = includes options.global.include_dirs in
     let test_flags = config.Clerk_cli.test_flags in

--- a/build_system/backend/common.mli
+++ b/build_system/backend/common.mli
@@ -31,7 +31,10 @@ module Flags : sig
     string list
 
   val default :
-    code_coverage:bool -> config:Clerk_cli.config -> (Var.t * string list) list
+    code_coverage:bool ->
+    inplace:bool ->
+    config:Clerk_cli.config ->
+    (Var.t * string list) list
 end
 
 module Ninja : sig

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1359,6 +1359,23 @@ let runtest_cmd =
       $ Cli.single_file
       $ Cli.whole_program)
 
+let run_ninja_start ~config ~quiet ~ninja_flags ~enabled_backends cont =
+  let default =
+    List.fold_left
+      (fun default_rules (module B : Clerk_backends.Backend.S) ->
+        let rule_stdlib_fr = Format.sprintf "Stdlib_fr@%s-module" B.name in
+        let rule_stdlib_en = Format.sprintf "Stdlib_en@%s-module" B.name in
+        let runtime_rule = Format.sprintf "@runtime-%s" B.name in
+        runtime_rule :: rule_stdlib_fr :: rule_stdlib_en :: default_rules)
+      ["Stdlib_fr@src"; "Stdlib_en@src"]
+      enabled_backends
+  in
+  Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet
+    ~default:0 ~config ~enabled_backends ~autotest:false ~ninja_flags
+    (fun nin_ppf _ _ ->
+      Nj.format_def nin_ppf (Nj.Default (Nj.Default.make default));
+      cont ())
+
 let start_cmd =
   let run config quiet (ninja_flags : string list) =
     let targets = config.Cli.options.targets in
@@ -1367,21 +1384,7 @@ let start_cmd =
       List.concat_map (fun target -> target.backends) targets
       |> normalize_backends
     in
-    let default =
-      List.fold_left
-        (fun default_rules (module B : Clerk_backends.Backend.S) ->
-          let rule_stdlib_fr = Format.sprintf "Stdlib_fr@%s-module" B.name in
-          let rule_stdlib_en = Format.sprintf "Stdlib_en@%s-module" B.name in
-          let runtime_rule = Format.sprintf "@runtime-%s" B.name in
-          runtime_rule :: rule_stdlib_fr :: rule_stdlib_en :: default_rules)
-        ["Stdlib_fr@src"; "Stdlib_en@src"]
-        enabled_backends
-    in
-    Clerk_rules.run_ninja ~include_dir:false ~code_coverage:false ~quiet
-      ~default:0 ~config ~enabled_backends ~autotest:false ~ninja_flags
-      (fun nin_ppf _ _ ->
-        Nj.format_def nin_ppf (Nj.Default (Nj.Default.make default));
-        0)
+    run_ninja_start ~config ~quiet ~ninja_flags ~enabled_backends (fun () -> 0)
   in
   let doc =
     "This command prepares the local build environment of the project with \
@@ -1505,7 +1508,7 @@ let list_vars_cmd =
   let run config =
     let var_bindings =
       Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
-        ~enabled_backends:Clerk_rules.all_backends ~config
+        ~enabled_backends:Clerk_rules.all_backends ~config ~inplace:false
     in
     Format.eprintf "Defined variables:@.";
     Format.open_vbox 0;
@@ -1524,25 +1527,19 @@ let list_vars_cmd =
   Cmd.v (Cmd.info ~doc "list-vars") Term.(const run $ Cli.init_term ())
 
 let json_schema_cmd =
-  let run config ninja_flags quiet file scope =
+  let run config file scope =
     let file = config.Cli.fix_path file in
-    Clerk_rules.run_ninja ~config ~code_coverage:false
-      ~enabled_backends:[(module Clerk_backends.Ocaml.Backend)]
-      ~ninja_flags ~autotest:false ~quiet
-      ~default:([], (fun _ -> assert false), [])
-      (build_test_deps ~config ~backend:`Interpret ~test_only:`No [file])
-    |> fun (items, _link_deps, var_bindings) ->
+    let var_bindings =
+      Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
+        ~enabled_backends:[] ~config ~inplace:true
+    in
     let catala_exe = Var.get_var var_bindings Var.catala_exe in
     let catala_flags = Var.get_var var_bindings Var.catala_flags in
-    match items with
-    | [] ->
-      Message.error "Found no valid compiled target to extract JSON schema"
-    | ({ Scan.file_name; _ }, _) :: _ ->
-      let cmd =
-        catala_exe @ ["json-schema"; file_name; "--scope"; scope] @ catala_flags
-      in
-      Message.debug "Running command: '%s'..." (String.concat " " cmd);
-      Clerk_cli.run_command_line cmd
+    let cmd =
+      catala_exe @ ["json-schema"; file; "--scope"; scope] @ catala_flags
+    in
+    Message.debug "Running command: '%s'..." (String.concat " " cmd);
+    Clerk_cli.run_command_line cmd
   in
   let doc =
     "Display the JSON-schema of the input and output JSON objects of the given \
@@ -1552,37 +1549,27 @@ let json_schema_cmd =
   in
   Cmd.v
     (Cmd.info ~doc "json-schema")
-    Term.(
-      const run
-      $ Cli.init_term ()
-      $ Cli.ninja_flags
-      $ Cli.quiet
-      $ Cli.single_file
-      $ Cli.scope)
+    Term.(const run $ Cli.init_term () $ Cli.single_file $ Cli.scope)
 
 let exceptions_cmd =
-  let run config ninja_flags file scope variable =
-    (* The exceptions command only needs the desugaring pass — no compiled
-       artifacts required. Bypass ninja and call catala directly. *)
+  let run config file scope variable =
+    (* The exceptions command only needs the desugaring pass — no compiled artifacts
+       required. Bypass ninja and call catala directly from the project root
+       instead of the build dir (with [inplace:true]) *)
     let file = config.Cli.fix_path file in
-    Clerk_rules.run_ninja ~config ~code_coverage:false
-      ~enabled_backends:[(module Clerk_backends.Ocaml.Backend)]
-      ~ninja_flags ~autotest:false ~quiet:true
-      ~default:([], (fun _ -> assert false), [])
-      (build_test_deps ~config ~backend:`Interpret ~test_only:`No [file])
-    |> fun (items, _link_deps, var_bindings) ->
-    match items with
-    | [] -> Message.error "Failed to compile %s dependencies" file
-    | ({ Scan.file_name; _ }, _) :: _ ->
-      let catala_exe = Var.get_var var_bindings Var.catala_exe in
-      let catala_flags = Var.get_var var_bindings Var.catala_flags in
-      let cmd =
-        catala_exe
-        @ ["exceptions"; file_name; "--scope"; scope; "--variable"; variable]
-        @ catala_flags
-      in
-      Message.debug "Running command: '%s'..." (String.concat " " cmd);
-      Clerk_cli.run_command_line cmd
+    let var_bindings =
+      Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
+        ~enabled_backends:[] ~config ~inplace:true
+    in
+    let catala_exe = Var.get_var var_bindings Var.catala_exe in
+    let catala_flags = Var.get_var var_bindings Var.catala_flags in
+    let cmd =
+      catala_exe
+      @ ["exceptions"; file; "--scope"; scope; "--variable"; variable]
+      @ catala_flags
+    in
+    Message.debug "Running command: '%s'..." (String.concat " " cmd);
+    Clerk_cli.run_command_line cmd
   in
   let doc =
     "Prints the exception tree for the definitions of a particular variable in \
@@ -1592,12 +1579,7 @@ let exceptions_cmd =
   Cmd.v
     (Cmd.info ~doc "exceptions")
     Term.(
-      const run
-      $ Cli.init_term ()
-      $ Cli.ninja_flags
-      $ Cli.single_file
-      $ Cli.scope
-      $ Cli.variable)
+      const run $ Cli.init_term () $ Cli.single_file $ Cli.scope $ Cli.variable)
 
 let main_cmd =
   Cmd.group Cli.info

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1528,7 +1528,6 @@ let list_vars_cmd =
 
 let json_schema_cmd =
   let run config file scope =
-    let file = config.Cli.fix_path file in
     let var_bindings =
       Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
         ~enabled_backends:[] ~config ~inplace:true
@@ -1539,6 +1538,7 @@ let json_schema_cmd =
       catala_exe @ ["json-schema"; file; "--scope"; scope] @ catala_flags
     in
     Message.debug "Running command: '%s'..." (String.concat " " cmd);
+    Sys.chdir File.original_cwd;
     Clerk_cli.run_command_line cmd
   in
   let doc =
@@ -1556,7 +1556,6 @@ let exceptions_cmd =
     (* The exceptions command only needs the desugaring pass — no compiled artifacts
        required. Bypass ninja and call catala directly from the project root
        instead of the build dir (with [inplace:true]) *)
-    let file = config.Cli.fix_path file in
     let var_bindings =
       Clerk_rules.base_bindings ~autotest:false ~code_coverage:false
         ~enabled_backends:[] ~config ~inplace:true
@@ -1569,6 +1568,7 @@ let exceptions_cmd =
       @ catala_flags
     in
     Message.debug "Running command: '%s'..." (String.concat " " cmd);
+    Sys.chdir File.original_cwd;
     Clerk_cli.run_command_line cmd
   in
   let doc =

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -43,11 +43,13 @@ let backend_from_config = function
     (module Clerk_backends.Java.Backend : Clerk_backends.Backend.S)
   | _ -> invalid_arg __FUNCTION__
 
-let base_bindings ~code_coverage ~autotest ~enabled_backends ~config =
+let base_bindings ~code_coverage ~autotest ~enabled_backends ~inplace ~config =
   let options = config.Clerk_cli.options in
   let test_flags = config.Clerk_cli.test_flags in
   let use_default_flags = test_flags = [] && options.global.catala_opts = [] in
-  let default_flags = Backend_common.Flags.default ~code_coverage ~config in
+  let default_flags =
+    Backend_common.Flags.default ~code_coverage ~inplace ~config
+  in
   let backend_flags =
     List.concat_map
       (fun (module Backend : Clerk_backends.Backend.S) ->
@@ -525,6 +527,7 @@ let run_ninja
     callback =
   let var_bindings =
     base_bindings ~code_coverage ~config ~enabled_backends ~autotest
+      ~inplace:false
   in
   with_ninja_process ~config ~clean_up_env ~ninja_flags ~quiet ~default
     (fun nin_ppf ->

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -26,6 +26,7 @@ val base_bindings :
   code_coverage:bool ->
   autotest:bool ->
   enabled_backends:backend list ->
+  inplace:bool ->
   config:Clerk_cli.config ->
   (Var.t * string list) list
 

--- a/build_system/clerk_utils/var.ml
+++ b/build_system/clerk_utils/var.ml
@@ -62,6 +62,8 @@ let re_var =
   let open Re in
   seq [str "${"; group (rep1 (diff any (char '}'))); char '}']
 
+type bindings = (t * string list) list
+
 let rec get_var =
   (* replaces ${var} with its value, recursively *)
   let re_single_var = Re.(compile (whole_string re_var)) in

--- a/build_system/clerk_utils/var.mli
+++ b/build_system/clerk_utils/var.mli
@@ -17,8 +17,11 @@
 
 open Catala_utils
 
-include module type of Ninja_utils.Var
-(** Ninja variable names *)
+include module type of struct
+  include Ninja_utils.Var
+end
+
+(** {1 Ninja variable names} *)
 
 (** {2 Global vars: always defined, at toplevel} *)
 
@@ -47,7 +50,7 @@ val class_path : t
 val cat_files : t
 val test_id : t
 
-(** {2 Utility functions} *)
+(** {1 Utility functions} *)
 
 type bindings = (t * string list) list
 

--- a/build_system/clerk_utils/var.mli
+++ b/build_system/clerk_utils/var.mli
@@ -1,0 +1,61 @@
+(* This file is part of the Catala build system, a specification language for
+   tax and social benefits computation rules. Copyright (C) 2020-2025 Inria,
+   contributors: Denis Merigoux <denis.merigoux@inria.fr>, Emile Rolley
+   <emile.rolley@tuta.io>, Louis Gesbert <louis.gesbert@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Catala_utils
+
+include module type of Ninja_utils.Var
+(** Ninja variable names *)
+
+(** {2 Global vars: always defined, at toplevel} *)
+
+val ninja_required_version : t
+val builddir : t
+val clerk_exe : t
+val clerk_flags : t
+val catala_exe : t
+val catala_flags : t
+val make : string -> t
+val runtime : t
+val all_vars : t String.Map.t
+
+(** {2 Definition spreading different rules} *)
+
+val tdir : t
+val includes : t
+
+(** {2 Rule vars, Used in specific rules} *)
+
+val input : t
+val output : t
+val src : t
+val dst : t
+val class_path : t
+val cat_files : t
+val test_id : t
+
+(** {2 Utility functions} *)
+
+type bindings = (t * string list) list
+
+val ( ! ) : t -> string
+(** Run-time reference to the given variable [!var = "${xvarname}"] *)
+
+val get_var : bindings -> t -> string list
+(** replaces [${xvar}] with its value, recursively *)
+
+val expand_vars : bindings -> string -> string
+(** expands [${xvar}] references in the given string *)

--- a/compiler/catala_utils/mark.ml
+++ b/compiler/catala_utils/mark.ml
@@ -31,3 +31,4 @@ let fold2 f (x, _) (y, _) = f x y
 let compare cmp a b = fold2 cmp a b
 let equal eq a b = fold2 eq a b
 let hash f (x, _) = f x
+let pp_link pp ppf ((_, pos) as x) = Message.pp_pos_link pos ppf "%a" pp x

--- a/compiler/catala_utils/mark.mli
+++ b/compiler/catala_utils/mark.mli
@@ -45,3 +45,7 @@ val equal : ('a -> 'a -> bool) -> ('a, 'm) ed -> ('a, 'm) ed -> bool
 val hash : ('a -> Hash.t) -> ('a, 'm) ed -> Hash.t
 (** Computes the hash of the marked values using the given function
     {b ignoring mark} *)
+
+val pp_link :
+  (Format.formatter -> 'a pos -> unit) -> Format.formatter -> 'a * Pos.t -> unit
+(** Prints the given pos-marked element with a link to its position *)

--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -208,11 +208,13 @@ let file_url =
       (if column > 1 then Printf.sprintf ":%d" column else "")
 
 let pp_pos_link pos ppf =
-  pp_link
-    ~target:
-      (file_url (Pos.get_file pos) ~line:(Pos.get_start_line pos)
-         ~column:(Pos.get_start_column pos))
-    ppf
+  if pos = Pos.void then Format.fprintf ppf
+  else
+    pp_link
+      ~target:
+        (file_url (Pos.get_file pos) ~line:(Pos.get_start_line pos)
+           ~column:(Pos.get_start_column pos))
+      ppf
 
 let pp_pos ppf pos = pp_pos_link pos ppf "%s" (Pos.to_string_short pos)
 

--- a/compiler/catala_utils/message.mli
+++ b/compiler/catala_utils/message.mli
@@ -119,6 +119,10 @@ val link : ?target:string -> unit -> Format.formatter -> string -> unit
 val pp_pos : Format.formatter -> Pos.t -> unit
 (** Prints the given position with style and, if possible, an hyperlink *)
 
+val pp_pos_link :
+  Pos.t -> Format.formatter -> ('a, Format.formatter, unit) format -> 'a
+(** Wraps the given format with a link to the given pos *)
+
 val file_url : ?line:int -> ?column:int -> string -> string
 (** Helper to build file targets for hyperlinks *)
 

--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -130,7 +130,7 @@ let format_exception_forest ~is_condition fmt trees =
 let pos_to_json (pos : Pos.t) : Yojson.Safe.t =
   `Assoc
     [
-      "filename", `String (File.make_absolute (Pos.get_file pos));
+      "filename", `String (Pos.get_file pos);
       "start_line", `Int (Pos.get_start_line pos);
       "start_column", `Int (Pos.get_start_column pos);
       "end_line", `Int (Pos.get_end_line pos);

--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -132,7 +132,7 @@ let format_exception_forest ~is_condition fmt trees =
 let pos_to_json (pos : Pos.t) : Yojson.Safe.t =
   `Assoc
     [
-      "filename", `String (Pos.get_file pos);
+      "filename", `String (File.make_absolute (Pos.get_file pos));
       "start_line", `Int (Pos.get_start_line pos);
       "start_column", `Int (Pos.get_start_column pos);
       "end_line", `Int (Pos.get_end_line pos);

--- a/compiler/desugared/print.ml
+++ b/compiler/desugared/print.ml
@@ -32,13 +32,13 @@ let conditions_of_vertex (v : Dependency.ExceptionVertex.t) : Ast.expr list =
    in the expression printer produce the same ANSI sequences as the outer
    formatter; this preserves syntax highlighting in the condition text. *)
 let render_condition_lines width fmt_outer e =
-  let buf = Buffer.create 80 in
+  let buf = Buffer.create 180 in
   let inner = Format.formatter_of_buffer buf in
   Format.pp_set_formatter_stag_functions inner
     (Format.pp_get_formatter_stag_functions fmt_outer ());
   Format.pp_set_tags inner true;
   Format.pp_set_margin inner (max 20 width);
-  Print.UserFacing.expr inner e;
+  Message.pp_pos_link (Expr.pos e) inner "%a" Print.UserFacing.expr e;
   Format.pp_print_flush inner ();
   String.split_on_char '\n' (Buffer.contents buf)
 
@@ -58,7 +58,9 @@ let rec print_exception_node
     | Leaf l -> l.Dependency.ExceptionVertex.label, l, []
     | Node (children, l) -> l.Dependency.ExceptionVertex.label, l, children
   in
-  Format.fprintf fmt "\"%a\"" LabelName.format label;
+  Message.pp_pos_link
+    (Mark.get (LabelName.get_info label))
+    fmt "\"%a\"" LabelName.format label;
   (* For nodes with children, run a │ bar down through all condition lines to
      visually connect the label to the child connectors below. For leaves, use
      plain spaces. Continuation lines of multi-line conditions align under [. *)


### PR DESCRIPTION
This relaxes the need to run ninja by fine-tuning the args needed by Catala.

NOTE: I removed the `make_absolute` from the JSON printing -- the relative path is now correct -- but the result in VScode should be checked for surprises

Also: adds a missing mli and hyperlinks (you can now click the conditions in the trace in terminal output)