### PR TITLE
Error out on use of private types

### DIFF
--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -268,8 +268,10 @@ let print_diff ppf p1 p2 =
       (* Account for "\r\n" *)
         else pos.Lexing.pos_cnum
     in
-    seek_in ic (pos_char pstart);
-    really_input_string ic (pend.Lexing.pos_cnum - pstart.Lexing.pos_cnum)
+    try
+      seek_in ic (max 0 (pos_char pstart));
+      really_input_string ic (pend.Lexing.pos_cnum - pstart.Lexing.pos_cnum)
+    with Sys_error _ | End_of_file -> "<could not read file>"
   in
   match Lazy.force diff_command with
   | `Stringdiff f -> f ppf (get_str p1) (get_str p2)

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -556,7 +556,7 @@ let summary ~build_dir tests =
       if disp_flags.coverage then
         box.print_line
           "%-13s @{<red;bold>%a@} @{<green;bold>%a@} @{<bold>%10d@} \
-           @{<hi_magenta;bold>%13d %%@}"
+           @{<bold>%a@}"
           "lines covered"
           (fun ppf -> function
             | 0 -> Format.fprintf ppf "@{<green>%10d@}" 0
@@ -565,11 +565,8 @@ let summary ~build_dir tests =
           (fun ppf -> function
             | 0 -> Format.fprintf ppf "@{<red>%10d@}" 0
             | n -> Format.fprintf ppf "%10d" n)
-          total_reached_lines total_reachable_lines
-          (int_of_float
-             (float_of_int total_reached_lines
-             /. float_of_int total_reachable_lines
-             *. 100.)));
+          total_reached_lines total_reachable_lines ratio
+          (total_reached_lines, total_reachable_lines));
   Format.pp_close_box ppf ();
   Format.pp_print_flush ppf ();
   success = total

--- a/build_system/clerk_report.ml
+++ b/build_system/clerk_report.ml
@@ -164,6 +164,8 @@ let colordiff_str s1 s2 =
   in
   pr_left, pr_right
 
+let no_tabs s = Re.(replace_string ~by:"        " (compile (char '\t')) s)
+
 let diff_command =
   lazy begin match disp_flags.diff_command with
   | None ->
@@ -173,7 +175,7 @@ let diff_command =
     let stringdiff ppf s1 s2 =
       let width = Message.terminal_columns () - 5 in
       let mid = (width - 1) / 2 in
-      let cut s = String.cut_at_width s mid in
+      let cut s = String.cut_at_width (no_tabs s) mid in
       let pad s =
         let s = cut s in
         Printf.sprintf "%s%*s" s (mid - String.width s) ""

--- a/compiler/catala_utils/message.ml
+++ b/compiler/catala_utils/message.ml
@@ -661,7 +661,7 @@ let register_content_as_delayed_error
     | None -> true
   in
   if register_error then (
-    let bt = Printexc.get_raw_backtrace () in
+    let bt = Printexc.get_callstack 12 in
     if Global.options.stop_on_error then
       Printexc.raise_with_backtrace (CompilerError m) bt;
     global_errors.rev_delayed_errors <-

--- a/compiler/catala_utils/pos.ml
+++ b/compiler/catala_utils/pos.ml
@@ -282,7 +282,7 @@ let format_loc_text_parts
         let match_num_cols = String.width matched_substring in
         Format.fprintf ppf "@{<blue>%*d │@} %a" nspaces line_no
           (fun ppf -> Format.pp_print_as ppf (String.width line))
-          line;
+          (Re.replace_string ~by:"        " Re.(compile (char '\t')) line);
         Format.pp_print_cut ppf ();
         if line_no >= sline && line_no <= eline then
           Format.fprintf ppf "@{<blue>%*s │@} %*s@{<bold;red>%t@}" nspaces ""

--- a/compiler/desugared/name_resolution.ml
+++ b/compiler/desugared/name_resolution.ml
@@ -581,8 +581,29 @@ let is_type_cond ((typ, _) : Surface.Ast.typ) =
     true
   | _ -> false
 
+let tdef_is_public ctxt ident =
+  match Ident.Map.find_opt ident ctxt.local.typedefs with
+  | Some (TStruct s_uid) -> (
+    match StructName.Map.find_opt s_uid ctxt.structs with
+    | Some (_, Public) -> true
+    | _ -> false)
+  | Some (TEnum e_uid) -> (
+    match EnumName.Map.find_opt e_uid ctxt.enums with
+    | Some (_, Public) -> true
+    | _ -> false)
+  | Some (TAbstract t_uid) -> (
+    match AbstractType.Map.find_opt t_uid ctxt.abstract_types with
+    | Some Public -> true
+    | _ -> false)
+  | Some (TScope (_, scope_str)) -> (
+    match StructName.Map.find_opt scope_str.out_struct_name ctxt.structs with
+    | Some (_, Public) -> true
+    | _ -> false)
+  | None -> false
+
 (** Process a basic type (all types except function types) *)
 let rec process_base_typ
+    ~toplevel
     ~rev_path
     ~vars
     (ctxt : context)
@@ -592,19 +613,19 @@ let rec process_base_typ
   | Surface.Ast.Condition -> TLit TBool, typ_pos
   | Surface.Ast.Data (Surface.Ast.Collection t) ->
     ( TArray
-        (process_base_typ ~rev_path ~vars ctxt
+        (process_base_typ ~toplevel ~rev_path ~vars ctxt
            (Surface.Ast.Data (Mark.remove t), Mark.get t)),
       typ_pos )
   | Surface.Ast.Data (Surface.Ast.Option t) ->
     ( TOption
-        (process_base_typ ~rev_path ~vars ctxt
+        (process_base_typ ~toplevel ~rev_path ~vars ctxt
            (Surface.Ast.Data (Mark.remove t), Mark.get t)),
       typ_pos )
   | Surface.Ast.Data (Surface.Ast.TTuple tl) ->
     ( TTuple
         (List.map
            (fun t ->
-             process_base_typ ~rev_path ~vars ctxt
+             process_base_typ ~toplevel ~rev_path ~vars ctxt
                (Surface.Ast.Data (Mark.remove t), Mark.get t))
            tl),
       typ_pos )
@@ -624,24 +645,67 @@ let rec process_base_typ
         | [], x -> (match rev_path with m :: _ -> [m] | [] -> []), x
         | path, x -> [List.hd (List.rev path)], x
       in
+      let private_error ?(delayed = true) (_, pos) pp_id id =
+        let fmt_pos =
+          [
+            ( (fun ppf ->
+                Format.fprintf ppf
+                  "@[<hov>The type definition is private because it is inside \
+                   a@ @{<yellow;bold>```catala@}@ block@ and@ not@ a@ \
+                   @{<yellow;bold>```catala-metadata@}@ block:@]"),
+              pos );
+          ]
+        in
+        let fmt =
+          format_of_string "Type %a@ is@ private@ and@ cannot@ be@ used@ here."
+        in
+        if delayed then
+          Message.delayed_error () ~kind:Parsing ~pos:typ_pos ~fmt_pos fmt pp_id
+            id
+        else Message.error ~pos:typ_pos ~fmt_pos fmt pp_id id
+      in
       match Ident.Map.find_opt ident ctxt.local.typedefs with
       | Some (TStruct s_uid) ->
+        if not (toplevel || tdef_is_public ctxt ident) then
+          private_error (StructName.get_info s_uid) StructName.format s_uid;
         let s_uid = StructName.map_info fix_path s_uid in
         TStruct s_uid, typ_pos
       | Some (TEnum e_uid) ->
+        if not (toplevel || tdef_is_public ctxt ident) then
+          private_error (EnumName.get_info e_uid) EnumName.format e_uid;
         let e_uid = EnumName.map_info fix_path e_uid in
         TEnum e_uid, typ_pos
       | Some (TAbstract t_uid) ->
+        if not (toplevel || tdef_is_public ctxt ident) then
+          private_error (AbstractType.get_info t_uid) AbstractType.format t_uid;
         let t_uid = AbstractType.map_info fix_path t_uid in
         TAbstract t_uid, typ_pos
-      | Some (TScope (_, scope_str)) ->
-        let s_uid = StructName.map_info fix_path scope_str.out_struct_name in
+      | Some (TScope (_, { out_struct_name = s_uid; _ })) ->
+        if not (toplevel || tdef_is_public ctxt ident) then
+          private_error (StructName.get_info s_uid) StructName.format s_uid;
+        let s_uid = StructName.map_info fix_path s_uid in
         TStruct s_uid, typ_pos
-      | None ->
-        Message.error ~pos:typ_pos
-          "Unknown type @{<yellow>\"%s\"@}, not a struct or enum previously \
-           declared"
-          ident)
+      | None -> (
+        match
+          Ident.Map.find_opt ident ctxt.local.used_modules
+          |> Option.map (fun m -> m, ModuleName.Map.find m ctxt.modules)
+        with
+        | Some (m, mctx) when Ident.Map.mem ident mctx.typedefs ->
+          let pos =
+            match Ident.Map.find ident mctx.typedefs with
+            | TStruct id -> Mark.get (StructName.get_info id)
+            | TEnum id -> Mark.get (EnumName.get_info id)
+            | TAbstract id -> Mark.get (AbstractType.get_info id)
+            | TScope (id, _) -> Mark.get (ScopeName.get_info id)
+          in
+          private_error ~delayed:false ((), pos) ModuleName.format m;
+          assert false
+        | _ ->
+          Message.error ~pos:typ_pos
+            "Unknown type \"@{<cyan>%s@}\":@ no@ declaration@ for@ a@ \
+             structure,@ enumeration,@ scope@ or@ external@ type@ by this name \
+             was@ found."
+            ident))
     | Surface.Ast.Named ((modul, mpos) :: path, id) -> (
       match Ident.Map.find_opt modul ctxt.local.used_modules with
       | None ->
@@ -655,7 +719,7 @@ let rec process_base_typ
           | mname :: _ ->
             ModuleName.map_info (fun (s, _) -> s, mpos) mname :: rev_path
         in
-        process_base_typ ~rev_path ~vars
+        process_base_typ ~toplevel:false ~rev_path ~vars
           { ctxt with local = mod_ctxt }
           Surface.Ast.(Data (Primitive (Named (path, id))), typ_pos))
     | Surface.Ast.Var None ->
@@ -669,7 +733,8 @@ let rec process_base_typ
           "Specifying type `anything` is not allowed at this point"))
 
 let process_base_typ ~vars (ctxt : context) ty =
-  process_base_typ ~rev_path:ctxt.local.current_revpath ~vars ctxt ty
+  let rpath = ctxt.local.current_revpath in
+  process_base_typ ~toplevel:true ~rev_path:rpath ~vars ctxt ty
 
 (** Process a type (function or not) *)
 let process_type (ctxt : context) ((naked_typ, typ_pos) : Surface.Ast.typ) : typ
@@ -804,6 +869,7 @@ let process_data_decl
 (** Process a struct declaration *)
 let process_struct_decl
     ?(visibility = Public)
+    ?scope
     (ctxt : context)
     (sdecl : Surface.Ast.struct_decl) : context =
   let s_uid = get_struct ctxt sdecl.struct_decl_name in
@@ -847,19 +913,25 @@ let process_struct_decl
       in
       let ctxt = { ctxt with local } in
       let structs =
+        let typ =
+          match scope with
+          | None -> process_type ctxt fdecl.Surface.Ast.struct_decl_field_typ
+          | Some s -> (
+            match
+              Ident.Map.find name (ScopeName.Map.find s ctxt.scopes).var_idmap
+            with
+            | ScopeVar v -> (ScopeVar.Map.find v ctxt.var_typs).var_sig_typ
+            | SubScope (v, sub) ->
+              let struc =
+                (ScopeName.Map.find sub ctxt.scopes).scope_out_struct
+              in
+              TStruct struc, Mark.get (ScopeVar.get_info v))
+        in
         StructName.Map.update s_uid
           (function
-            | None ->
-              Some
-                ( StructField.Map.singleton f_uid
-                    (process_type ctxt fdecl.Surface.Ast.struct_decl_field_typ),
-                  visibility )
+            | None -> Some (StructField.Map.singleton f_uid typ, visibility)
             | Some (fields, _) ->
-              Some
-                ( StructField.Map.add f_uid
-                    (process_type ctxt fdecl.Surface.Ast.struct_decl_field_typ)
-                    fields,
-                  visibility ))
+              Some (StructField.Map.add f_uid typ fields, visibility))
           ctxt.structs
       in
       { ctxt with structs })
@@ -1064,7 +1136,7 @@ let process_scope_decl
     }
   else
     let ctxt =
-      process_struct_decl ~visibility ctxt
+      process_struct_decl ~scope:scope_uid ~visibility ctxt
         {
           struct_decl_name = decl.scope_decl_name;
           struct_decl_fields = output_fields;
@@ -1602,8 +1674,9 @@ let form_context (surface, mod_uses) surface_modules : context =
                      Period_en as Period` to expose type `Period_en.Period` as
                      `Period`. *)
                   if
