### PR TITLE
Clerk: strip trailing CR from scope-test output (fix 0 tests on native Windows)

### DIFF
--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -46,7 +46,7 @@ let out_line output_buf str =
 (* Strips trailing line endings. Notably, on Windows catala's stdout is in text
    mode, so lines we parse below arrive with "\r\n"; [input_line] only drops the
    "\n", leaving a '\r' that would defeat the [whole_string] matches. *)
-let re_endline = Re.(compile @@ seq [rep (set "\r\n")])
+let re_endline = Re.(compile @@ rep (set "\r\n"))
 
 let sanitize =
   let re_endtest = Re.(compile @@ seq [bol; str "```"]) in

--- a/build_system/clerk_runtest.ml
+++ b/build_system/clerk_runtest.ml
@@ -43,6 +43,11 @@ let out_line output_buf str =
       pos_bol = pos_cnum;
     }
 
+(* Strips trailing line endings. Notably, on Windows catala's stdout is in text
+   mode, so lines we parse below arrive with "\r\n"; [input_line] only drops the
+   "\n", leaving a '\r' that would defeat the [whole_string] matches. *)
+let re_endline = Re.(compile @@ seq [rep (set "\r\n")])
+
 let sanitize =
   let re_endtest = Re.(compile @@ seq [bol; str "```"]) in
   let re_modhash =
@@ -59,7 +64,6 @@ let sanitize =
              char '"';
            ])
   in
-  let re_endline = Re.(compile @@ seq [rep (set "\r\n")]) in
   let re_backslash = Re.(compile (repn (char '\\') 1 (Some 2))) in
   fun str ->
     str
@@ -208,7 +212,10 @@ let run_catala_test_scopes
   in
   Unix.close cmd_out_wr;
   let out_lines =
-    Seq.of_dispenser (fun () -> In_channel.input_line command_ic)
+    Seq.of_dispenser (fun () ->
+        Option.map
+          (Re.replace_string re_endline ~by:"")
+          (In_channel.input_line command_ic))
   in
   let parse_error line =
     let re_error =


### PR DESCRIPTION
On native Windows, `clerk test` reports **0/0/0** ("ALL TESTS PASSED", zero counted) for any project whose tests are `#[test]` *scopes* — even though the tests run fine. 

**Cause.** `clerk runtest` parses `catala interpret --quiet`'s `"<scope>: passed"` lines (`compiler/driver.ml`, commented "parsed by Clerk"). On a native Windows build catala's stdout is in text mode, so those lines arrive as `…passed\r\n`. `run_catala_test_scopes` reads them with `In_channel.input_line`, which strips the `\n` but keeps the `\r`, and the result is matched under `whole_string` — so `passed\r` never matches and every scope result is dropped. CLI (`catala-test-cli`) tests were unaffected because they already go through `sanitize` (which strips `\r\n`); the scope-test path did not.

**Fix.** Hoist the existing `re_endline` out of `sanitize` to module scope and strip trailing line endings from each scope-test output line in `run_catala_test_scopes`.
