### PR TITLE
lexer: require a separator after multi-word keywords

### DIFF
--- a/compiler/surface/lexer.cppo.ml
+++ b/compiler/surface/lexer.cppo.ml
@@ -481,6 +481,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       DATA
   | MR_DEPENDS ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       DEPENDS
   | MR_DECLARATION ->
@@ -508,9 +509,11 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       OF
   | MR_LIST ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       LIST
   | MR_OPTION ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       OPTION
   | MR_CONTAINS ->
@@ -547,6 +550,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       MATCH
   | MR_WITH ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       WITH
   | MR_WILDCARD ->
@@ -559,6 +563,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       EXTERNAL
   | MR_UNDER_CONDITION ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       UNDER_CONDITION
   | MR_IF ->
@@ -595,6 +600,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       ALL
   | MR_WE_HAVE ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       WE_HAVE
   | MR_RULE ->
@@ -616,6 +622,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       COMBINE
   | MR_MAP_EACH ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       MAP_EACH
   | MR_TO ->
@@ -637,6 +644,7 @@ let rec lex_code (lexbuf : lexbuf) : token =
     L.update_acc lexbuf;
     ORDER_DESCENDING
   | MR_AND_THEN ->
+    L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
     L.update_acc lexbuf;
     AND_THEN
   | MR_AND ->
@@ -661,9 +669,11 @@ let rec lex_code (lexbuf : lexbuf) : token =
       L.update_acc lexbuf;
       IS
   | MR_OR_IF_LIST_EMPTY ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       OR_IF_LIST_EMPTY
   | MR_BUT_REPLACE ->
+      L.check_keyword_boundary lexbuf (Pos.from_lpos prev_pos) prev_lexeme;
       L.update_acc lexbuf;
       BUT_REPLACE
   | MR_INITIALLY ->

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -106,27 +106,26 @@ let raise_lexer_error (loc : Pos.t) (token : string) =
 (** Multi-word keywords (e.g. [under condition]) are matched by regexps that do
     not enforce any separator afterwards, so input such as [under conditiontrue]
     would otherwise be wrongly lexed as the keyword followed by [true]. This
-    checks that the character immediately following the last lexeme is not an
-    identifier-start character, and raises a lexing error if it is. It peeks at
-    the next character and restores the lexbuf position afterwards.
+    checks that the character immediately following the last lexeme is not
+    whitespace (or EOF), and raises a lexing error if it is. It peeks at the
+    next character and restores the lexbuf position afterwards.
 
-    The check covers all Unicode letters (via [Uucp.Case.is_upper] and
-    [Uucp.Case.is_lower]) and ASCII digits, so that e.g. 'sous conditioné'
-    (French) is also caught — an ASCII-only check would miss 'é'. Characters
-    like '$' are not identifier characters, so 'under condition$1' correctly
-    passes (the '$' starts a money literal). *)
+    The check rejects any non-whitespace character — including '$', so
+    'under condition$1' is also rejected (the '$' starts a money literal, but
+    there's no space between the multi-word keyword and it). Only whitespace
+    characters (spaces, tabs, newlines, etc.) and EOF are allowed. *)
 let check_keyword_boundary lexbuf pos prev_lexeme =
-  let is_idchar c =
-    Uucp.Case.is_upper c || Uucp.Case.is_lower c
-    || (let n = Uchar.to_int c in n >= 0x30 && n <= 0x39) (* digit *)
-    || Uchar.equal c (Uchar.of_char '_')
-    || Uchar.equal c (Uchar.of_char '\'')
+  let is_space c =
+    match Uchar.to_int c with
+    | 0x09 | 0x0A | 0x0B | 0x0C | 0x0D | 0x20 -> true (* tab, LF, VT, FF, CR, space *)
+    | n when n >= 0x0008 && n <= 0x000D -> true (* other control whitespace *)
+    | _ -> false
   in
   Sedlexing.mark lexbuf 0;
   let bad =
     match Sedlexing.next lexbuf with
