### PR TITLE
Fix toplevel leftover traces

### DIFF
--- a/compiler/shared_ast/interpreter.ml
+++ b/compiler/shared_ast/interpreter.ml
@@ -1013,6 +1013,7 @@ let evaluate_expr_trace : type d r.
     ((d, r, yes) interpr_kind, 't) gexpr ->
     ((d, r, yes) interpr_kind, 't) gexpr =
  fun ?on_expr ?(disable_trace = false) ctx lang s e ->
+  Runtime.reset_trace ();
   Fun.protect
     (fun () ->
       let f () = evaluate_expr ?on_expr ctx lang e in

--- a/tests/trace/good/bit_of_everything.catala_en
+++ b/tests/trace/good/bit_of_everything.catala_en
@@ -63,54 +63,6 @@ scope T:
 
 ```catala-test-cli
 $ catala interpret -s T --trace
-→ Applying function f
-─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
-  │
-2 │ declaration f
-  │             ‾
-  ⊡ Condition evaluated to true
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
-    │
-  6 │     if x then not x else not x
-    │        ‾
-  ⊸ Branch taken
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.15-20:
-    │
-  6 │     if x then not x else not x
-    │               ‾‾‾‾‾
-← Function f applied: false
-→ Applying function f
-─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
-  │
-2 │ declaration f
-  │             ‾
-  ⊡ Condition evaluated to false
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
-    │
-  6 │     if x then not x else not x
-    │        ‾
-  ⊸ Branch taken
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.26-31:
-    │
-  6 │     if x then not x else not x
-    │                          ‾‾‾‾‾
-← Function f applied: true
-→ Applying function f
-─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
-  │
-2 │ declaration f
-  │             ‾
-  ⊡ Condition evaluated to true
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
-    │
-  6 │     if x then not x else not x
-    │        ‾
-  ⊸ Branch taken
-  ─➤ tests/trace/good/bit_of_everything.catala_en:6.15-20:
-    │
-  6 │     if x then not x else not x
-    │               ‾‾‾‾‾
-← Function f applied: false
 → Entering scope T
 ─➤ tests/trace/good/bit_of_everything.catala_en:24.19-20:
    │

--- a/tests/trace/good/bit_of_everything.catala_en
+++ b/tests/trace/good/bit_of_everything.catala_en
@@ -1,10 +1,13 @@
 ```catala
 declaration f
   content boolean
-  depends on x content integer
+  depends on x content boolean
   equals
-    if x = 0 then false else true
+    if x then not x else not x
 
+declaration l_f content list of boolean
+  equals
+    [ f of true; f of false; f of true ]
 declaration scope A:
   input i content boolean
   output f_scope_a content boolean depends on x content integer
@@ -48,208 +51,277 @@ scope T:
     -- anything : true
 
   definition res equals
-    output of A with { -- i: f of 2 or g of 3 }
+    let x equals
+      match (content of x among l_f such that x) with pattern
+      -- Absent : impossible
+      -- Present content c : c
+    in
+    output of A with { -- i: x or g of 3 }
 
   assertion 42 = 42
 ```
 
 ```catala-test-cli
 $ catala interpret -s T --trace
+→ Applying function f
+─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
+  │
+2 │ declaration f
+  │             ‾
+  ⊡ Condition evaluated to true
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
+    │
+  6 │     if x then not x else not x
+    │        ‾
+  ⊸ Branch taken
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.15-20:
+    │
+  6 │     if x then not x else not x
+    │               ‾‾‾‾‾
+← Function f applied: false
+→ Applying function f
+─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
+  │
+2 │ declaration f
+  │             ‾
+  ⊡ Condition evaluated to false
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
+    │
+  6 │     if x then not x else not x
+    │        ‾
+  ⊸ Branch taken
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.26-31:
+    │
+  6 │     if x then not x else not x
+    │                          ‾‾‾‾‾
+← Function f applied: true
+→ Applying function f
+─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
+  │
+2 │ declaration f
+  │             ‾
+  ⊡ Condition evaluated to true
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-9:
+    │
+  6 │     if x then not x else not x
+    │        ‾
+  ⊸ Branch taken
+  ─➤ tests/trace/good/bit_of_everything.catala_en:6.15-20:
+    │
+  6 │     if x then not x else not x
+    │               ‾‾‾‾‾
+← Function f applied: false
 → Entering scope T
-─➤ tests/trace/good/bit_of_everything.catala_en:21.19-20:
+─➤ tests/trace/good/bit_of_everything.catala_en:24.19-20:
    │
-21 │ declaration scope T:
+24 │ declaration scope T:
    │                   ‾
   ≔ Scope variable definition ssv:
     A {
       -- f_scope_a: <function>
       -- a_A: true
     }
-  ─➤ tests/trace/good/bit_of_everything.catala_en:23.3-6:
+  ─➤ tests/trace/good/bit_of_everything.catala_en:26.3-6:
      │
-  23 │   ssv scope A
+  26 │   ssv scope A
      │   ‾‾‾
     → Entering scope A
     
       ⊕ Definition fulfilled
-      ─➤ tests/trace/good/bit_of_everything.catala_en:28.14-19:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:31.14-19:
          │
-      28 │   definition ssv.i equals let zzz equals 333 in true
+      31 │   definition ssv.i equals let zzz equals 333 in true
          │              ‾‾‾‾‾
       ⊸ Consequence:
-      ─➤ tests/trace/good/bit_of_everything.catala_en:28.27-53:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:31.27-53:
          │
-      28 │   definition ssv.i equals let zzz equals 333 in true
+      31 │   definition ssv.i equals let zzz equals 333 in true
          │                           ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
       ≔ Local variable zzz definition: 333
-      ─➤ tests/trace/good/bit_of_everything.catala_en:28.42-45:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:31.42-45:
          │
-      28 │   definition ssv.i equals let zzz equals 333 in true
+      31 │   definition ssv.i equals let zzz equals 333 in true
          │                                          ‾‾‾
       ≔ Scope input variable definition i: true
-      ─➤ tests/trace/good/bit_of_everything.catala_en:9.9-10:
-        │
-      9 │   input i content boolean
-        │         ‾
-      ≔ Scope variable definition f_scope_a: <function>
-      ─➤ tests/trace/good/bit_of_everything.catala_en:10.10-19:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:12.9-10:
          │
-      10 │   output f_scope_a content boolean depends on x content integer
+      12 │   input i content boolean
+         │         ‾
+      ≔ Scope variable definition f_scope_a: <function>
+      ─➤ tests/trace/good/bit_of_everything.catala_en:13.10-19:
+         │
+      13 │   output f_scope_a content boolean depends on x content integer
          │          ‾‾‾‾‾‾‾‾‾
       ≔ Scope variable definition a_A: true
-      ─➤ tests/trace/good/bit_of_everything.catala_en:11.10-13:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:14.10-13:
          │
-      11 │   output a_A content boolean
+      14 │   output a_A content boolean
          │          ‾‾‾
         ⊕ Definition fulfilled
-        ─➤ tests/trace/good/bit_of_everything.catala_en:18.14-17:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:21.14-17:
            │
-        18 │   definition a_A equals i
+        21 │   definition a_A equals i
            │              ‾‾‾
         ⊸ Consequence:
-        ─➤ tests/trace/good/bit_of_everything.catala_en:18.25-26:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:21.25-26:
            │
-        18 │   definition a_A equals i
+        21 │   definition a_A equals i
            │                         ‾
     ← Exiting Scope A: A {
                            -- f_scope_a: <function>
                            -- a_A: true
                          }
   ≔ Scope variable definition a_T: false
-  ─➤ tests/trace/good/bit_of_everything.catala_en:22.10-13:
+  ─➤ tests/trace/good/bit_of_everything.catala_en:25.10-13:
      │
-  22 │   output a_T content boolean
+  25 │   output a_T content boolean
      │          ‾‾‾
     ⊕ Definition two not fulfilled
-    ─➤ tests/trace/good/bit_of_everything.catala_en:41.19-26:
+    ─➤ tests/trace/good/bit_of_everything.catala_en:44.19-26:
        │
-    41 │   under condition 43 > 43
+    44 │   under condition 43 > 43
        │                   ‾‾‾‾‾‾‾
     ⊕ Definition one fulfilled
-    ─➤ tests/trace/good/bit_of_everything.catala_en:35.19-26:
+    ─➤ tests/trace/good/bit_of_everything.catala_en:38.19-26:
        │
-    35 │   under condition 42 = 42
+    38 │   under condition 42 = 42
        │                   ‾‾‾‾‾‾‾
     ⊸ Consequence:
-    ─➤ tests/trace/good/bit_of_everything.catala_en:37.5-16:
+    ─➤ tests/trace/good/bit_of_everything.catala_en:40.5-16:
        │
-    37 │     not ssv.a_A
+    40 │     not ssv.a_A
        │     ‾‾‾‾‾‾‾‾‾‾‾
   ≔ Scope variable definition g: <function>
-  ─➤ tests/trace/good/bit_of_everything.catala_en:24.12-13:
+  ─➤ tests/trace/good/bit_of_everything.catala_en:27.12-13:
      │
-  24 │   internal g content boolean depends on x content integer
+  27 │   internal g content boolean depends on x content integer
      │            ‾
   ≔ Scope variable definition res:
     A {
       -- f_scope_a: <function>
       -- a_A: true
     }
-  ─➤ tests/trace/good/bit_of_everything.catala_en:25.10-13:
+  ─➤ tests/trace/good/bit_of_everything.catala_en:28.10-13:
      │
-  25 │   output res content A
+  28 │   output res content A
      │          ‾‾‾
     ⊕ Definition fulfilled
-    ─➤ tests/trace/good/bit_of_everything.catala_en:50.14-17:
+    ─➤ tests/trace/good/bit_of_everything.catala_en:53.14-17:
        │
-    50 │   definition res equals
+    53 │   definition res equals
        │              ‾‾‾
     ⊸ Consequence:
-    ─➤ tests/trace/good/bit_of_everything.catala_en:51.5-48:
+    ─➤ tests/trace/good/bit_of_everything.catala_en:54.5-59.43:
        │
-    51 │     output of A with { -- i: f of 2 or g of 3 }
-       │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-    → Entering scope A
-    
-      → Applying function f
-      ─➤ tests/trace/good/bit_of_everything.catala_en:2.13-14:
-        │
-      2 │ declaration f
-        │             ‾
-        ⊡ Condition evaluated to false
-        ─➤ tests/trace/good/bit_of_everything.catala_en:6.8-13:
-          │
-        6 │     if x = 0 then false else true
-          │        ‾‾‾‾‾
-        ⊸ Branch taken
-        ─➤ tests/trace/good/bit_of_everything.catala_en:6.30-34:
-          │
-        6 │     if x = 0 then false else true
-          │                              ‾‾‾‾
-      ← Function f applied: true
-      → Applying function g
-      ─➤ tests/trace/good/bit_of_everything.catala_en:51.40-41:
+    54 │     let x equals
+       │     ‾‾‾‾‾‾‾‾‾‾‾‾
+    55 │       match (content of x among l_f such that x) with pattern
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    56 │       -- Absent : impossible
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    57 │       -- Present content c : c
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    58 │     in
+       │     ‾‾
+    59 │     output of A with { -- i: x or g of 3 }
+       │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    ≔ Local variable x definition: true
+    ─➤ tests/trace/good/bit_of_everything.catala_en:55.7-57.31:
+       │
+    55 │       match (content of x among l_f such that x) with pattern
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    56 │       -- Absent : impossible
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    57 │       -- Present content c : c
+       │       ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+      ⊡ Condition evaluated to Present content true
+      ─➤ tests/trace/good/bit_of_everything.catala_en:55.13-49:
          │
-      51 │     output of A with { -- i: f of 2 or g of 3 }
-         │                                        ‾
+      55 │       match (content of x among l_f such that x) with pattern
+         │             ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+      ⊸ Branch taken: case Present
+      ─➤ tests/trace/good/bit_of_everything.catala_en:57.30-31:
+         │
+      57 │       -- Present content c : c
+         │                              ‾
+    → Entering scope A
+    ─➤ tests/trace/good/bit_of_everything.catala_en:59.5-43:
+       │
+    59 │     output of A with { -- i: x or g of 3 }
+       │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+      → Applying function g
+      ─➤ tests/trace/good/bit_of_everything.catala_en:59.35-36:
+         │
+      59 │     output of A with { -- i: x or g of 3 }
+         │                                   ‾
         ⊕ Definition fulfilled
-        ─➤ tests/trace/good/bit_of_everything.catala_en:45.14-15:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:48.14-15:
            │
-        45 │   definition g of x equals
+        48 │   definition g of x equals
            │              ‾
         ⊸ Consequence:
-        ─➤ tests/trace/good/bit_of_everything.catala_en:46.5-48.23:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:49.5-51.23:
            │
-        46 │     match (if x = 3 then Absent else Present content 3) with pattern
+        49 │     match (if x = 3 then Absent else Present content 3) with pattern
            │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-        47 │     -- Absent : false
+        50 │     -- Absent : false
            │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
-        48 │     -- anything : true
+        51 │     -- anything : true
            │     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
         ⊡ Condition evaluated to Absent
-        ─➤ tests/trace/good/bit_of_everything.catala_en:46.11-56:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:49.11-56:
            │
-        46 │     match (if x = 3 then Absent else Present content 3) with pattern
+        49 │     match (if x = 3 then Absent else Present content 3) with pattern
            │           ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
           ⊡ Condition evaluated to true
-          ─➤ tests/trace/good/bit_of_everything.catala_en:46.15-20:
+          ─➤ tests/trace/good/bit_of_everything.catala_en:49.15-20:
              │
-          46 │     match (if x = 3 then Absent else Present content 3) with pattern
+          49 │     match (if x = 3 then Absent else Present content 3) with pattern
              │               ‾‾‾‾‾
           ⊸ Branch taken
-          ─➤ tests/trace/good/bit_of_everything.catala_en:46.26-32:
+          ─➤ tests/trace/good/bit_of_everything.catala_en:49.26-32:
              │
-          46 │     match (if x = 3 then Absent else Present content 3) with pattern
+          49 │     match (if x = 3 then Absent else Present content 3) with pattern
              │                          ‾‾‾‾‾‾
         ⊸ Branch taken: case Absent
-        ─➤ tests/trace/good/bit_of_everything.catala_en:47.17-22:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:50.17-22:
            │
-        47 │     -- Absent : false
+        50 │     -- Absent : false
            │                 ‾‾‾‾‾
       ← Function g applied: false
       ≔ Scope input variable definition i: true
-      ─➤ tests/trace/good/bit_of_everything.catala_en:9.9-10:
-        │
-      9 │   input i content boolean
-        │         ‾
-      ≔ Scope variable definition f_scope_a: <function>
-      ─➤ tests/trace/good/bit_of_everything.catala_en:10.10-19:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:12.9-10:
          │
-      10 │   output f_scope_a content boolean depends on x content integer
+      12 │   input i content boolean
+         │         ‾
+      ≔ Scope variable definition f_scope_a: <function>
+      ─➤ tests/trace/good/bit_of_everything.catala_en:13.10-19:
+         │
+      13 │   output f_scope_a content boolean depends on x content integer
          │          ‾‾‾‾‾‾‾‾‾
       ≔ Scope variable definition a_A: true
-      ─➤ tests/trace/good/bit_of_everything.catala_en:11.10-13:
+      ─➤ tests/trace/good/bit_of_everything.catala_en:14.10-13:
          │
-      11 │   output a_A content boolean
+      14 │   output a_A content boolean
          │          ‾‾‾
         ⊕ Definition fulfilled
-        ─➤ tests/trace/good/bit_of_everything.catala_en:18.14-17:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:21.14-17:
            │
-        18 │   definition a_A equals i
+        21 │   definition a_A equals i
            │              ‾‾‾
         ⊸ Consequence:
-        ─➤ tests/trace/good/bit_of_everything.catala_en:18.25-26:
+        ─➤ tests/trace/good/bit_of_everything.catala_en:21.25-26:
            │
-        18 │   definition a_A equals i
+        21 │   definition a_A equals i
            │                         ‾
     ← Exiting Scope A: A {
                            -- f_scope_a: <function>
                            -- a_A: true
                          }
   ⊹ Assertion
-  ─➤ tests/trace/good/bit_of_everything.catala_en:53.3-20:
+  ─➤ tests/trace/good/bit_of_everything.catala_en:61.3-20:
      │
-  53 │   assertion 42 = 42
+  61 │   assertion 42 = 42
      │   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 ← Exiting Scope T:
   T {


### PR DESCRIPTION
This PR removes some leftover traces from the first of the "double-evaluation" that we perform. Incidentally, it makes the trace less precise as we lose what was done in the first beta-reduction. We might want to offer different level of details.