-                    defname = ModuleName.to_string modl
-                    || module_content.Surface.Ast.module_is_stdlib
+                    (defname = ModuleName.to_string modl
+                    || module_content.Surface.Ast.module_is_stdlib)
+                    && tdef_is_public { ctxt with local = mctx } defname
                   then Some tdef
                   else None)
               mod_uses
@@ -1669,8 +1742,9 @@ let form_context (surface, mod_uses) surface_modules : context =
         | Some tdef ->
           let defname, _ = typedef_info tdef in
           if
-            defname = ModuleName.to_string modl
-            || module_content.Surface.Ast.module_is_stdlib
+            (defname = ModuleName.to_string modl
+            || module_content.Surface.Ast.module_is_stdlib)
+            && tdef_is_public { ctxt with local = mctx } defname
           then Some tdef
           else None (* some *))
       mod_uses

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -743,7 +743,10 @@ module Commands = struct
        end
        else
          match results, options.Global.output_format with
-         | [], Human -> Message.result "Computation successful!"
+         | [], Human ->
+           Message.results
+             ~title:(ScopeName.to_string scope_uid)
+             [(fun ppf -> Format.pp_print_string ppf "Computation successful!")]
          | _ :: _, Human ->
            Message.results
              ~title:(ScopeName.to_string scope_uid)