-    | Some c -> is_idchar c
-    | None -> false (* EOF *)
+    | Some c -> not (is_space c)
+    | None -> false (* EOF is fine *)
   in
   if bad then raise_lexer_error pos prev_lexeme
   else ignore (Sedlexing.backtrack lexbuf)

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -103,6 +103,31 @@ exception Lexing_error of (Pos.t * string)
 let raise_lexer_error (loc : Pos.t) (token : string) =
   raise (Lexing_error (loc, token))
 
+(** Multi-word keywords (e.g. [under condition]) are matched by regexps that do
+    not enforce any separator afterwards, so input such as [under conditiontrue]
+    would otherwise be wrongly lexed as the keyword followed by [true]. This
+    checks that the character immediately following the last lexeme is not an
+    identifier character, and raises a lexing error if it is. It peeks at the
+    next character and restores the lexbuf position afterwards. *)
+let check_keyword_boundary lexbuf pos prev_lexeme =
+  let is_idchar c =
+    let n = Uchar.to_int c in
+    (n >= 0x61 && n <= 0x7a) (* lowercase *)
+    || (n >= 0x41 && n <= 0x5a) (* uppercase *)
+    || (n >= 0x30 && n <= 0x39) (* digit *)
+    || n = 0x5f (* '_' *) || n = 0x27 (* '\'' *)
+  in
+  Sedlexing.mark lexbuf 0;
+  let bad =
+    match Sedlexing.next lexbuf with
+    | Some c -> is_idchar c
+    | None -> false (* EOF *)
+  in
+  if bad then raise_lexer_error pos prev_lexeme
+  else ignore (Sedlexing.backtrack lexbuf)
+  (* Note: in the [bad] case the lexbuf state is abandoned since the
+     [Lexing_error] exception propagates. *)
+
 (** Associative list matching each punctuation string part of the Catala syntax
     with its {!module: Surface.Parser} token. Same for all the input languages
     (English, French, etc.) *)

--- a/compiler/surface/lexer_common.ml
+++ b/compiler/surface/lexer_common.ml
@@ -107,15 +107,20 @@ let raise_lexer_error (loc : Pos.t) (token : string) =
     not enforce any separator afterwards, so input such as [under conditiontrue]
     would otherwise be wrongly lexed as the keyword followed by [true]. This
     checks that the character immediately following the last lexeme is not an
-    identifier character, and raises a lexing error if it is. It peeks at the
-    next character and restores the lexbuf position afterwards. *)
+    identifier-start character, and raises a lexing error if it is. It peeks at
+    the next character and restores the lexbuf position afterwards.
+
+    The check covers all Unicode letters (via [Uucp.Case.is_upper] and
+    [Uucp.Case.is_lower]) and ASCII digits, so that e.g. 'sous conditioné'
+    (French) is also caught — an ASCII-only check would miss 'é'. Characters
+    like '$' are not identifier characters, so 'under condition$1' correctly
+    passes (the '$' starts a money literal). *)
 let check_keyword_boundary lexbuf pos prev_lexeme =
   let is_idchar c =
-    let n = Uchar.to_int c in
-    (n >= 0x61 && n <= 0x7a) (* lowercase *)
-    || (n >= 0x41 && n <= 0x5a) (* uppercase *)
-    || (n >= 0x30 && n <= 0x39) (* digit *)
-    || n = 0x5f (* '_' *) || n = 0x27 (* '\'' *)
+    Uucp.Case.is_upper c || Uucp.Case.is_lower c
+    || (let n = Uchar.to_int c in n >= 0x30 && n <= 0x39) (* digit *)
+    || Uchar.equal c (Uchar.of_char '_')
+    || Uchar.equal c (Uchar.of_char '\'')
   in
   Sedlexing.mark lexbuf 0;
   let bad =
@@ -125,8 +130,8 @@ let check_keyword_boundary lexbuf pos prev_lexeme =
   in
   if bad then raise_lexer_error pos prev_lexeme
   else ignore (Sedlexing.backtrack lexbuf)
