### PR TITLE
Fix too large generated java code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,9 @@ in behavior visible for the end-users of the tooling.
   the `--trace` mechanism:
   - Added support in the `Java` backend;
   - Added `clerk run --trace ...` options.
+
+* [#1075](https://github.com/CatalaLang/catala/pull/1075) Fixes a bug
+  where, for large Catala programs, the java generated code is too
+  large and would yield "code too large" error. We now split large
+  methods into smaller methods whenever necessary.
+  Also, removed law headings from positions in Java (same as C).

--- a/compiler/catala_utils/cli.ml
+++ b/compiler/catala_utils/cli.ml
@@ -648,6 +648,26 @@ module Flags = struct
            also $(b,json-schema) command to generate the accepted JSON's \
            schema for a given scope."
 
+  let split_threshold =
+    let converter =
+      conv
+        ( (fun s ->
+            Arg.conv_parser int s
+            |> function
+            | Ok i ->
+              if i < 100 then Error (`Msg "value must be at least 100")
+              else Ok i
+            | e -> e),
+          Format.pp_print_int )
+    in
+    value
+    & opt (some converter) None
+    & info ["split-threshold"] ~docv:"NUM"
+        ~doc:
+          "Maximum allowed size of a Catala expression before splitting into \
+           multiple chunks. Only relevant for non-OCaml backends. Java is set \
+           to 10,000 by default."
+
   let output_format = Global.output_format
   let trace = Global.trace
   let trace_format = Global.trace_format

--- a/compiler/catala_utils/cli.mli
+++ b/compiler/catala_utils/cli.mli
@@ -67,6 +67,7 @@ module Flags : sig
   val include_dirs : raw_file list Term.t
   val stdlib_dir : raw_file option Term.t
   val disable_counterexamples : bool Term.t
+  val split_threshold : int option Term.t
 
   val extra_files : file list Term.t
   (** for the 'latex' command *)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -237,6 +237,7 @@ module Passes = struct
       ~keep_module_names
       ~monomorphize_types
       ~split_threshold
+      ~split_scope_var_defs
       ~renaming
       ~lift_pos : Scalc.Ast.program * TypeIdent.t list * Renaming.context =
     let prg, type_ordering, renaming_context =
@@ -258,6 +259,7 @@ module Passes = struct
             no_struct_literals;
             keep_module_names;
             renaming_context;
+            split_scope_var_defs;
           }
         prg,
       type_ordering,
@@ -1066,7 +1068,8 @@ module Commands = struct
       Passes.scalc options ~includes ~stdlib ~optimize ~check_invariants
         ~autotest ~closure_conversion ~keep_special_ops ~dead_value_assignment
         ~no_struct_literals ~keep_module_names:false ~monomorphize_types
-        ~split_threshold ~renaming:(Some Renaming.default)
+        ~split_threshold ~split_scope_var_defs:false
+        ~renaming:(Some Renaming.default)
         ~lift_pos:(Some Lcalc.To_ocaml.op_needs_pos)
     in
     get_output_format options output
@@ -1126,6 +1129,7 @@ module Commands = struct
         ~keep_module_names:false ~monomorphize_types:false
         ~renaming:(Some Scalc.To_python.renaming)
         ~lift_pos:(Some Scalc.To_python.op_needs_pos) ~split_threshold
+        ~split_scope_var_defs:false
     in
     Message.debug "Compiling program into Python...";
     get_output_format options output
@@ -1178,6 +1182,7 @@ module Commands = struct
         ~keep_module_names:true ~monomorphize_types:false
         ~renaming:(Some Scalc.To_java.renaming)
         ~lift_pos:(Some Scalc.To_java.op_needs_pos) ~split_threshold
+        ~split_scope_var_defs:true
     in
     Message.debug "Compiling program into Java...";
     get_output_format options output
@@ -1229,6 +1234,7 @@ module Commands = struct
         ~keep_module_names:false ~monomorphize_types:false
         ~renaming:(Some Scalc.To_c.renaming)
         ~lift_pos:(Some Scalc.To_c.op_needs_pos) ~split_threshold
+        ~split_scope_var_defs:false
     in
     Message.debug "Compiling program into C...";
     get_output_format options output

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -141,6 +141,7 @@ module Passes = struct
       ~closure_conversion
       ~keep_special_ops
       ~monomorphize_types
+      ~split_threshold
       ~renaming
       ~lift_pos :
       typed Lcalc.Ast.program * TypeIdent.t list * Renaming.context option =
@@ -199,6 +200,13 @@ module Passes = struct
         Message.debug "Lifting inline code locations...";
         Lcalc.Lift_positions.process_program ~op_needs_pos prg
     in
+    let prg =
+      match split_threshold with
+      | None -> prg
+      | Some threshold ->
+        Message.debug "Splitting expressions larger than %d nodes..." threshold;
+        Lcalc.Split.split_program ~threshold prg
+    in
     match renaming with
     | None -> prg, type_ordering, None
     | Some renaming ->
@@ -228,12 +236,13 @@ module Passes = struct
       ~no_struct_literals
       ~keep_module_names
       ~monomorphize_types
+      ~split_threshold
       ~renaming
       ~lift_pos : Scalc.Ast.program * TypeIdent.t list * Renaming.context =
     let prg, type_ordering, renaming_context =
       lcalc options ~includes ~stdlib ~optimize ~check_invariants ~autotest
         ~typed:Expr.typed ~closure_conversion ~keep_special_ops
-        ~monomorphize_types ~renaming ~lift_pos
+        ~monomorphize_types ~split_threshold ~renaming ~lift_pos
     in
     let renaming_context =
       match renaming_context with
@@ -850,6 +859,7 @@ module Commands = struct
       closure_conversion
       keep_special_ops
       monomorphize_types
+      split_threshold
       ex_scopes =
     let options =
       if closure_conversion then disable_trace options else options
@@ -857,7 +867,8 @@ module Commands = struct
     let prg, _, _ =
       Passes.lcalc options ~includes ~stdlib ~optimize ~check_invariants
         ~autotest ~closure_conversion ~keep_special_ops ~typed
-        ~monomorphize_types ~renaming:(Some Renaming.default) ~lift_pos:None
+        ~monomorphize_types ~split_threshold ~renaming:(Some Renaming.default)
+        ~lift_pos:None
     in
     get_output_format options output
     @@ fun _ fmt ->
@@ -897,6 +908,7 @@ module Commands = struct
         $ Cli.Flags.closure_conversion
         $ Cli.Flags.keep_special_ops
         $ Cli.Flags.monomorphize_types
+        $ Cli.Flags.split_threshold
         $ Cli.Flags.ex_scopes)
 
   let interpret_lcalc
@@ -918,7 +930,8 @@ module Commands = struct
     let prg, _, _ =
       Passes.lcalc options ~includes ~stdlib ~optimize ~check_invariants
         ~autotest:false ~closure_conversion ~keep_special_ops
-        ~monomorphize_types ~typed ~renaming:None ~lift_pos:None
+        ~monomorphize_types ~split_threshold:None ~typed ~renaming:None
+        ~lift_pos:None
     in
     Interpreter.load_runtime_modules
       ~hashf:(Hash.finalise ~monomorphize_types)
@@ -1005,7 +1018,8 @@ module Commands = struct
     let prg, type_ordering, _ =
       Passes.lcalc options ~includes ~stdlib ~optimize ~check_invariants
         ~autotest ~typed:Expr.typed ~closure_conversion ~keep_special_ops:true
-        ~monomorphize_types:false ~renaming:(Some Lcalc.To_ocaml.renaming)
+        ~monomorphize_types:false ~split_threshold:None
+        ~renaming:(Some Lcalc.To_ocaml.renaming)
         ~lift_pos:(Some Lcalc.To_ocaml.op_needs_pos)
     in
     Message.debug "Compiling program into OCaml...";
@@ -1043,6 +1057,7 @@ module Commands = struct
       dead_value_assignment
       no_struct_literals
       monomorphize_types
+      split_threshold
       ex_scope_opt =
     let options =
       if closure_conversion then disable_trace options else options
@@ -1051,7 +1066,7 @@ module Commands = struct
       Passes.scalc options ~includes ~stdlib ~optimize ~check_invariants
         ~autotest ~closure_conversion ~keep_special_ops ~dead_value_assignment
         ~no_struct_literals ~keep_module_names:false ~monomorphize_types
-        ~renaming:(Some Renaming.default)
+        ~split_threshold ~renaming:(Some Renaming.default)
         ~lift_pos:(Some Lcalc.To_ocaml.op_needs_pos)
     in
     get_output_format options output
@@ -1090,6 +1105,7 @@ module Commands = struct
         $ Cli.Flags.dead_value_assignment
         $ Cli.Flags.no_struct_literals
         $ Cli.Flags.monomorphize_types
+        $ Cli.Flags.split_threshold
         $ Cli.Flags.ex_scope_opt)
 
   let python
@@ -1100,7 +1116,8 @@ module Commands = struct
       optimize
       check_invariants
       autotest
-      closure_conversion =
+      closure_conversion
+      split_threshold =
     let options = disable_trace options in
     let prg, type_ordering, _ren_ctx =
       Passes.scalc options ~includes ~stdlib ~optimize ~check_invariants
@@ -1108,7 +1125,7 @@ module Commands = struct
         ~dead_value_assignment:true ~no_struct_literals:false
         ~keep_module_names:false ~monomorphize_types:false
         ~renaming:(Some Scalc.To_python.renaming)
-        ~lift_pos:(Some Scalc.To_python.op_needs_pos)
+        ~lift_pos:(Some Scalc.To_python.op_needs_pos) ~split_threshold
     in
     Message.debug "Compiling program into Python...";
     get_output_format options output
@@ -1129,24 +1146,30 @@ module Commands = struct
         $ Cli.Flags.optimize
         $ Cli.Flags.check_invariants
         $ Cli.Flags.autotest
-        $ Cli.Flags.closure_conversion)
+        $ Cli.Flags.closure_conversion
+        $ Cli.Flags.split_threshold)
 
   let java
       options
       includes
       stdlib
       (output : Global.raw_file option)
-      _optimize
+      optimize
       check_invariants
       autotest
-      closure_conversion =
+      closure_conversion
+      split_threshold =
     let options =
       if closure_conversion then disable_trace options else options
     in
-    let optimize =
-      (* javac has a limit on bytecode statement per method, without
-         optimizations we easily reach it. We mitigate by enforcing them. *)
-      true
+    let split_threshold : int option =
+      (* [javac] has a limit on the number of bytecode statements per
+         method: by default, we set a split threshold limit of
+         10_000. This value was determined empirically as there is no
+         direct relation between lcalc AST size and the generated java
+         bytecode size. Hence, this value may be too big or too large
+         depending on the program shape. *)
+      Option.(some (value split_threshold ~default:10_000))
     in
     let prg, _type_ordering, _ren_ctx =
       Passes.scalc options ~includes ~stdlib ~optimize ~check_invariants
@@ -1154,7 +1177,7 @@ module Commands = struct
         ~dead_value_assignment:true ~no_struct_literals:false
         ~keep_module_names:true ~monomorphize_types:false
         ~renaming:(Some Scalc.To_java.renaming)
-        ~lift_pos:(Some Scalc.To_java.op_needs_pos)
+        ~lift_pos:(Some Scalc.To_java.op_needs_pos) ~split_threshold
     in
     Message.debug "Compiling program into Java...";
     get_output_format options output
@@ -1186,9 +1209,18 @@ module Commands = struct
         $ Cli.Flags.optimize
         $ Cli.Flags.check_invariants
         $ Cli.Flags.autotest
-        $ Cli.Flags.closure_conversion)
+        $ Cli.Flags.closure_conversion
+        $ Cli.Flags.split_threshold)
 
-  let c options includes stdlib output optimize check_invariants autotest =
+  let c
+      options
+      includes
+      stdlib
+      output
+      optimize
+      check_invariants
+      autotest
+      split_threshold =
     let options = disable_trace options in
     let prg, type_ordering, _ren_ctx =
       Passes.scalc options ~includes ~stdlib ~optimize ~check_invariants
@@ -1196,7 +1228,7 @@ module Commands = struct
         ~dead_value_assignment:false ~no_struct_literals:true
         ~keep_module_names:false ~monomorphize_types:false
         ~renaming:(Some Scalc.To_c.renaming)
-        ~lift_pos:(Some Scalc.To_c.op_needs_pos)
+        ~lift_pos:(Some Scalc.To_c.op_needs_pos) ~split_threshold
     in
     Message.debug "Compiling program into C...";
     get_output_format options output
@@ -1216,7 +1248,8 @@ module Commands = struct
         $ Cli.Flags.output
         $ Cli.Flags.optimize
         $ Cli.Flags.check_invariants
-        $ Cli.Flags.autotest)
+        $ Cli.Flags.autotest
+        $ Cli.Flags.split_threshold)
 
   let depends options includes stdlib prefix subdir extension extra_files =
     let file = Global.input_src_file options.Global.input_src in

--- a/compiler/driver.mli
+++ b/compiler/driver.mli
@@ -84,6 +84,7 @@ module Passes : sig
     keep_module_names:bool ->
     monomorphize_types:bool ->
     split_threshold:int option ->
+    split_scope_var_defs:bool ->
     renaming:Shared_ast.Renaming.t option ->
     lift_pos:
       (Shared_ast.lcalc Shared_ast.Op.t -> Shared_ast.naked_typ -> bool) option ->

--- a/compiler/driver.mli
+++ b/compiler/driver.mli
@@ -62,6 +62,7 @@ module Passes : sig
     closure_conversion:bool ->
     keep_special_ops:bool ->
     monomorphize_types:bool ->
+    split_threshold:int option ->
     renaming:Shared_ast.Renaming.t option ->
     lift_pos:
       (Shared_ast.lcalc Shared_ast.Op.t -> Shared_ast.naked_typ -> bool) option ->
@@ -82,6 +83,7 @@ module Passes : sig
     no_struct_literals:bool ->
     keep_module_names:bool ->
     monomorphize_types:bool ->
+    split_threshold:int option ->
     renaming:Shared_ast.Renaming.t option ->
     lift_pos:
       (Shared_ast.lcalc Shared_ast.Op.t -> Shared_ast.naked_typ -> bool) option ->

--- a/compiler/index.mld
+++ b/compiler/index.mld
@@ -70,6 +70,7 @@ lcalc/                       |   Compile the default terms
                              |   (optional) closure conversion
                              |   (optional) monomorphisation
                              |   Reification of positions
+                             |   (optional) large expression splitting
                              |   Collision-free renaming
                              v
 scalc/                       |   Turn expressions into statements

--- a/compiler/lcalc/split.ml
+++ b/compiler/lcalc/split.ml
@@ -1,0 +1,633 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2026 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Catala_utils
+open Shared_ast
+
+type size_mark = (int * typed mark) custom
+
+type 'a split_ctx = {
+  split_threshold : int;
+  decl_ctx : decl_ctx;
+  topdefs : (lcalc, size_mark) Shared_ast__Definitions.gexpr Var.Set.t;
+}
+
+(** Bottom-up fold mapping typed marks to size marks, i.e., each node's mark
+    will contain its sub-term (approximated) size. *)
+let add_size (type a) : (a, typed) gexpr -> (a, size_mark) boxed_gexpr =
+ fun e ->
+  let location_size = 6 in
+  let op_size : a operator -> int = function
+    (* Traces in backends outputs a [begin] corresponding to the tag
+       and its location and an [end] node with its value. *)
+    | Tag (ScopeCall _) -> 3 + location_size + 2
+    | Tag (FunCall _) -> 3 + location_size + 2
+    | Tag (ScopeVarDef _) -> 2 + 2 + 2 + location_size + 2
+    | Tag (LocalVarDef _) -> 3 + location_size + 2
+    | Tag (LocalTupDef { names }) -> 2 + List.length names + location_size + 2
+    | Tag BranchingCondition -> 2 + location_size + 2
+    | Tag (Branching None) -> 2 + location_size + 2
+    | Tag (Branching (Some _)) -> 3 + location_size + 2
+    | Tag Assertion -> 2 + location_size + 2
+    | Tag (Exception { label = None; _ }) -> 3 + location_size + 2
+    | Tag (Exception { label = Some _; _ }) -> 4 + location_size + 2
+    | DebugPrint _ | Sort _ | Add_dat_dur _ | Sub_dat_dur _ -> 2
+    | _ -> 1
+  in
+  let rec add_size (e : (a, typed) gexpr) : int * (a, size_mark) boxed_gexpr =
+    let (Typed { pos; ty = _ } as m) = Mark.get e in
+    let mk_mark n : size_mark mark = Custom { pos; custom = n, m } in
+    match Mark.remove e with
+    | EVar _ | EExternal _ | ELit _ | EEmpty | ECustom _ | EBad | EFatalError _
+      ->
+      let new_m = mk_mark 1 in
+      1, Expr.map_marks ~f:(fun _ -> new_m) e
+    | ELocation _ | EPos _ ->
+      let new_m = mk_mark location_size in
+      location_size, Expr.map_marks ~f:(fun _ -> new_m) e
+    | EFatalError_pos { error; pos_expr } ->
+      let size_pos_expr, pos_expr = add_size pos_expr in
+      let size = 2 + size_pos_expr in
+      size, Expr.efatalerror_pos ~error ~pos_expr (mk_mark size)
+    | ETuple args ->
+      let size_args, args = List.map add_size args |> List.split in
+      let size = List.fold_left ( + ) 1 size_args in
+      let e' = Expr.etuple args (mk_mark size) in
+      size, e'
+    | EArray args ->
+      let size_args, args = List.map add_size args |> List.split in
+      let size = List.fold_left ( + ) 1 size_args in
+      size, Expr.earray args (mk_mark size)
+    | ETupleAccess { e; index; size = size_acs } ->
+      let size_e, e = add_size e in
+      let size = size_e + 1 in
+      size, Expr.etupleaccess ~e ~index ~size:size_acs (mk_mark size)
+    | EInj { e = sube; name; cons } ->
+      let size_e, e = add_size sube in
+      let size = size_e + 1 in
+      size, Expr.einj ~e ~name ~cons (mk_mark size)
+    | EAssert sube ->
+      let size_e, sube = add_size sube in
+      let size = size_e + 1 in
+      size, Expr.eassert sube (mk_mark size)
+    | EErrorOnEmpty sube ->
+      let size_e, sube = add_size sube in
+      let size = size_e + 1 in
+      size, Expr.eerroronempty sube (mk_mark size)
+    | EPureDefault sube ->
+      let size_e, sube = add_size sube in
+      let size = size_e + 1 in
+      size, Expr.epuredefault sube (mk_mark size)
+    | EApp { f; args; tys } ->
+      let size_args, args = List.map add_size args |> List.split in
+      let size_f, f = add_size f in
+      let size = List.fold_left ( + ) 1 size_args + size_f + 1 in
+      size, Expr.eapp ~f ~args ~tys (mk_mark size)
+    | EAppOp { args; op; tys } ->
+      let size_args, args = List.map add_size args |> List.split in
+      let size_op = op_size (Mark.remove op) in
+      let size = List.fold_left ( + ) (1 + size_op) size_args in
+      size, Expr.eappop ~args ~op ~tys (mk_mark size)
+    | EAbs { binder; pos; tys } ->
+      let vars, body = Bindlib.unmbind binder in
+      let size_body, body = add_size body in
+      let vars = Array.map Var.translate vars in
+      let binder = Expr.bind vars body in
+      let size = Array.length vars + 1 + size_body in
+      size, Expr.eabs binder pos tys (mk_mark size)
+    | EIfThenElse { cond; etrue; efalse } ->
+      let size_cond, cond = add_size cond in
+      let size_etrue, etrue = add_size etrue in
+      let size_efalse, efalse = add_size efalse in
+      let size = 1 + size_cond + size_etrue + size_efalse in
+      size, Expr.eifthenelse cond etrue efalse (mk_mark size)
+    | EDefault { excepts; just; cons } ->
+      let size_excepts, excepts =
+        List.map add_size excepts
+        |> List.split
+        |> fun (a, b) -> List.fold_left ( + ) 0 a, b
+      in
+      let size_just, just = add_size just in
+      let size_cons, cons = add_size cons in
+      let size = size_excepts + size_just + size_cons + 1 in
+      size, Expr.edefault ~excepts ~just ~cons (mk_mark size)
+    | EStruct { name; fields } ->
+      let size_fields, fields =
+        let size = ref 0 in
+        let r =
+          StructField.Map.map
+            (fun e ->
+              let size_e, e = add_size e in
+              size := !size + 1 + size_e;
+              e)
+            fields
+        in
+        !size, r
+      in
+      let size = 1 + size_fields in
+      size, Expr.estruct ~name ~fields (mk_mark size)
+    | EDStructAmend { e; fields; name_opt } ->
+      let size_fields, fields =
+        let size = ref 0 in
+        let r =
+          MarkedIdent.Map.map
+            (fun e ->
+              let size_e, e = add_size e in
+              size := !size + 1 + size_e;
+              e)
+            fields
+        in
+        !size, r
+      in
+      let size_e, e = add_size e in
+      let size = 1 + size_e + size_fields in
+      size, Expr.edstructamend ~e ~fields ~name_opt (mk_mark size)
+    | EDStructAccess { e; name_opt; field } ->
+      let size_e, e = add_size e in
+      let size = 1 + size_e in
+      size, Expr.edstructaccess ~e ~name_opt ~field (mk_mark size)
+    | EStructAccess { e; name; field } ->
+      let size_e, e = add_size e in
+      let size = 1 + size_e in
+      size, Expr.estructaccess ~e ~name ~field (mk_mark size)
+    | EMatch { e; cases; name } ->
+      let size_cases, cases =
+        let size = ref 0 in
+        let r =
+          EnumConstructor.Map.map
+            (fun e ->
+              let size_e, e = add_size e in
+              size := !size + 1 + size_e;
+              e)
+            cases
+        in
+        !size, r
+      in
+      let size_e, e = add_size e in
+      let size = size_cases + size_e in
+      size, Expr.ematch ~e ~cases ~name (mk_mark size)
+    | EScopeCall { args; scope } ->
+      let size_args, args =
+        let size = ref 0 in
+        let r =
+          ScopeVar.Map.map
+            (fun (x, e) ->
+              let size_e, e = add_size e in
+              size := !size + 1 + size_e;
+              x, e)
+            args
+        in
+        !size, r
+      in
+      let size = 1 + size_args in
+      size, Expr.escopecall ~scope ~args (mk_mark size)
+  in
+  snd (add_size e)
+
+let remove_size e =
+  Expr.map_marks
+    ~f:(function Custom { custom = _size, ty_m; pos = _ } -> ty_m)
+    e
+
+let get_size (e : (_, size_mark mark) Mark.ed) =
+  let (Custom { custom = size, _m; _ }) = Mark.get e in
+  size
+
+let size_mark_ty
+    (Custom { custom = _size, Typed { ty; _ }; _ } : size_mark mark) =
+  ty
+
+let update_size_mark_ty (Custom { custom = size, Typed m; pos }) ty =
+  Custom { custom = size, Typed { m with ty }; pos }
+
+let update_mark_size
+    new_size
+    (Custom { custom = _size, m; pos } : size_mark mark) : size_mark mark =
+  Custom { custom = new_size, m; pos }
+
+(** Convert the given expression into a topdef parametrized by its free
+    variables and a call to this function with the appropriate arguments. *)
+let split_expression (ctx : 'a split_ctx) (e : (_, size_mark) gexpr) =
+  let fv : (lcalc, size_mark) gexpr Var.t = Var.make "compute_chunk" in
+  let free_vars =
+    Expr.free_vars_marked e
+    |> Var.Map.filter (fun v _m ->
+        not (Var.Set.mem (Var.translate v) ctx.topdefs))
+    |> Var.Map.bindings
+  in
+  let fname = TopdefName.fresh [] (Bindlib.name_of fv, Pos.void) in
+  let orig_mark = Mark.get e in
+  let (free_vars_e : _ boxed_gexpr list), free_vars_typs =
+    List.map (fun (v, m) -> Expr.evar v m, size_mark_ty m) free_vars
+    |> List.split
+  in
+  let f = Expr.evar fv (update_mark_size 1 orig_mark) in
+  let ret_ty = Type.arrow_return (size_mark_ty orig_mark) in
+  let free_vars_v = Array.of_list (List.map fst free_vars) in
+  let topdef_ty = TArrow (free_vars_typs, ret_ty), Pos.void in
+  let topdef_mark =
+    update_size_mark_ty orig_mark topdef_ty
+    |> update_mark_size (1 + List.length free_vars_e + get_size e)
+  in
+  let binder = Expr.bind free_vars_v (Expr.rebox e) in
+  let call_mark = update_mark_size (2 + List.length free_vars) orig_mark in
+  let ecall = Expr.eapp ~f ~args:free_vars_e ~tys:free_vars_typs call_mark in
+  let topdef_abs =
+    Expr.eabs binder (List.map Expr.pos free_vars) free_vars_typs topdef_mark
+  in
+  let topdef_e =
+    fname, topdef_ty, Private, remove_size (Expr.unbox topdef_abs)
+  in
+  let decl_ctx =
+    {
+      ctx.decl_ctx with
+      ctx_topdefs =
+        TopdefName.Map.add fname (topdef_ty, Private) ctx.decl_ctx.ctx_topdefs;
+    }
+  in
+  let fv = Var.translate fv in
+  let ctx : 'a split_ctx =
+    { ctx with decl_ctx; topdefs = Var.Set.add fv ctx.topdefs }
+  in
+  (fv, topdef_e, ctx), ecall
+
+(** Partition the given array in two: the result is an array concatenation with
+    the left argument being a call to a topdef building a sub-array with
+    elements that fits in the [split_threshold] argument. The right argument is
+    the remaining array left unchanged. This function also returns the generated
+    topdef. *)
+let split_array (ctx : 'a split_ctx) (e : (_, size_mark) gexpr) =
+  let rec split_until_full (curr_size, acc) = function
+    | [] -> assert false
+    | h :: t ->
+      let new_size = curr_size + get_size h in
+      if new_size > ctx.split_threshold then (List.rev acc, h :: t), curr_size
+      else split_until_full (new_size, h :: acc) t
+  in
+  let orig_mark = Mark.get e in
+  let elts =
+    match Mark.remove e with EArray elts -> elts | _ -> assert false
+  in
+  let (l, r), left_size = split_until_full (0, []) elts in
+  let fv = Var.make "compute_subarray" in
+  let free_l_vars =
+    List.fold_left
+      (fun m e ->
+        Var.Map.union (fun _ l _ -> Some l) m (Expr.free_vars_marked e))
+      Var.Map.empty l
+    |> Var.Map.filter (fun v _ ->
+        (* Assumes topdefs are reachable *)
+        not (Var.Set.mem (Var.translate v) ctx.topdefs))
+    |> Var.Map.bindings
+  in
+  let fname = TopdefName.fresh [] (Bindlib.name_of fv, Pos.void) in
+  let l_mark = update_mark_size (1 + left_size) orig_mark in
+  let right_size = get_size e - left_size - 1 in
+  let r_mark = update_mark_size (1 + right_size) orig_mark in
+  let call_mark = update_mark_size (1 + List.length free_l_vars) orig_mark in
+  let free_vars_e, free_vars_typs =
+    List.map (fun (v, m) -> Expr.evar v m, size_mark_ty m) free_l_vars
+    |> List.split
+  in
+  let f = Expr.evar fv (update_mark_size 1 orig_mark) in
+  let ecall = Expr.eapp ~f ~args:free_vars_e ~tys:free_vars_typs call_mark in
+  let topdef_ty = TArrow (free_vars_typs, size_mark_ty orig_mark), Pos.void in
+  let binder =
+    Expr.bind
+      (Array.of_list (List.map fst free_l_vars))
+      (Expr.earray (List.map Expr.rebox l) l_mark)
+  in
+  let topdef_mark = update_size_mark_ty orig_mark topdef_ty in
+  let topdef_abs =
+    Expr.eabs binder (List.map Expr.pos free_l_vars) free_vars_typs topdef_mark
+  in
+  let topdef_e =
+    fname, topdef_ty, Private, remove_size (Expr.unbox topdef_abs)
+  in
+  let decl_ctx =
+    {
+      ctx.decl_ctx with
+      ctx_topdefs =
+        TopdefName.Map.add fname (topdef_ty, Private) ctx.decl_ctx.ctx_topdefs;
+    }
+  in
+  let ctx =
+    { ctx with decl_ctx; topdefs = Var.Set.add (Var.translate fv) ctx.topdefs }
+  in
+  let right_array = Expr.earray (List.map Expr.rebox r) r_mark in
+  let concat_mark =
+    update_mark_size (2 + get_size ecall + get_size right_array) orig_mark
+  in
+  let array_concat =
+    Expr.eappop ~op:(Op.Concat, Pos.void) ~args:[ecall; right_array]
+      ~tys:[size_mark_ty l_mark; size_mark_ty r_mark]
+      concat_mark
+  in
+  (fv, topdef_e, ctx), array_concat
+
+let is_small_enough ctx e = get_size e <= ctx.split_threshold
+let is_too_large ctx e = not (is_small_enough ctx e)
+
+(** Handles non-splittable arguments, e.g., call arguments, tuple, etc. The
+    heuristic is: if one of the argument is too large (w.r.t to the
+    [split_threshold]), we split it, otherwise, we split the largest element. *)
+let rec handle_args ctx args =
+  let r, rev_args =
+    List.fold_left
+      (function
+        | (Some _ as r), rev_args -> fun e -> r, Expr.rebox e :: rev_args
+        | None, rev_args ->
+          fun e ->
+            if is_too_large ctx e then
+              let r, e = find_split_candidate ctx e in
+              r, e :: rev_args
+            else None, Expr.rebox e :: rev_args)
+      (None, []) args
+  in
+  match r with
+  | Some _ as r -> r, List.rev rev_args
+  | None ->
+    (* We cannot split args => reduce the largest arg *)
+    let sizes = List.mapi (fun i arg -> i, get_size arg) args in
+    let i_max, _ =
+      List.fold_left
+        (fun ((_, max_size) as acc) (i, size) ->
+          if max_size < size then i, size else acc)
+        (-1, 0) sizes
+    in
+    let all_r, args =
+      List.mapi
+        (fun i arg ->
+          if i = i_max then
+            let r, ecall = find_split_candidate ctx arg in
+            r, ecall
+          else None, Expr.(rebox arg))
+        args
+      |> List.split
+    in
+    let r =
+      List.fold_left
+        (function None -> fun r -> r | acc -> fun _ -> acc)
+        None all_r
+    in
+    r, args
+
+(** Handles arrays: if one of the element is too large (w.r.t to the
+    [split_threshold]), we split it. Otherwise, we divide it using
+    [split_array]. *)
+and handle_arrays (ctx : 'a split_ctx) e =
+  let rec find_and_rewrite_too_large_elt acc = function
+    | [] -> None
+    | h :: t ->
+      if is_too_large ctx h then
+        let r, f = find_split_candidate ctx h in
+        Some (r, List.rev_append (f :: acc) (List.map Expr.rebox t))
+      else find_and_rewrite_too_large_elt (Expr.rebox h :: acc) t
+  in
+  match Mark.remove e with
+  | EArray l -> (
+    match find_and_rewrite_too_large_elt [] l with
+    | Some (r, args) ->
+      let size_elts = List.map get_size args |> List.fold_left ( + ) 0 in
+      r, Expr.earray args (update_mark_size (1 + size_elts) (Mark.get e))
+    | None ->
+      let (fv, topdef_e, ctx), array_concat = split_array ctx e in
+      Some (fv, topdef_e, ctx), array_concat)
+  | _ -> assert false
+
+(** Iterates over the AST to look for a good split candidate, i.e., an ast node
+    small enough to be split into a topdef. The AST is dynamically resized
+    depending on the hoisted expression avoiding extra AST traversals. *)
+and find_split_candidate (ctx : _ split_ctx) (e : (_, size_mark) gexpr) =
+  let is_abs = function EAbs _, _ -> true | _ -> false in
+  if is_small_enough ctx e && not (is_abs e)
+  (* We void splitting on abstraction. It yields weird code
+     construction. *)
+  then
+    let (fv, topdef, ctx), ecall = split_expression ctx e in
+    Some (fv, topdef, ctx), ecall
+  else
+    let m = Mark.get e in
+    let add_to_mark_size node_size new_e m =
+      update_mark_size (node_size + get_size new_e) m
+    in
+    let add_all_to_mark_size node_size new_args =
+      let size_args = List.fold_left ( + ) 0 (List.map get_size new_args) in
+      update_mark_size (node_size + size_args) m
+    in
+    (* Current node is too large *)
+    match Mark.remove e with
+    | EBad | EPos _ | ELocation _ | ELit _ | EVar _ | EExternal _
+    | EFatalError_pos _ ->
+      None, Expr.rebox e
+    | EApp { f; args; tys } ->
+      let size_args = List.fold_left (fun s arg -> get_size arg + s) 0 args in
+      if get_size f >= size_args then
+        let r, f = find_split_candidate ctx f in
+        ( r,
+          Expr.eapp ~f ~args:(List.map Expr.rebox args) ~tys
+            (add_to_mark_size (1 + size_args) f m) )
+      else
+        let r, args = handle_args ctx args in
+        ( r,
+          Expr.eapp ~f:(Expr.rebox f) ~args ~tys
+            (add_all_to_mark_size (1 + get_size f) args) )
+    | EAppOp { op; tys; args } ->
+      let r, args = handle_args ctx args in
+      r, Expr.eappop ~op ~args ~tys (add_all_to_mark_size 2 args)
+    | EArray _elts ->
+      let r, e = handle_arrays ctx e in
+      (* Mark already resized in [handle_arrays] *)
+      r, e
+    | ETuple args ->
+      let r, args = handle_args ctx args in
+      r, Expr.etuple args (add_all_to_mark_size 1 args)
+    | EAbs { binder; pos; tys } ->
+      let vars, body = Bindlib.unmbind binder in
+      let r, body = find_split_candidate ctx body in
+      let binder = Expr.bind vars body in
+      ( r,
+        Expr.eabs binder pos tys
+          (add_to_mark_size (1 + Array.length vars) body m) )
+    | EIfThenElse { cond; etrue; efalse } -> (
+      match handle_args ctx [cond; etrue; efalse] with
+      | ret, ([cond; etrue; efalse] as l) ->
+        ret, Expr.eifthenelse cond etrue efalse (add_all_to_mark_size 1 l)
+      | _ -> assert false)
+    | ETupleAccess { e; index; size } ->
+      let r, e = find_split_candidate ctx e in
+      r, Expr.etupleaccess ~e ~index ~size (add_to_mark_size 1 e m)
+    | EInj { name; cons; e } ->
+      let r, e = find_split_candidate ctx e in
+      r, Expr.einj ~name ~cons ~e (add_to_mark_size 1 e m)
+    | EStruct { name; fields } ->
+      let fields, l_e = StructField.Map.bindings fields |> List.split in
+      let r, l_e = handle_args ctx l_e in
+      let fields = List.combine fields l_e |> StructField.Map.of_list in
+      let bdgs = StructField.Map.bindings fields in
+      ( r,
+        Expr.estruct ~name ~fields
+          (add_all_to_mark_size (1 + List.length bdgs) (List.map snd bdgs)) )
+    | EStructAccess { name; field; e } ->
+      let r, e = find_split_candidate ctx e in
+      r, Expr.estructaccess ~name ~field ~e (add_to_mark_size 1 e m)
+    | EMatch { name; e; cases } ->
+      let size_cases =
+        EnumConstructor.Map.fold (fun _ arg s -> get_size arg + s) cases 0
+      in
+      let r, e =
+        if get_size e >= size_cases then
+          let r, e = find_split_candidate ctx e in
+          let cases = EnumConstructor.Map.map Expr.rebox cases in
+          let bdgs = EnumConstructor.Map.bindings cases in
+          ( r,
+            Expr.ematch ~name ~e ~cases
+              (add_all_to_mark_size
+                 (1 + get_size e + List.length bdgs)
+                 (List.map snd bdgs)) )
+        else
+          let constrs, l_e = EnumConstructor.Map.bindings cases |> List.split in
+          let r, l_e = handle_args ctx l_e in
+          let cases = List.combine constrs l_e |> EnumConstructor.Map.of_list in
+          ( r,
+            Expr.ematch ~name ~e:(Expr.rebox e) ~cases
+              (add_all_to_mark_size (1 + get_size e + List.length l_e) l_e) )
+      in
+      r, e
+
+(** Fixpoint expression split. The returns the new expression and the hoisted
+    topdefs. *)
+let rec split_expression ctx rev_topdefs (e : (_, size_mark) gexpr) =
+  if is_too_large ctx e then (
+    let curr_size = get_size e in
+    let r, e = find_split_candidate ctx e in
+    let new_size = get_size e in
+    if curr_size <= new_size then
+      Message.error ~internal:true
+        "Split expression is not smaller than the original expression";
+    match r with
+    | None -> Message.error ~internal:true "Could not split expression"
+    | Some (fv, (fname, topdef_ty, vis, topdef_abs), ctx) ->
+      let new_acc = (fv, fname, topdef_ty, vis, topdef_abs) :: rev_topdefs in
+      let b =
+        Bindlib.box_apply (split_expression ctx new_acc) (Expr.Box.lift e)
+      in
+      Bindlib.unbox b)
+  else ctx, rev_topdefs, e
+
+(* See the mli *)
+let split_program ~threshold (p : 'm program) : 'm program =
+  let ctx =
+    {
+      split_threshold = threshold;
+      decl_ctx = p.decl_ctx;
+      topdefs = Var.Set.empty;
+    }
+  in
+  let rec split_code_items ctx = function
+    | Last exports ->
+      let exports : _ code_export Bindlib.box list =
+        List.map
+          (fun (ex, e) ->
+            Bindlib.box_apply (fun e -> ex, e) Expr.(Box.lift (rebox e)))
+          exports
+      in
+      ctx, Bindlib.box_apply (fun x -> Last x) (Bindlib.box_list exports)
+    | Cons (ScopeDef (sname, body), next_bind) ->
+      let scope_var, scope_body_expr = Bindlib.unbind body.scope_body_expr in
+      let (ctx, rev_topdefs), new_scope_body_expr =
+        BoundList.fold_map ~init:(ctx, [])
+          ~last:(fun (ctx, rev_topdefs) last_e ->
+            (ctx, rev_topdefs), Expr.Box.lift (Expr.rebox last_e))
+          ~f:(fun (ctx, rev_topdefs) var let_e ->
+            let e = Expr.unbox (add_size let_e.scope_let_expr) in
+            let new_ctx, new_rev_topdefs, new_scope_let_expr =
+              split_expression ctx rev_topdefs e
+            in
+            ( (new_ctx, new_rev_topdefs),
+              var,
+              Bindlib.box_apply
+                (fun scope_let_expr -> { let_e with scope_let_expr })
+                (Expr.Box.lift (remove_size new_scope_let_expr)) ))
+          scope_body_expr
+      in
+      let prefix_topdefs :
+          (_ Bindlib.var * (_, typed) gexpr code_item Bindlib.box) list =
+        List.rev_map
+          (fun (fv, fname, topdef_ty, vis, topdef_abs) ->
+            ( Var.translate fv,
+              Bindlib.box_apply
+                (fun topdef_abs -> Topdef (fname, topdef_ty, vis, topdef_abs))
+                (Expr.Box.lift topdef_abs) ))
+          rev_topdefs
+      in
+      let new_scope_body_expr =
+        Bindlib.bind_var scope_var new_scope_body_expr
+      in
+      let fv, next = Bindlib.unbind next_bind in
+      let new_item :
+          (lcalc, typed) gexpr Var.t
+          * (lcalc, typed) gexpr code_item Bindlib.box =
+        ( Var.translate fv,
+          Bindlib.box_apply
+            (fun new_scope_body_expr ->
+              ScopeDef
+                (sname, { body with scope_body_expr = new_scope_body_expr }))
+            new_scope_body_expr )
+      in
+      let ctx, next = split_code_items ctx next in
+      let prefix_boundlist =
+        List.fold_right
+          (fun (v, topdef) acc -> BoundList.cons (Var.translate v) topdef acc)
+          (prefix_topdefs @ [new_item])
+          next
+      in
+      ctx, prefix_boundlist
+    | Cons (Topdef (name, typ, vis, e), next_bind) ->
+      let ctx, rev_topdefs, new_e =
+        split_expression ctx [] (Expr.unbox (add_size e))
+      in
+      let prefix_topdefs : (_ Bindlib.var * _ gexpr code_item Bindlib.box) list
+          =
+        List.rev_map
+          (fun (fv, fname, topdef_ty, vis, topdef_abs) ->
+            ( Var.translate fv,
+              Bindlib.box_apply
+                (fun topdef_abs -> Topdef (fname, topdef_ty, vis, topdef_abs))
+                (Expr.Box.lift topdef_abs) ))
+          rev_topdefs
+      in
+      let fv, next = Bindlib.unbind next_bind in
+      let new_item =
+        ( fv,
+          Bindlib.box_apply
+            (fun new_e -> Topdef (name, typ, vis, new_e))
+            (Expr.Box.lift (remove_size new_e)) )
+      in
+      let ctx =
+        { ctx with topdefs = Var.Set.add (Var.translate fv) ctx.topdefs }
+      in
+      let ctx, next = split_code_items ctx next in
+      let prefix_boundlist =
+        List.fold_right
+          (fun (v, topdef) acc -> BoundList.cons v topdef acc)
+          (prefix_topdefs @ [new_item])
+          next
+      in
+      ctx, prefix_boundlist
+  in
+  let ctx, code_items = split_code_items ctx p.code_items in
+  { p with decl_ctx = ctx.decl_ctx; code_items = Bindlib.unbox code_items }

--- a/compiler/lcalc/split.mli
+++ b/compiler/lcalc/split.mli
@@ -1,0 +1,29 @@
+(* This file is part of the Catala compiler, a specification language for tax
+   and social benefits computation rules. Copyright (C) 2026 Inria, contributor:
+   Vincent Botbol <vincent.botbol@inria.fr>
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Shared_ast
+
+val split_program :
+  threshold:int -> (lcalc, typed) gexpr program -> (lcalc, typed) gexpr program
+(** Splits the program ensuring that expressions are not larger to the given
+    [threshold]. We approximate an expression size as its number of AST nodes.
+    Split expressions will be lifted as topdefs and original expressions are
+    replaced by calls to the generated functions. We iterate until every
+    program's expression satisfies the size requirements.
+
+    This is necessary in the java backend as there is a bytecode size limit in
+    each java's method. However, this mechanism is generic enough to be ported
+    to other backends. *)

--- a/compiler/plugins/api_web.ml
+++ b/compiler/plugins/api_web.ml
@@ -511,7 +511,7 @@ let run
     Driver.Passes.lcalc options ~includes ~stdlib ~optimize ~check_invariants
       ~autotest:false ~closure_conversion ~keep_special_ops ~typed:Expr.typed
       ~monomorphize_types ~renaming:(Some Lcalc.To_ocaml.renaming)
-      ~lift_pos:(Some Lcalc.To_ocaml.op_needs_pos)
+      ~lift_pos:(Some Lcalc.To_ocaml.op_needs_pos) ~split_threshold:None
   in
   Driver.Commands.get_output_format options ~ext:"api_web.ml" output
     (fun jsoo_output_file fmt ->

--- a/compiler/plugins/json_schema.ml
+++ b/compiler/plugins/json_schema.ml
@@ -221,7 +221,7 @@ let run
     Driver.Passes.lcalc options ~includes ~stdlib ~optimize ~check_invariants
       ~autotest:false ~closure_conversion ~keep_special_ops ~typed:Expr.typed
       ~monomorphize_types ~renaming:(Some Lcalc.To_ocaml.renaming)
-      ~lift_pos:None
+      ~lift_pos:None ~split_threshold:None
   in
   Driver.Commands.get_output_format options ~ext:"schema.json" output
   @@ fun output_file fmt ->

--- a/compiler/plugins/python.ml
+++ b/compiler/plugins/python.ml
@@ -37,7 +37,7 @@ let run
       ~dead_value_assignment:true ~no_struct_literals:false
       ~keep_module_names:false ~monomorphize_types:false
       ~renaming:(Some Scalc.To_python.renaming)
-      ~lift_pos:(Some Scalc.To_python.op_needs_pos)
+      ~lift_pos:(Some Scalc.To_python.op_needs_pos) ~split_threshold:None
   in
 
   Message.debug "Compiling program into Python...";

--- a/compiler/plugins/python.ml
+++ b/compiler/plugins/python.ml
@@ -38,6 +38,7 @@ let run
       ~keep_module_names:false ~monomorphize_types:false
       ~renaming:(Some Scalc.To_python.renaming)
       ~lift_pos:(Some Scalc.To_python.op_needs_pos) ~split_threshold:None
+      ~split_scope_var_defs:false
   in
 
   Message.debug "Compiling program into Python...";

--- a/compiler/scalc/ast.ml
+++ b/compiler/scalc/ast.ml
@@ -101,6 +101,8 @@ type scope_body = {
   scope_body_var : FuncName.t;
   scope_body_func : func;
   scope_body_visibility : visibility;
+  scope_body_var_defs :
+    (VarName.t Mark.pos * FuncName.t * func) list option (* only set in java *);
 }
 
 type code_item =

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -26,6 +26,7 @@ type translation_config = {
   no_struct_literals : bool;
   keep_module_names : bool;
   renaming_context : Renaming.context;
+  split_scope_var_defs : bool;
 }
 
 type 'm ctxt = {
@@ -577,6 +578,117 @@ let rec translate_scope_body_expr ctx (scope_expr : 'm L.expr scope_body_expr) :
     RevBlock.rebuild (decl ++ statements)
       ~tail:(translate_scope_body_expr { ctx with ren_ctx } scope_let_next)
 
+let translate_split_scope_body_expr
+    (outer_ctx : 'm ctxt)
+    (ctx : 'm ctxt)
+    (scope_expr : 'm L.expr scope_body_expr) :
+    (A.VarName.t Mark.pos * A.FuncName.t * A.func) list * A.block =
+  let rec loop (var_def_funcs, scope_body, local_vars, (ctx : 'm ctxt)) =
+    function
+    | Last e ->
+      let block, new_e, _ren_ctx = translate_expr ctx e in
+      ( List.rev var_def_funcs,
+        RevBlock.rebuild (scope_body ++ block)
+          ~tail:[A.SReturn new_e, Mark.get new_e] )
+    | Cons (scope_let, next_bnd) ->
+      let let_var, scope_let_next, binded_ctx = unbind ctx next_bnd in
+      let ctx = binded_ctx in
+      let pos = scope_let.scope_let_pos in
+      let let_var_id, ctx = register_fresh_var ctx let_var ~pos in
+      if scope_let.scope_let_kind = Assertion then
+        let statements, ren_ctx =
+          translate_assignment ctx None scope_let.scope_let_expr
+        in
+        loop
+          ( var_def_funcs,
+            scope_body ++ statements,
+            Var.Set.add let_var local_vars,
+            { ctx with ren_ctx } )
+          scope_let_next
+      else if scope_let.scope_let_kind = ScopeVarDefinition then begin
+        let decl_var_name = let_var_id, pos in
+        let ret_typ = scope_let.scope_let_typ in
+        let fun_name, ctx =
+          register_fresh_func ~pos ~poly:false ctx
+            (Var.make (A.VarName.to_string let_var_id ^ "_def"))
+        in
+        let free_var_args =
+          Expr.free_vars_marked scope_let.scope_let_expr
+          |> Var.Map.bindings
+          |> List.filter_map (fun (var, m) ->
+              if
+                Var.Map.mem var outer_ctx.func_dict
+                || Var.Map.mem var outer_ctx.var_dict
+              then None
+              else
+                Some (A.VarName.fresh (Bindlib.name_of var, Expr.mark_pos m), m))
+        in
+        let call_expr =
+          ( A.EApp
+              {
+                f = A.EFunc fun_name, pos;
+                args =
+                  List.map
+                    (fun (v, m) -> A.EVar v, Expr.mark_pos m)
+                    free_var_args;
+                typ = ret_typ;
+                poly = false;
+              },
+            pos )
+        in
+        let decl_and_call =
+          RevBlock.make
+            [
+              A.SLocalDecl { name = decl_var_name; typ = ret_typ }, pos;
+              ( A.SLocalDef
+                  { name = decl_var_name; typ = ret_typ; expr = call_expr },
+                pos );
+            ]
+        in
+        let var_def_func : A.func =
+          let func_params : (A.VarName.t Mark.pos * typ) list =
+            List.map
+              (fun (v, m) -> Mark.add (Expr.mark_pos m) v, Expr.ty (v, m))
+              free_var_args
+          in
+          let func_body =
+            let stmts, e, _ =
+              translate_expr binded_ctx scope_let.scope_let_expr
+            in
+            RevBlock.rebuild stmts ~tail:[A.SReturn e, Mark.get e]
+          in
+          let func_return_typ = ret_typ in
+          { A.func_params; func_body; func_return_typ }
+        in
+        loop
+          ( (decl_var_name, fun_name, var_def_func) :: var_def_funcs,
+            scope_body ++ decl_and_call,
+            Var.Set.add let_var local_vars,
+            ctx )
+          scope_let_next
+      end
+      else
+        let decl, assign_to =
+          ( RevBlock.make
+              [
+                ( A.SLocalDecl
+                    { name = let_var_id, pos; typ = scope_let.scope_let_typ },
+                  pos );
+              ],
+            Some (let_var_id, pos) )
+        in
+        let statements, ren_ctx =
+          translate_assignment ctx assign_to scope_let.scope_let_expr
+        in
+        loop
+          ( var_def_funcs,
+            scope_body ++ decl ++ statements,
+            Var.Set.add let_var local_vars,
+            { ctx with ren_ctx } )
+          scope_let_next
+  in
+  loop ([], RevBlock.empty, Var.Set.empty, ctx) scope_expr
+
 let translate_program ~(config : translation_config) (p : 'm L.program) :
     A.program =
   let ctxt =
@@ -616,10 +728,19 @@ let translate_program ~(config : translation_config) (p : 'm L.program) :
       let scope_input_var_id, inner_ctx =
         register_fresh_var ctxt scope_input_var ~pos:input_pos
       in
-      let new_scope_body =
-        translate_scope_body_expr
-          { inner_ctx with context_name = ScopeName.base name }
-          scope_body_expr
+      let scope_body_var_defs, new_scope_body =
+        if config.split_scope_var_defs then
+          let var_defs, scope_body =
+            translate_split_scope_body_expr outer_ctx
+              { inner_ctx with context_name = ScopeName.base name }
+              scope_body_expr
+          in
+          Some var_defs, scope_body
+        else
+          ( None,
+            translate_scope_body_expr
+              { inner_ctx with context_name = ScopeName.base name }
+              scope_body_expr )
       in
       let func_id, outer_ctx =
         register_fresh_func outer_ctx var ~pos:input_pos ~poly:false
@@ -641,6 +762,7 @@ let translate_program ~(config : translation_config) (p : 'm L.program) :
                   TStruct body.scope_body_output_struct, input_pos;
               };
             scope_body_visibility = body.scope_body_visibility;
+            scope_body_var_defs;
           }
         :: rev_items )
     | Topdef (name, topdef_ty, visibility, (EAbs abs, m)) ->

--- a/compiler/scalc/from_lcalc.ml
+++ b/compiler/scalc/from_lcalc.ml
@@ -186,8 +186,13 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
     let stmts, new_exceptions, ren_ctx = translate_expr_list ctxt exceptions in
     let ctxt = { ctxt with ren_ctx } in
     let stmts, excs, ctxt =
+      let ty =
+        match Expr.ty arr with
+        | TArray ty, _ -> ty
+        | _ -> Type.universal (Expr.pos expr)
+      in
       if not ctxt.config.no_struct_literals then
-        stmts, (A.EArray { elts = new_exceptions; ty = Expr.ty arr }, pos), ctxt
+        stmts, (A.EArray { elts = new_exceptions; ty }, pos), ctxt
       else
         let arr_var_name, ctxt =
           fresh_var ~pos ctxt ("exc_" ^ ctxt.context_name)
@@ -198,8 +203,7 @@ and translate_expr (ctxt : 'm ctxt) (expr : 'm L.expr) :
                  {
                    name = arr_var_name, pos;
                    typ = t_arr;
-                   expr =
-                     A.EArray { elts = new_exceptions; ty = Expr.ty arr }, pos;
+                   expr = A.EArray { elts = new_exceptions; ty }, pos;
                  },
                pos )
         in

--- a/compiler/scalc/from_lcalc.mli
+++ b/compiler/scalc/from_lcalc.mli
@@ -37,6 +37,10 @@ type translation_config = {
           defined in the preamble of the output. If set, module names are
           immutable and must be used as is in all references. *)
   renaming_context : Renaming.context;
+  split_scope_var_defs : bool;
+      (** Split scope's variable definitions into multiple functions to ensure
+          small function size. Necessary in Java to prevent 'code too large'
+          errors. *)
 }
 
 val translate_program :

--- a/compiler/scalc/print.ml
+++ b/compiler/scalc/print.ml
@@ -188,27 +188,53 @@ and format_block
     ?(debug : bool = false)
     (fmt : Format.formatter)
     (block : block) : unit =
+  Format.pp_open_vbox fmt 0;
   Format.pp_print_list
     ~pp_sep:(fun fmt () ->
       Print.punctuation fmt ";";
       Format.pp_print_space fmt ())
     (format_statement decl_ctx ~debug)
-    fmt block
+    fmt block;
+  Format.pp_close_box fmt ()
 
 let format_item decl_ctx ?debug ppf def =
-  Format.pp_open_hvbox ppf 2;
-  Format.pp_open_hovbox ppf 4;
-  Print.keyword ppf "let ";
   let () =
     match def with
     | SVar { var; expr; typ = _; visibility = _ } ->
+      Format.pp_open_vbox ppf 2;
+      Format.pp_open_hovbox ppf 4;
+      Print.keyword ppf "let ";
       format_var_name ppf var;
       Print.punctuation ppf " =";
       Format.pp_close_box ppf ();
       Format.pp_print_space ppf ();
       format_expr decl_ctx ?debug ppf expr
-    | SScope { scope_body_var = var; scope_body_func = func; _ }
-    | SFunc { var; func; visibility = _ } ->
+    | SScope
+        { scope_body_var = var; scope_body_func = func; scope_body_var_defs; _ }
+      ->
+      let scope_body_var_defs = Option.value ~default:[] scope_body_var_defs in
+      List.iter
+        (fun (_var_name, var_func_name, var_func) ->
+          Format.pp_open_vbox ppf 2;
+          Format.pp_open_hovbox ppf 4;
+          Print.keyword ppf "let ";
+          format_func_name ppf var_func_name;
+          Format.pp_print_list
+            (fun ppf (arg, ty) ->
+              Format.fprintf ppf "@ (%a: %a)" format_var_name (Mark.remove arg)
+                format_type ty)
+            ppf var_func.func_params;
+          Print.punctuation ppf " =";
+          Format.pp_close_box ppf ();
+          Format.pp_print_cut ppf ();
+          format_block decl_ctx ?debug ppf var_func.func_body;
+          Format.pp_close_box ppf ();
+          Format.pp_print_cut ppf ();
+          Format.pp_print_newline ppf ())
+        scope_body_var_defs;
+      Format.pp_open_vbox ppf 2;
+      Format.pp_open_hovbox ppf 4;
+      Print.keyword ppf "let ";
       format_func_name ppf var;
       Format.pp_print_list
         (fun ppf (arg, ty) ->
@@ -217,7 +243,21 @@ let format_item decl_ctx ?debug ppf def =
         ppf func.func_params;
       Print.punctuation ppf " =";
       Format.pp_close_box ppf ();
-      Format.pp_print_space ppf ();
+      Format.pp_print_cut ppf ();
+      format_block decl_ctx ?debug ppf func.func_body
+    | SFunc { var; func; visibility = _ } ->
+      Format.pp_open_vbox ppf 2;
+      Format.pp_open_hovbox ppf 4;
+      Print.keyword ppf "let ";
+      format_func_name ppf var;
+      Format.pp_print_list
+        (fun ppf (arg, ty) ->
+          Format.fprintf ppf "@ (%a: %a)" format_var_name (Mark.remove arg)
+            format_type ty)
+        ppf func.func_params;
+      Print.punctuation ppf " =";
+      Format.pp_close_box ppf ();
+      Format.pp_print_cut ppf ();
       format_block decl_ctx ?debug ppf func.func_body
   in
   Format.pp_close_box ppf ();

--- a/compiler/scalc/to_c.ml
+++ b/compiler/scalc/to_c.ml
@@ -1036,6 +1036,34 @@ and format_block (ctx : ctx) (env : env) (fmt : Format.formatter) (b : block) :
     in
     List.iter (format_statement ctx env fmt) remaining
 
+let format_func ~ppc ~pph ctx env var func visibility =
+  let { func_params; func_body; func_return_typ } = func in
+  let local_vars =
+    VarName.Set.of_list (List.map (fun (v, _) -> Mark.remove v) func_params)
+  in
+  let pp_intf = if visibility = Public then [pph] else [] in
+  pp (ppc :: pp_intf) "@,@[<v 2>@[<hov 4>%s%a@ @[<hv 1>(%a)@]@]"
+    (if visibility = Public then "" else "static ")
+    (format_typ ~const:true ctx.decl_ctx (fun fmt ->
+         Format.pp_print_space fmt ();
+         FuncName.format fmt var))
+    func_return_typ
+    (Format.pp_print_list
+       ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
+       (fun fmt (var, typ) ->
+         Format.pp_open_hovbox fmt 2;
+         (format_typ ~const:true ctx.decl_ctx (fun fmt ->
+              Format.pp_print_space fmt ();
+              VarName.format fmt (Mark.remove var)))
+           fmt typ;
+         Format.pp_close_box fmt ()))
+    func_params;
+  pp pp_intf "@];@,";
+  pp [ppc] "@;<1 -2>{%a@]@,}@,"
+    (format_block ctx { env with local_vars })
+    func_body;
+  env
+
 let format_code_item ctx ~ppc ~pph env = function
   | SVar
       {
@@ -1090,40 +1118,20 @@ let format_code_item ctx ~ppc ~pph env = function
       expr;
     pp [ppc] "@;<1 -2>}@]@,";
     { env with global_vars = VarName.Set.add var env.global_vars }
-  | SFunc { var; func; visibility }
+  | SFunc { var; func; visibility } ->
+    format_func ~ppc ~pph ctx env var func visibility
   | SScope
       {
         scope_body_var = var;
         scope_body_func = func;
         scope_body_visibility = visibility;
+        scope_body_var_defs = None;
         _;
       } ->
-    let { func_params; func_body; func_return_typ } = func in
-    let local_vars =
-      VarName.Set.of_list (List.map (fun (v, _) -> Mark.remove v) func_params)
-    in
-    let pp_intf = if visibility = Public then [pph] else [] in
-    pp (ppc :: pp_intf) "@,@[<v 2>@[<hov 4>%s%a@ @[<hv 1>(%a)@]@]"
-      (if visibility = Public then "" else "static ")
-      (format_typ ~const:true ctx.decl_ctx (fun fmt ->
-           Format.pp_print_space fmt ();
-           FuncName.format fmt var))
-      func_return_typ
-      (Format.pp_print_list
-         ~pp_sep:(fun fmt () -> Format.fprintf fmt ",@ ")
-         (fun fmt (var, typ) ->
-           Format.pp_open_hovbox fmt 2;
-           (format_typ ~const:true ctx.decl_ctx (fun fmt ->
-                Format.pp_print_space fmt ();
-                VarName.format fmt (Mark.remove var)))
-             fmt typ;
-           Format.pp_close_box fmt ()))
-      func_params;
-    pp pp_intf "@];@,";
-    pp [ppc] "@;<1 -2>{%a@]@,}@,"
-      (format_block ctx { env with local_vars })
-      func_body;
-    env
+    format_func ~ppc ~pph ctx env var func visibility
+  | SScope { scope_body_var_defs = Some _; _ } ->
+    Message.error ~internal:true
+      "Found unexpected split scope variable definitions."
 
 let format_main ctx env (fmt : Format.formatter) (p : Ast.program) =
   Format.pp_open_vbox fmt 0;

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -251,6 +251,10 @@ let rec format_lit (ppf : formatter) (l : lit Mark.pos) : unit =
   match Mark.remove l with
   | LBool true -> pp_print_string ppf "CatalaBool.TRUE"
   | LBool false -> pp_print_string ppf "CatalaBool.FALSE"
+  | LInt i when Z.fits_int64 i ->
+    fprintf ppf "new CatalaInteger(%s%s)"
+      (Runtime.integer_to_string i)
+      (if Z.fits_int32 i then "" else "l")
   | LInt i ->
     fprintf ppf "new CatalaInteger(\"%s\")" (Runtime.integer_to_string i)
   | LUnit -> pp_print_string ppf "null"
@@ -263,6 +267,15 @@ let rec format_lit (ppf : formatter) (l : lit Mark.pos) : unit =
         (Mark.copy l (LInt (Q.num i)))
         format_lit
         (Mark.copy l (LInt (Q.den i)))
+  | LMoney e when Z.fits_int64 e ->
+    if Z.(rem e (of_int 100) = zero) then
+      fprintf ppf "new CatalaMoney(%s%s)"
+        Runtime.(integer_to_string (money_round e))
+        (if Z.fits_int32 e then "" else "l")
+    else
+      fprintf ppf "CatalaMoney.ofCents(%s%s)"
+        Runtime.(integer_to_string (money_to_cents e))
+        (if Z.fits_int32 e then "" else "l")
   | LMoney e ->
     fprintf ppf "CatalaMoney.ofCents(\"%s\")"
       (Runtime.integer_to_string (Runtime.money_to_cents e))

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -429,14 +429,9 @@ let rec format_expression ctx (ppf : formatter) (e : expr) : unit =
   | EAppOp { op = DebugPrint str, _; args = [e]; _ } ->
     fprintf ppf "System.err.println(\"%s = \" + %a.toString())" str
       (format_expression ctx) e
-  | EAppOp
-      {
-        op = (HandleExceptions, _) as op;
-        args = [(EArray { elts = exprs; _ }, _)];
-        _;
-      } ->
-    fprintf ppf "@[<hv 2>%a@;<0 -1>(new CatalaArray<>(@ %a@ )@])" format_op op
-      (pp_print_list ~pp_sep:pp_comma (fun ppf e -> format_expression ctx ppf e))
+  | EAppOp { op = (HandleExceptions, _) as op; args = exprs; _ } ->
+    fprintf ppf "@[<hv 2>%a@;<0 -1>(%a@])" format_op op
+      (pp_print_list ~pp_sep:pp_comma (format_expression ctx))
       exprs
   | EAppOp { op = Concat, _; args = [(EArray { elts = []; _ }, _); e2]; _ } ->
     (* Do not append to empty list *)

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -534,6 +534,10 @@ let rec format_expression ctx (ppf : formatter) (e : expr) : unit =
       (pp_print_list ~pp_sep:pp_comma (fun ppf e ->
            fprintf ppf "%a" (format_expression ctx) e))
       es
+  | ETupleAccess { e1; index; typ = (TArrow _, _) as typ } ->
+    fprintf ppf "(%a)@;<0 -1>(%a.get(%d))" (format_typ ctx) typ
+      (format_expression_with_paren ctx)
+      e1 index
   | ETupleAccess { e1; index; typ } ->
     fprintf ppf "CatalaValue.<%a>cast@;<0 -1>(%a.get(%d))" (format_typ ctx) typ
       (format_expression_with_paren ctx)

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -23,7 +23,7 @@ module L = Lcalc.Ast
 open Format
 
 let pp_comma ppf () = fprintf ppf ",@ "
-let pp_skip_line ppf () = fprintf ppf "\n@,"
+let pp_skip_line ppf () = fprintf ppf "@\n@,"
 
 let pp_print_list_padded ?pp_sep pp ppf l =
   if l = [] then ()
@@ -39,6 +39,7 @@ type context = {
   in_globals : bool;
   global_funcs : FuncName.Set.t;
   global_vars : VarName.Set.t;
+  var_def_funcs : FuncName.Set.t;
   external_global_funcs : String.Set.t;
   external_global_vars : String.Set.t;
   external_scopes : string String.Map.t;
@@ -623,7 +624,6 @@ let rec format_stmt ~toplevel (ctx : context) ppf (stmt : Ast.stmt Mark.pos) =
       | [(SIfThenElse { if_expr; then_block; else_block }, _)] ->
         Format.fprintf ppf " else if (%a.asBoolean()) {@ %a@;<1 -4>}"
           (format_expression ctx) if_expr (format_block ctx) then_block;
-
         pr_else else_block
       | [(SLocalDef { expr = ELit LUnit, _; _ }, _)]
       | [(SReturn (ELit LUnit, _), _)] ->
@@ -760,6 +760,20 @@ and format_block ?(toplevel = false) ctx ppf (block : Ast.block) =
       pp_print_space ppf ();
       format_stmts ~toplevel r
     | (SLocalDecl { name = n, _; typ }, _)
+      :: ( SLocalDef
+             { name = n2, _; expr = EApp { f = EFunc fname, _; args; _ }, _; _ },
+           _ )
+      :: r
+      when VarName.equal n n2 && FuncName.Set.mem fname ctx.var_def_funcs ->
+      (* Special case for scope variable definitions functions that
+         are not compiled as lambdas *)
+      fprintf ppf "@[<hov 4>final %a@ %a = %a(%a);@]" (format_typ ctx) typ
+        VarName.format n FuncName.format fname
+        (pp_print_list ~pp_sep:pp_comma (format_expression ctx))
+        args;
+      pp_print_space ppf ();
+      format_stmts ~toplevel r
+    | (SLocalDecl { name = n, _; typ }, _)
       :: (SLocalDef { name = n2, _; expr; _ }, _)
       :: r
       when VarName.equal n n2 ->
@@ -848,25 +862,36 @@ and format_pos_as_expr ctx ppf p =
 let format_constructor_body (ctx : context) sbody ppf =
   format_block ~toplevel:true ctx ppf sbody.scope_body_func.func_body
 
-let format_constructor (ctx : context) (sbody : scope_body) ppf =
-  let in_struct_name =
-    match sbody.scope_body_func.func_params with
-    | [(_vname, (TStruct sn, _))] -> sn
-    | _ -> assert false
+let format_scope_var_def
+    ctx
+    ppf
+    ((_scope_var, func_name, func) : VarName.t Mark.pos * FuncName.t * func) =
+  let format_params ppf =
+    pp_print_list ~pp_sep:pp_comma (fun ppf pp_v -> pp_v ppf) ppf
   in
-  StructName.Map.find_opt in_struct_name ctx.decl_ctx.ctx_structs
-  |> function
-  | None -> ()
-  | Some in_fields ->
-    if StructField.Map.cardinal in_fields >= 255 then
-      Message.error
-        "The scope %a has too many input variables: Java does not support more \
-         than 255 parameters in methods. "
-        ScopeName.format_original sbody.scope_body_name;
-    fprintf ppf "@[<v 4>@[<hov 4>%a%a@ (@[<hov>%a@])@;<1 -4>{@]@,%t@;<1 -4>}@]"
-      format_visibility sbody.scope_body_visibility format_scope
-      sbody.scope_body_name (format_struct_params ctx) in_fields
-      (format_constructor_body ctx sbody)
+  let params =
+    List.map
+      (fun (v, t) ->
+        fun ppf ->
+         fprintf ppf "final %a %a" (format_typ ctx) t VarName.format
+           (Mark.remove v))
+      func.func_params
+  in
+  fprintf ppf
+    "@[<v 4>@[<hov 4>private %a %a(@[<hov>%a@])@;<1 -4>{@]@,%a@;<1 -4>}@]"
+    (format_typ ctx) func.func_return_typ FuncName.format func_name
+    format_params params (format_block ctx) func.func_body
+
+let format_constructor (ctx : context) in_fields ppf (sbody : scope_body) =
+  if StructField.Map.cardinal in_fields >= 255 then
+    Message.error
+      "The scope %a has too many input variables: Java does not support more \
+       than 255 parameters in methods. "
+      ScopeName.format_original sbody.scope_body_name;
+  fprintf ppf "@[<v 4>@[<hov 4>%a%a@ (@[<hov>%a@])@;<1 -4>{@]@,%t@;<1 -4>}@]"
+    format_visibility sbody.scope_body_visibility format_scope
+    sbody.scope_body_name (format_struct_params ctx) in_fields
+    (format_constructor_body ctx sbody)
 
 let format_output_parameter ?(vis = Public) ctx ppf (field_name, typ) =
   fprintf ppf "@[<h>%afinal@ %a@ %a;@]" format_visibility vis (format_typ ctx)
@@ -1050,18 +1075,43 @@ let format_scope ctx ppf (sbody : Ast.scope_body) =
       "The scope %a has too many output variables: Java does not support more \
        than 255 parameters in methods, this would yield invalid Java code. "
       ScopeName.format_original sbody.scope_body_name;
+  let in_struct_name =
+    match sbody.scope_body_func.func_params with
+    | [(_vname, (TStruct sn, _))] -> sn
+    | _ -> assert false
+  in
+  let scope_body_var_defs =
+    match sbody.scope_body_var_defs with
+    | None ->
+      Message.error ~internal:true
+        "Found unexpected non-split scope variable definitions."
+    | Some x -> x
+  in
+  let ctx =
+    {
+      ctx with
+      var_def_funcs =
+        List.map (fun (_, fname, _) -> fname) scope_body_var_defs
+        |> FuncName.Set.of_list;
+    }
+  in
+  let in_fields = StructName.Map.find in_struct_name ctx.decl_ctx.ctx_structs in
   fprintf ppf
     "@[<v 4>@[<hov 4>public static class %a extends CatalaStruct {@]@\n\
      @,\
-     %a@ %t@\n\
+     %a@ %a@\n\
+     @,\
+     %a@\n\
      @,\
      %t@]@\n\
      }"
     format_scope sbody.scope_body_name
     (format_scope_output_parameters ctx sbody)
     out_fields
-    (format_constructor ctx sbody)
-    pp_out_struct
+    (pp_print_list ~pp_sep:pp_skip_line (format_scope_var_def ctx))
+    scope_body_var_defs
+    (format_constructor ctx in_fields)
+    sbody pp_out_struct
 
 let gather_externals ctx =
   let external_global_funcs, external_global_vars =
@@ -1114,6 +1164,7 @@ let populate_context (p : Ast.program) : context =
       in_globals = false;
       global_funcs = FuncName.Set.empty;
       global_vars = VarName.Set.empty;
+      var_def_funcs = FuncName.Set.empty;
       external_global_funcs = String.Set.empty;
       external_global_vars = String.Set.empty;
       external_scopes = String.Map.empty;

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -44,11 +44,6 @@ type context = {
   external_scopes : string String.Map.t;
 }
 
-let format_string_list (ppf : formatter) (uids : string list) : unit =
-  fprintf ppf "new String[]{%a}"
-    (pp_print_list ~pp_sep:pp_comma pp_print_string)
-    (List.map String.quote uids)
-
 let java_keywords =
   (* list taken from
      https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html *)
@@ -399,11 +394,9 @@ let rec format_expression ctx (ppf : formatter) (e : expr) : unit =
   | EPosLit ->
     let pos = Mark.get e in
     fprintf ppf
-      "@[<hv 2>new CatalaPosition@;\
-       <0 -1>(@[<hov>\"%s\",@ %d, %d,@ %d, %d,@ %a@])@]"
+      "@[<hv 2>new CatalaPosition@;<0 -1>(@[<hov>\"%s\",@ %d, %d,@ %d, %d@])@]"
       (Pos.get_file pos) (Pos.get_start_line pos) (Pos.get_start_column pos)
-      (Pos.get_end_line pos) (Pos.get_end_column pos) format_string_list
-      (Pos.get_law_info pos)
+      (Pos.get_end_line pos) (Pos.get_end_column pos)
   | EAppOp { op = ValueFromJson (ty, str), p; args = [_e]; _ } ->
     let encoded_string =
       (* Java needs utf-16, we quote the string then escape the non-latin1

--- a/compiler/scalc/to_python.ml
+++ b/compiler/scalc/to_python.ml
@@ -641,6 +641,9 @@ let format_code_item ctx fmt = function
   | SVar { var; expr; typ = _; visibility = _ } ->
     Format.fprintf fmt "@[<hv 4>%a = (@,%a@;<0 -4>)@]@," VarName.format var
       (format_expression ctx) expr
+  | SScope { scope_body_var_defs = Some _; _ } ->
+    Message.error ~internal:true
+      "Found unexpected split scope variable definitions."
   | SFunc { var; func; visibility = _ }
   | SScope { scope_body_var = var; scope_body_func = func; _ } ->
     Format.fprintf fmt "@[<v 4>@[<hov 2>def %a(@,%a@;<0 -2>) -> %a:@]@ %a@]@,"

--- a/compiler/shared_ast/expr.ml
+++ b/compiler/shared_ast/expr.ml
@@ -871,6 +871,17 @@ let rec free_vars : ('a, 't) gexpr -> ('a, 't) gexpr Var.Set.t = function
 (* Could also be done with [rebox] followed by [Bindlib.free_vars], if that
    returned more than a context *)
 
+let rec free_vars_marked : ('a, 'm) gexpr -> (('a, 'm) gexpr, 'm mark) Var.Map.t
+    = function
+  | EVar v, m -> Var.Map.singleton v m
+  | EAbs { binder; _ }, _ ->
+    let vs, body = Bindlib.unmbind binder in
+    Array.fold_right Var.Map.remove vs (free_vars_marked body)
+  | e ->
+    shallow_fold
+      (fun e -> Var.Map.union (fun _ l _ -> Some l) (free_vars_marked e))
+      e Var.Map.empty
+
 (* This function is first defined in [Print], only for dependency reasons *)
 let skip_wrappers : type a. (a, 'm) gexpr -> (a, 'm) gexpr = Print.skip_wrappers
 

--- a/compiler/shared_ast/expr.mli
+++ b/compiler/shared_ast/expr.mli
@@ -500,6 +500,11 @@ val compare : ('a, 'm) gexpr -> ('a, 'm) gexpr -> int
 val is_value : ('a any, 'm) gexpr -> bool
 val free_vars : ('a any, 'm) gexpr -> ('a, 'm) gexpr Var.Set.t
 
+val free_vars_marked : ('a any, 'm) gexpr -> (('a, 'm) gexpr, 'm mark) Var.Map.t
+(** Returns the free variables of the given expression with their marked
+    expression. Note that only it only returns the first occurence of duplicate
+    variables. *)
+
 val size : ('a, 'm) gexpr -> int
 (** Used by the optimizer to know when to stop *)
 

--- a/compiler/shared_ast/print.ml
+++ b/compiler/shared_ast/print.ml
@@ -1216,11 +1216,16 @@ module UserFacing = struct
     aux_value
 end
 
-let rec s_expr : type a. Format.formatter -> (a, 't) gexpr -> unit =
- fun fmt e ->
+let rec s_expr : type a m.
+    ?pp_mark:(Format.formatter -> m mark -> unit) ->
+    Format.formatter ->
+    (a, m) gexpr ->
+    unit =
+ fun ?(pp_mark = fun _ _ -> ()) fmt e ->
   let open Format in
   let pf = fprintf in
   let pp_sep fmt () = pf fmt ",@ " in
+  let s_expr = s_expr ~pp_mark in
   let ppl fmt l = pf fmt "@[<hov 2>[ %a ]@]" (pp_print_list ~pp_sep s_expr) l in
   let pp_marked_id fmt (sf, e) =
     pf fmt "@[<hov 1>%a: %a@]" MarkedIdent.format sf s_expr e
@@ -1232,6 +1237,7 @@ let rec s_expr : type a. Format.formatter -> (a, 't) gexpr -> unit =
     | None -> pf fmt "NONE"
     | Some x -> pf fmt "SOME(%a)" pp x
   in
+  pp_mark fmt (Mark.get e);
   match Mark.remove e with
   | ELit (LBool b) -> pf fmt "LitBool<%b>" b
   | ELit (LInt i) -> pf fmt "LitInt<%s>" (Z.to_string i)
@@ -1253,7 +1259,7 @@ let rec s_expr : type a. Format.formatter -> (a, 't) gexpr -> unit =
   | EVar v -> pf fmt "Var(%s#%d)" (Bindlib.name_of v) (Bindlib.uid_of v)
   | EAbs { binder; _ } ->
     let vars, e = Bindlib.unmbind binder in
-    let vars : (a, 't) gexpr list =
+    let vars : (a, m) gexpr list =
       Array.to_list vars |> List.map (fun v -> Mark.add (Mark.get e) (EVar v))
     in
     pf fmt "@[<hov 1>Abs(%a,@ %a)@]" ppl vars s_expr e

--- a/compiler/shared_ast/print.mli
+++ b/compiler/shared_ast/print.mli
@@ -64,7 +64,11 @@ val expr : ?debug:bool -> unit -> Format.formatter -> ('a, 'm) gexpr -> unit
       variable indices and operator suffixes. See the interface below for more
       detailed control. *)
 
-val s_expr : Format.formatter -> (_, _) gexpr -> unit
+val s_expr :
+  ?pp_mark:(Format.formatter -> 'm mark -> unit) ->
+  Format.formatter ->
+  (_, 'm) gexpr ->
+  unit
 (** S-expression printer for all AST nodes. *)
 
 val negated_op : Format.formatter -> 'a operator -> unit

--- a/compiler/shared_ast/var.ml
+++ b/compiler/shared_ast/var.ml
@@ -115,6 +115,7 @@ module Map = struct
   let keys m = keys m |> List.map get
   let values m = values m
   let format_keys ?pp_sep m = format_keys ?pp_sep m
+  let filter f m = filter (fun v x -> f (get v) x) m
 
   (* Add more as needed *)
 end

--- a/compiler/shared_ast/var.mli
+++ b/compiler/shared_ast/var.mli
@@ -79,6 +79,7 @@ module Map : sig
     ('e var -> 'x -> 'x -> 'x option) -> ('e, 'x) t -> ('e, 'x) t -> ('e, 'x) t
 
   val fold : ('e var -> 'x -> 'acc -> 'acc) -> ('e, 'x) t -> 'acc -> 'acc
+  val filter : ('e var -> 'x -> bool) -> ('e, 'x) t -> ('e, 'x) t
   val keys : ('e, 'x) t -> 'e var list
   val values : ('e, 'x) t -> 'x list
 

--- a/runtimes/java/catala/runtime/CatalaPosition.java
+++ b/runtimes/java/catala/runtime/CatalaPosition.java
@@ -8,18 +8,16 @@ public final class CatalaPosition
     public int startColumn;
     public int endLine;
     public int endColumn;
-    public String[] law_headings;
 
-    public CatalaPosition(String filename, int startLine, int startColumn, int endLine, int endColumn, String[] law_headings) {
+    public CatalaPosition(String filename, int startLine, int startColumn, int endLine, int endColumn) {
         this.filename = filename;
         this.startLine = startLine;
         this.startColumn = startColumn;
         this.endLine = endLine;
         this.endColumn = endColumn;
-        this.law_headings = law_headings;
     }
 
-    public final static CatalaPosition empty = new CatalaPosition("", 0, 0, 0, 0, new String[]{});
+    public final static CatalaPosition empty = new CatalaPosition("", 0, 0, 0, 0);
 
     @Override
     public CatalaBool equalsTo(CatalaPosition p, CatalaPosition o) {
@@ -67,11 +65,6 @@ public final class CatalaPosition
         p_pos.accept(this.startLine, this.startColumn);
         b.append(",\"end\":");
         p_pos.accept(this.endLine, this.endColumn);
-        if (!(this.law_headings == null || this.law_headings.length == 0)) {
-            for (String s : this.law_headings) {
-                b.append(",").append(s);
-            }
-        }
         return b.append("}").toString();
     }
 }

--- a/stdlib/java/date_internal.java
+++ b/stdlib/java/date_internal.java
@@ -37,14 +37,14 @@ public class Date_internal {
                 = tup_arg_22 -> {
                     CatalaDate d = CatalaValue.<CatalaDate>cast(tup_arg_22.get(0));
                     CatalaDuration dur = CatalaValue.<CatalaDuration>cast(tup_arg_22.get(1));
-                    return d.addDurationRoundDown(new CatalaPosition("", 0, 0, 0, 0, new String[]{}), dur);
+                    return d.addDurationRoundDown(new CatalaPosition("", 0, 0, 0, 0), dur);
                 };
 
         public static final CatalaFunction<CatalaTuple, CatalaDate> addRoundedUp
                 = tup_arg_23 -> {
                     CatalaDate d = CatalaValue.<CatalaDate>cast(tup_arg_23.get(0));
                     CatalaDuration dur = CatalaValue.<CatalaDuration>cast(tup_arg_23.get(1));
-                    return d.addDurationRoundUp(new CatalaPosition("", 0, 0, 0, 0, new String[]{}), dur);
+                    return d.addDurationRoundUp(new CatalaPosition("", 0, 0, 0, 0), dur);
                 };
     }
 }

--- a/stdlib/java/money_internal.java
+++ b/stdlib/java/money_internal.java
@@ -18,7 +18,7 @@ public class Money_internal {
                         CatalaInteger ten = CatalaInteger.of(10);
                         if (n == 1) {
                             CatalaPosition dummy_pos
-                            = new CatalaPosition("none", 1, 1, 1, 1, null);
+                            = new CatalaPosition("none", 1, 1, 1, 1);
                             return m.multiply(ten).round().divide(dummy_pos, ten);
                         } else {
                             BigInteger pow_ten = ten.asBigInteger().pow(-n);

--- a/tests/modules/good/java/prorata_external.java
+++ b/tests/modules/good/java/prorata_external.java
@@ -5,7 +5,7 @@ public class Prorata_external {
 
     public static class Globals {
 
-        private static final CatalaPosition dummy_position = new CatalaPosition("src/periodes.java", 0, 0, 0, 0, new String[]{});
+        private static final CatalaPosition dummy_position = new CatalaPosition("src/periodes.java", 0, 0, 0, 0);
 
         @SuppressWarnings("unchecked")
         public static final CatalaFunction<CatalaTuple, CatalaArray<CatalaMoney>> prorata

--- a/tests/modules/good/java/text.java
+++ b/tests/modules/good/java/text.java
@@ -5,14 +5,10 @@ public class Text {
     public static class Globals {
 
         public static final CatalaArray<CatalaPosition> loc
-                = new CatalaArray<>(new CatalaPosition("tests/modules/good/text.catala_en", 8, 13, 8, 16,
-                        new String[]{"Text types in Catala"}),
-                        new CatalaPosition("tests/modules/good/text.catala_en", 9, 13, 9, 16,
-                                new String[]{"Text types in Catala"}),
-                        new CatalaPosition("tests/modules/good/text.catala_en", 10, 13, 10, 21,
-                                new String[]{"Text types in Catala"}),
-                        new CatalaPosition("tests/modules/good/text.catala_en", 11, 13, 11, 19,
-                                new String[]{"Text types in Catala"}));
+                = new CatalaArray<>(new CatalaPosition("tests/modules/good/text.catala_en", 8, 13, 8, 16),
+                        new CatalaPosition("tests/modules/good/text.catala_en", 9, 13, 9, 16),
+                        new CatalaPosition("tests/modules/good/text.catala_en", 10, 13, 10, 21),
+                        new CatalaPosition("tests/modules/good/text.catala_en", 11, 13, 11, 19));
 
         static final CatalaFunction<CatalaUnit, Text__1> fooInit = unit -> {
             return new Text__1("foo\\");

--- a/tests/name_resolution/good/toplevel_defs.catala_en
+++ b/tests/name_resolution/good/toplevel_defs.catala_en
@@ -132,9 +132,11 @@ let loc =
     <toplevel_defs:77.24-49>; <toplevel_defs:98.10-11>;
     <toplevel_defs:101.24-35>]
 
-let glob1 = 44.12
+let glob1 =
+  44.12
 
-let glob2 = A {"y": ≥ nth(2) loc glob1 30., "z": 123. * 17.}
+let glob2 =
+  A {"y": ≥ nth(2) loc glob1 30., "z": 123. * 17.}
 
 let s (s_in: #[test] S_in) =
   decl a : decimal;
@@ -154,7 +156,8 @@ let s (s_in: #[test] S_in) =
     b = arg."0";
   return S {"a": a, "b": b}
 
-let glob3 (x: money) = return to_rat x + 10.
+let glob3 (x: money) =
+  return to_rat x + 10.
 
 let s2 (s2_in: #[test] S2_in) =
   decl a : decimal;
@@ -167,7 +170,8 @@ let s2 (s2_in: #[test] S2_in) =
     a = arg."0";
   return S2 {"a": a}
 
-let glob4 (x: money) (y: decimal) = return to_rat x * y + 10.
+let glob4 (x: money) (y: decimal) =
+  return to_rat x * y + 10.
 
 let s3 (s3_in: #[test] S3_in) =
   decl a : decimal;
@@ -187,7 +191,8 @@ let glob5_init =
   y = 1000.;
   return x * y
 
-let glob5 = glob5_init ()
+let glob5 =
+  glob5_init ()
 
 let s4 (s4_in: #[test] S4_in) =
   decl a : decimal;


### PR DESCRIPTION
This PR fixes the issue with the java backend generated too large methods which would yield a "code too large" error.
We introduce an expression split mechanism in the lcalc pass which lifts large lambda-terms into topdefs and replaces the original ones with topdef calls Too large arrays are replaced in the same fashion by concatening the topdef call.
This is enabled by default in java but may also be freely used in the other backends.

Also, scalc scope variable definitions can be split in several functions. This is needed for java as the current concatenation of all expressions as a single block generates too large code that escape the previous mechanism detection. 

We introduce a `--split-threshold` argument that expects an integer (>100) that represents the limit on an expression size before splitting. As we assume a relation between the lcalc lambda terms and the java bytecode, we empirically determined that a "safe" upper bound would be of 10K nodes in the considered lambda-terms. Hence, that is the default value (only in java) if none was provided.

## Checklist

* [x] Update the CHANGELOG.md

### If this PR adds a feature or has breaking changes

* [x] Update the existing Catala code in case of breaking changes at https://github.com/CatalaLang/catala-examples.
  * [x] The corresponding PR is: https://github.com/CatalaLang/catala-examples/pull/58

