### PR TITLE
Merge back adjacent LawText nodes together before calling pandoc

### DIFF
--- a/compiler/literate/html.ml
+++ b/compiler/literate/html.ml
@@ -135,7 +135,7 @@ let rec law_structure_to_html
     (parents_headings : string list)
     (fmt : Format.formatter)
     (i : A.law_structure) : unit =
-  match i with
+  match merge_adjacent_lawtext i with
   | A.LawText t ->
     let t = pre_html t in
     if t = "" then () else Format.fprintf fmt "<div class='law-text'>%s</div>" t

--- a/compiler/literate/latex.ml
+++ b/compiler/literate/latex.ml
@@ -296,9 +296,7 @@ let rec law_structure_to_latex
       | `Fr -> Format.fprintf fmt " sous le nom \\texttt{%s}}"
       | _ -> Format.fprintf fmt " under the name \\texttt{%s}}")
         (pre_latexify (Mark.remove al)))
-  | A.LawText t ->
-    Message.debug "Pandoc %s" t;
-    Format.fprintf fmt "%s" (pre_latexify t)
+  | A.LawText t -> Format.fprintf fmt "%s" (pre_latexify t)
   | A.CodeBlock (_, c, false) when not print_only_law ->
     let start_line = Pos.get_start_line (Mark.get c) + 1 in
     let filename = Pos.get_file (Mark.get c) in

--- a/compiler/literate/latex.ml
+++ b/compiler/literate/latex.ml
@@ -241,7 +241,7 @@ let rec law_structure_to_latex
     (print_only_law : bool)
     (fmt : Format.formatter)
     (i : A.law_structure) : unit =
-  match i with
+  match merge_adjacent_lawtext i with
   | A.LawHeading (heading, children) ->
     Format.fprintf fmt "\\%s{%s}\n\n"
       (match heading.law_heading_precedence with
@@ -296,7 +296,9 @@ let rec law_structure_to_latex
       | `Fr -> Format.fprintf fmt " sous le nom \\texttt{%s}}"
       | _ -> Format.fprintf fmt " under the name \\texttt{%s}}")
         (pre_latexify (Mark.remove al)))
-  | A.LawText t -> Format.fprintf fmt "%s" (pre_latexify t)
+  | A.LawText t ->
+    Message.debug "Pandoc %s" t;
+    Format.fprintf fmt "%s" (pre_latexify t)
   | A.CodeBlock (_, c, false) when not print_only_law ->
     let start_line = Pos.get_start_line (Mark.get c) + 1 in
     let filename = Pos.get_file (Mark.get c) in

--- a/compiler/literate/literate_common.ml
+++ b/compiler/literate/literate_common.ml
@@ -138,3 +138,20 @@ let call_pygmentize ?lang args =
   | Some lang ->
     with_pygmentize_lexer lang
     @@ fun lex_args -> File.process_out ~check_exit cmd (lex_args @ args)
+
+let rec merge_adjacent_lawtext (i : Surface.Ast.law_structure) :
+    Surface.Ast.law_structure =
+  let open Surface.Ast in
+  match i with
+  | LawHeading (h, c) ->
+    LawHeading
+      ( h,
+        List.rev
+          (List.fold_left
+             (fun acc next_block ->
+               match acc, next_block with
+               | LawText t1 :: tl, LawText t2 -> LawText (t1 ^ "\n" ^ t2) :: tl
+               | _ -> next_block :: acc)
+             []
+             (List.map merge_adjacent_lawtext c)) )
+  | LawInclude _ | ModuleDef _ | ModuleUse _ | CodeBlock _ | LawText _ -> i

--- a/compiler/literate/literate_common.mli
+++ b/compiler/literate/literate_common.mli
@@ -58,3 +58,11 @@ val call_pygmentize : ?lang:Global.backend_lang -> string list -> string
 val with_pygmentize_lexer : Global.backend_lang -> (string list -> 'a) -> 'a
 (** Creates the required lexer file and returns the corresponding [pygmentize]
     command-line arguments *)
+
+val merge_adjacent_lawtext :
+  Surface.Ast.law_structure -> Surface.Ast.law_structure
+(** Traverses the tree header structure of the legal text and merges adjacent
+    [LawText] nodes, separating them with "\n". This has the effect of putting
+    together lines of text that would have been separated in the tree otherwise.
+    Use this function before feeding the legal text to `pandoc`, as the Catala
+    lexer separates lines of legal text into adjacent [LawText]. *)

--- a/tests-extra/literate/good/test_grave_char_en.catala_en
+++ b/tests-extra/literate/good/test_grave_char_en.catala_en
@@ -63,42 +63,21 @@ $ catala latex
 /subsection{Law text should be able to contain backquote chars
 /texttt{/textasciigrave{}}.}
 
-
-
 This is a block of law text containing `. This allows to:
 
-
-
 /begin{itemize}
-/tightlist
 /item
   use /texttt{Markdown} code block inside /texttt{Catala} files,
-/end{itemize}
-
-
-
-/begin{itemize}
-/tightlist
 /item
   /emph{escape} special characters such as /texttt{/#} or
   /texttt{/textgreater{}},
-/end{itemize}
-
-
-
-/begin{itemize}
-/tightlist
 /item
   use Fenced Code Blocks:
 /end{itemize}
 
-
-
 /begin{verbatim}
 let () = print_endline "Hello world!"
 /end{verbatim}
-
-
 
 /begin{Verbatim}[commandchars=//{/},numbers=left,firstnumber=19,stepnumber=1,label={/hspace*{/fill}/texttt{test/_grave/_char/_en.catala/_en}}]
 /```catala
@@ -111,17 +90,11 @@ let () = print_endline "Hello world!"
 /end{Verbatim}
 
 
-
-
 Even after /texttt{Catala} code block:
-
-
 
 /begin{verbatim}
 int main(void) { return 0; }
 /end{verbatim}
-
-
 
 /begin{verbatim}
 $ catala Typecheck --check-invariants
@@ -133,8 +106,6 @@ $ catala Typecheck --check-invariants
 └─
 /end{verbatim}
 
-
-
 /begin{verbatim}
 $ catala test-scope A
 ┌─[RESULT]─ A ─
@@ -142,14 +113,10 @@ $ catala test-scope A
 └─
 /end{verbatim}
 
-
-
 /begin{verbatim}
 $ catala test-scope A
 ┌─[RESULT]─ A ─
 │ literate_parsing_is_ok = true
 └─
 /end{verbatim}
-
-
 ```


### PR DESCRIPTION
This PR restores the correct styling by pandoc of blocks of legal text containing multi-line artefacts like table. Since we call pandoc separately on each `LawText` block and that our lexer/parser creates a new `LawText` block from each different line, pandoc never saw the whole tables but only lines of it, preventing it from rendering it correctly.