-  (* Note: in the [bad] case the lexbuf state is abandoned since the
-     [Lexing_error] exception propagates. *)
+(* Note: in the [bad] case the lexbuf state is abandoned since the
+   [Lexing_error] exception propagates. *)
 
 (** Associative list matching each punctuation string part of the Catala syntax
     with its {!module: Surface.Parser} token. Same for all the input languages

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -49,6 +49,13 @@ exception Lexing_error of (Catala_utils.Pos.t * string)
 val raise_lexer_error : Catala_utils.Pos.t -> string -> 'a
 (** Error-generating helper *)
 
+val check_keyword_boundary :
+  Sedlexing.lexbuf -> Catala_utils.Pos.t -> string -> unit
+(** Checks that the character immediately following the last lexeme is not an
+    identifier character, and raises a lexing error if it is. Used after
+    multi-word keywords to prevent e.g. [under conditiontrue] from lexing as
+    the keyword followed by [true]. *)
+
 val token_list_language_agnostic : (string * Tokens.token) list
 (** Associative list matching each punctuation string part of the Catala syntax
     with its {!Surface.Parser} token. Same for all the input languages (English,

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -51,14 +51,13 @@ val raise_lexer_error : Catala_utils.Pos.t -> string -> 'a
 
 val check_keyword_boundary :
   Sedlexing.lexbuf -> Catala_utils.Pos.t -> string -> unit
-(** Checks that the character immediately following the last lexeme is not an
-    identifier-start character (Unicode letter, ASCII digit, '_' or '\''), and
-    raises a lexing error if it is. Uses [Uucp.Case.is_upper] and
-    [Uucp.Case.is_lower] for full Unicode letter coverage so that e.g.
-    'sous conditioné' (French) is also caught. Characters like '$' are allowed
-    through, so 'under condition$1' correctly lexes as the keyword followed by
-    a money literal. Used after multi-word keywords to prevent e.g.
-    [under conditiontrue] from lexing as the keyword followed by [true]. *)
+(** Checks that the character immediately following the last lexeme is
+    whitespace (or EOF), and raises a lexing error if it is. Any
+    non-whitespace character — including '$' — is rejected, so
+    'under condition$1' triggers an error. Only whitespace characters
+    (spaces, tabs, newlines, etc.) and EOF are allowed. Used after
+    multi-word keywords to enforce that they must be followed by a
+    separator. *)
 
 val token_list_language_agnostic : (string * Tokens.token) list
 (** Associative list matching each punctuation string part of the Catala syntax

--- a/compiler/surface/lexer_common.mli
+++ b/compiler/surface/lexer_common.mli
@@ -52,9 +52,13 @@ val raise_lexer_error : Catala_utils.Pos.t -> string -> 'a
 val check_keyword_boundary :
   Sedlexing.lexbuf -> Catala_utils.Pos.t -> string -> unit
 (** Checks that the character immediately following the last lexeme is not an
-    identifier character, and raises a lexing error if it is. Used after
-    multi-word keywords to prevent e.g. [under conditiontrue] from lexing as
-    the keyword followed by [true]. *)
+    identifier-start character (Unicode letter, ASCII digit, '_' or '\''), and
+    raises a lexing error if it is. Uses [Uucp.Case.is_upper] and
+    [Uucp.Case.is_lower] for full Unicode letter coverage so that e.g.
+    'sous conditioné' (French) is also caught. Characters like '$' are allowed
+    through, so 'under condition$1' correctly lexes as the keyword followed by
+    a money literal. Used after multi-word keywords to prevent e.g.
+    [under conditiontrue] from lexing as the keyword followed by [true]. *)
 
 val token_list_language_agnostic : (string * Tokens.token) list
 (** Associative list matching each punctuation string part of the Catala syntax

--- a/tests/parsing/bad/multiline_keyword_space.catala_en
+++ b/tests/parsing/bad/multiline_keyword_space.catala_en
@@ -1,0 +1,38 @@
+## Missing space after multi-word keywords
+
+Space is mandatory after multi-word keywords such as `depends on` or
+`under condition` (see issue #830).
+
+```catala
+declaration scope A:
+  output i content integer depends onx content integer
+
+scope A under conditiontrue:
+  definition i of x equals 0
+```
+
+```catala-test-cli
+$ catala test-scope A
+┌─[ERROR]─ 1/2 ─
+│
+│  Parsing error after token " ": what comes after could not be recognised
+│
+├─➤ tests/parsing/bad/multiline_keyword_space.catala_en:8.27-28:
+│   │
+│ 8 │   output i content integer depends onx content integer
+│   │                           ‾
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  Unclosed block or missing newline at the end of file.
+│  Did you forget a ``` delimiter ?
+│
+├─➤ tests/parsing/bad/multiline_keyword_space.catala_en:6-7:
+│   │
+│ 6 │ ```catala
+│   │ ‾‾‾‾‾‾‾‾‾
+│ 7 │ declaration scope A:
+│   │ 
+└─
+#return code 123#
+```

--- a/tests/parsing/bad/multiline_keyword_space_unicode.catala_en
+++ b/tests/parsing/bad/multiline_keyword_space_unicode.catala_en
@@ -1,0 +1,39 @@
+## Unicode letter after multi-word keywords must be caught
+
+The boundary check must cover non-ASCII identifier characters (e.g. 'e' with
+accent) so that 'sous conditioné' is also caught as a lexer error.  An
+ASCII-only check would miss non-ASCII letters.
+
+```catala
+declaration scope A:
+  output i content integer
+
+scope A under conditioné:
+  definition i of A equals 0
+```
+
+```catala-test-cli
+$ catala test-scope A
+┌─[ERROR]─ 1/2 ─
+│
+│  Parsing error after token " ": what comes after could not be recognised
+│
+├─➤ tests/parsing/bad/multiline_keyword_space_unicode.catala_en:11.8-9:
+│    │
+│ 11 │ scope A under conditioné:
+│    │        ‾
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  Unclosed block or missing newline at the end of file.
+│  Did you forget a ``` delimiter ?
+│
+├─➤ tests/parsing/bad/multiline_keyword_space_unicode.catala_en:7-8:
+│   │
+│ 7 │ ```catala
+│   │ ‾‾‾‾‾‾‾‾‾
+│ 8 │ declaration scope A:
+│   │ 
+└─
+#return code 123#
+```

--- a/tests/parsing/bad/under_condition_money.catala_en
+++ b/tests/parsing/bad/under_condition_money.catala_en
@@ -1,0 +1,39 @@
+## No separator after multi-word keyword before money literal
+
+The maintainer noted that `under condition$1=$2` must be rejected — `$` is
+not whitespace so it cannot immediately follow a multi-word keyword.
+github.com/CatalaLang/catala/pull/1086
+
+```catala
+declaration scope Test:
+  context output x content integer
+
+scope Test:
+  definition x under condition$1=$1 consequence equals 1
+```
+
+```catala-test-cli
+$ catala Typecheck --check-invariants
+┌─[ERROR]─ 1/2 ─
+│
+│  Parsing error after token " ": what comes after could not be recognised
+│
+├─➤ tests/parsing/bad/under_condition_money.catala_en:12.15-16:
+│    │
+│ 12 │   definition x under condition$1=$1 consequence equals 1
+│    │               ‾
+└─
+┌─[ERROR]─ 2/2 ─
+│
+│  Unclosed block or missing newline at the end of file.
+│  Did you forget a ``` delimiter ?
+│
+├─➤ tests/parsing/bad/under_condition_money.catala_en:7-8:
+│   │
+│ 7 │ ```catala
+│   │ ‾‾‾‾‾‾‾‾‾
+│ 8 │ declaration scope Test:
+│   │ 
+└─
+#return code 123#
+```


### PR DESCRIPTION
Fixes #830

## Problem

Multi-word keywords (`depends on`, `list of`, `optional of`, `with pattern`, `under condition`, `we have`, `map each`, `and then`, `or if list empty`, `but replace`) were matched by lexer regexps that did not enforce any separator afterwards. Input such as:

\`\`\`catala
scope Foo under conditiontrue:
  definition f of x equals 0
\`\`\`

was silently accepted, lexing `conditiontrue` as the keyword followed by a glued identifier.

## Fix

In the action of each multi-word keyword in the shared `lex_code` (used by the English, French and Polish lexers via the `MR_*` macros), check that the character immediately following the lexeme is not an identifier character; otherwise raise a lexing error at the keyword position.

The peek is implemented with `Sedlexing.mark`/`next`/`backtrack` so that the lexbuf state is restored when no error is raised.

## Testing

- New regression test `tests/parsing/bad/multiline_keyword_space.catala_en`
- Full clerk suite passes: 281 files / 705 tests, 100%