### PR TITLE
Bump version to 1.2.1 everywhere

### DIFF
--- a/catala-js.opam
+++ b/catala-js.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "1.2.0"
+version: "1.2.1"
 synopsis:
   "Catala additional tools for javascript"
 description: """

--- a/catala-proof.opam
+++ b/catala-proof.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "1.2.0"
+version: "1.2.1"
 synopsis:
   "Catala proof backend plugin"
 description: """

--- a/catala.opam
+++ b/catala.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "1.2.0"
+version: "1.2.1"
 synopsis:
   "Compiler and library for the literate programming language for tax code specification"
 description: """

--- a/catala.opam.locked
+++ b/catala.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "catala"
-version: "1.2.0"
+version: "1.2.1"
 synopsis:
   "Compiler and library for the literate programming language for tax code specification"
 description:

--- a/doc/syntax/cheat-sheet.typ
+++ b/doc/syntax/cheat-sheet.typ
@@ -2,7 +2,7 @@
 
 #let render_title(title, subtitle) = {
     place(top+left, image("logo.svg", width: 30pt))
-    place(top+right)[v1.2.0 · Revision \#1 · ⓒ #datetime.today().year()]
+    place(top+right)[v1.2.1 · Revision \#1 · ⓒ #datetime.today().year()]
     box(height:30pt, width:100%, align(horizon+center,{
         upper(text(size:15pt, title))
         h(30pt)

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -2,7 +2,7 @@ publiccodeYmlVersion: "0"
 name: Catala
 url: https://github.com/CatalaLang/catala
 landingURL: https://catala-lang.org
-softwareVersion: "1.2.0"
+softwareVersion: "1.2.1"
 releaseDate: "2026-05-29"
 logo: https://github.com/CatalaLang.png
 platforms:

--- a/runtimes/python/pyproject.toml
+++ b/runtimes/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "catala-runtime"
 description = "Runtime libraries needed to execute Catala programs compiled to Python"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
   "gmpy2 ~= 2.2.0rc1",
   "typing",

--- a/runtimes/rescript/package.json
+++ b/runtimes/rescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catala-lang/rescript-catala",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ReScript wrapper for the Catala runtime",
   "scripts": {
     "clean": "rescript clean",


### PR DESCRIPTION
While releasing 1.2.1, I forgot to bump `master` version. It doesn't impact the release as the opam files in the public/private repo are consistent but master's executables will say 1.2.0 instead of 1.2.1.