--- a/compiler/web/catala_web_interpreter.ml
+++ b/compiler/web/catala_web_interpreter.ml
@@ -294,7 +294,7 @@ let () =
                Message.pp_to_string ~ansi (fun ppf ->
                    match results with
                    | [] ->
-                     Message.results ~ppf
+                     Message.results ~ppf ~title:scope
                        [
                          (fun ppf ->
                            Format.fprintf ppf "Computation successful!");

--- a/tests/enum/bad/not_ending_wildcard.catala_en
+++ b/tests/enum/bad/not_ending_wildcard.catala_en
@@ -72,7 +72,7 @@ $ catala test-scope First_case
 │ Next reachable case:
 ├─➤ tests/enum/bad/not_ending_wildcard.catala_en:36.2-15:
 │    │
-│ 36 │ 	-- Case1 : 42
+│ 36 │         -- Case1 : 42
 │    │         ‾‾‾‾‾‾‾‾‾‾‾‾‾
 └─ Wildcard must be the last case
    └─ Wildcard can't be the a middle case
@@ -115,7 +115,7 @@ $ catala test-scope Middle_case
 │ Next reachable case:
 ├─➤ tests/enum/bad/not_ending_wildcard.catala_en:36.2-15:
 │    │
-│ 36 │ 	-- Case1 : 42
+│ 36 │         -- Case1 : 42
 │    │         ‾‾‾‾‾‾‾‾‾‾‾‾‾
 └─ Wildcard must be the last case
    └─ Wildcard can't be the a middle case

--- a/tests/exception/good/context_with_default.catala_en
+++ b/tests/exception/good/context_with_default.catala_en
@@ -29,7 +29,7 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-cli
 $ catala test-scope Bar
-┌─[RESULT]─
+┌─[RESULT]─ Bar ─
 │ Computation successful!
 └─
 ```

--- a/tests/io/good/condition_only_input.catala_en
+++ b/tests/io/good/condition_only_input.catala_en
@@ -42,7 +42,7 @@ let scope B (B_in: B_in): B =
 
 ```catala-test-cli
 $ catala test-scope B
-┌─[RESULT]─
+┌─[RESULT]─ B ─
 │ Computation successful!
 └─
 ```

--- a/tests/modules/bad/mod_def.catala_en
+++ b/tests/modules/bad/mod_def.catala_en
@@ -1,10 +1,18 @@
 > Module Mod_def
 
+```catala-metadata
+declaration structure Public:
+  data z content integer
+```
 
 ```catala
+declaration structure Mod_def:
+  data foo content Public
+
 declaration enumeration E:
   -- C content integer
 
 declaration scope S:
+  internal i content Mod_def
   context output x content integer
 ```

--- a/tests/modules/bad/mod_def.catala_en
+++ b/tests/modules/bad/mod_def.catala_en
@@ -1,0 +1,10 @@
+> Module Mod_def
+
+
+```catala
+declaration enumeration E:
+  -- C content integer
+
+declaration scope S:
+  context output x content integer
+```

--- a/tests/modules/bad/mod_use.catala_en
+++ b/tests/modules/bad/mod_use.catala_en
@@ -1,0 +1,17 @@
+> Using Mod_def
+
+
+```catala
+declaration scope Test:
+  context output x content Mod_def.E
+
+scope Test:
+  definition x equals Mod_def.E.C content 1
+```
+
+
+```catala-test-cli
+$ catala interpret --scope Test
+> This should fail, since the enumeration is not <
+>         properly exposed in Mod_def.           <
+```

--- a/tests/modules/bad/mod_use.catala_en
+++ b/tests/modules/bad/mod_use.catala_en
@@ -3,15 +3,32 @@
 
 ```catala
 declaration scope Test:
-  context output x content Mod_def.E
+  output v content Mod_def.Public
+  output x content Mod_def.E
 
 scope Test:
+  definition v equals Mod_def.Public { --z: 3 }
   definition x equals Mod_def.E.C content 1
 ```
 
 
 ```catala-test-cli
-$ catala interpret --scope Test
-> This should fail, since the enumeration is not <
->         properly exposed in Mod_def.           <
+$ catala test-scope Test
+┌─[ERROR]─
+│
+│  Type Mod_def.E is private and cannot be used here.
+│
+├─➤ tests/modules/bad/mod_use.catala_en:7.20-29:
+│   │
+│ 7 │   output x content Mod_def.E
+│   │                    ‾‾‾‾‾‾‾‾‾
+│
+│ The type definition is private because it is inside a ```catala block and
+│ not a ```catala-metadata block:
+├─➤ tests/modules/bad/mod_def.catala_en:12.25-26:
+│    │
+│ 12 │ declaration enumeration E:
+│    │                         ‾
+└─
+#return code 123#
 ```

--- a/tests/modules/bad/mod_use2.catala_en
+++ b/tests/modules/bad/mod_use2.catala_en
@@ -1,0 +1,43 @@
+> Using Mod_def
+
+
+```catala
+declaration scope Test:
+  output v content Mod_def.Public
+  output w content Mod_def
+
+scope Test:
+  definition v equals Mod_def.Public { --z: 3 }
+  definition w equals Mod_def { --foo: v }
+```
+
+
+```catala-test-cli
+$ catala test-scope Test
+┌─[ERROR]─ 1/2 ─
+│
+│  Type Mod_def is private and cannot be used here.
+│
+├─➤ tests/modules/bad/mod_use2.catala_en:7.20-27:
+│   │
+│ 7 │   output w content Mod_def
+│   │                    ‾‾‾‾‾‾‾
+│
+│ The type definition is private because it is inside a ```catala block and
+│ not a ```catala-metadata block:
+├─➤ tests/modules/bad/mod_def.catala_en:9.23-30:
+│   │
+│ 9 │ declaration structure Mod_def:
+│   │                       ‾‾‾‾‾‾‾
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  "v": unknown identifier for a variable of scope Test
+│
+├─➤ tests/modules/bad/mod_use2.catala_en:10.14-15:
+│    │
+│ 10 │   definition v equals Mod_def.Public { --z: 3 }
+│    │              ‾
+└─
+#return code 123#
+```

--- a/tests/scope/good/subscope_function_arg_not_defined2.catala_en
+++ b/tests/scope/good/subscope_function_arg_not_defined2.catala_en
@@ -33,7 +33,7 @@ $ catala Typecheck --check-invariants
 
 ```catala-test-cli
 $ catala test-scope Caller
-┌─[RESULT]─
+┌─[RESULT]─ Caller ─
 │ Computation successful!
 └─
 ```


### PR DESCRIPTION
Name resolution didn't check it, so before this patch, it would give ugly error messages in the backends.

This also includes nice hints detecting that the type exists but isn't exposed, and suggesting to use catala-metadata blocks.

Also includes some more cosmetic changes, see the patches.