### PR TITLE
Java fixes

### DIFF
--- a/.woodpecker/windows.yaml
+++ b/.woodpecker/windows.yaml
@@ -53,6 +53,8 @@ steps:
       - (& opam env) -split '\r?\n' | ForEach-Object { Invoke-Expression $$_ }
       - dune exec -- clerk test tests doc
       - dune exec -- clerk test tests --backend ocaml -c--disable-warnings --vars CC=x86_64-w64-mingw32-gcc
+      - dune exec -- clerk test tests --backend java -c--disable-warnings
+      - dune exec -- clerk test tests --backend c -c--disable-warnings --vars CC=x86_64-w64-mingw32-gcc
 
   - name: examples
     image: powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,7 @@ in behavior visible for the end-users of the tooling.
     library definition files in OCaml and Python (more to come)
   - In general, better handling of caching and faster builds (made sure in
     particular that the underlying `ninja` build process is run only once)
+
+* [#1087](https://github.com/CatalaLang/catala/pull/1087/) Escape
+  non-ascii characters in Java backend strings as unicode. All Java
+  strings are now agnostic of encodings.

--- a/compiler/scalc/to_java.ml
+++ b/compiler/scalc/to_java.ml
@@ -334,12 +334,28 @@ let poly_cast ctx ppf e fmt =
       (format_typ ctx) typ
   | _ -> fprintf ppf fmt
 
-(* [String.quote] the filename so Windows backslashes survive as a Java string
+(* Quote as a Java string literal, escaping every non-ASCII character: javac
+   reads source in the platform encoding (cp1252 on Windows), which mangles or
+   rejects raw UTF-8. Java expands [\uXXXX] — a UTF-16 code unit — back before
+   lexing, so the string value is unchanged. *)
+let java_string s =
+  let utf16 = Buffer.create (2 * String.length s) in
+  Seq.iter (Buffer.add_utf_16be_uchar utf16) (String.utf8_seq (String.quote s));
+  let utf16 = Buffer.contents utf16 in
+  let buf = Buffer.create (String.length utf16) in
+  for i = 0 to (String.length utf16 / 2) - 1 do
+    let u = String.get_uint16_be utf16 (2 * i) in
+    if u < 0x80 then Buffer.add_char buf (Char.chr u)
+    else Format.ksprintf (Buffer.add_string buf) "\\u%04x" u
+  done;
+  Buffer.contents buf
+
+(* [java_string] the filename so Windows backslashes survive as a Java string
    literal (unescaped "C:\proj\mod" is an illegal escape). *)
 let format_pos (ppf : formatter) (pos : Pos.t) : unit =
   fprintf ppf
     "@[<hv 2>new CatalaPosition@;<0 -1>(@[<hov>%s,@ %d, %d,@ %d, %d@])@]"
-    (String.quote (Pos.get_file pos))
+    (java_string (Pos.get_file pos))
     (Pos.get_start_line pos) (Pos.get_start_column pos) (Pos.get_end_line pos)
     (Pos.get_end_column pos)
 
@@ -417,23 +433,13 @@ let rec format_expression ctx (ppf : formatter) (e : expr) : unit =
   | ELit l -> fprintf ppf "%a" format_lit (Mark.copy e l)
   | EPosLit -> format_pos ppf (Mark.get e)
   | EAppOp { op = ValueFromJson (ty, str), p; args = [_e]; _ } ->
-    let encoded_string =
-      (* Java needs utf-16, we quote the string then escape the non-latin1
-         characters *)
-      let buf = Buffer.create (String.length str) in
-      String.quote str
-      |> String.utf8_seq
-      |> Seq.iter (fun c ->
-          if Uchar.is_char c then Buffer.add_char buf (Uchar.to_char c)
-          else
-            Format.ksprintf (Buffer.add_string buf) "\\u%04x" (Uchar.to_int c));
-      Buffer.contents buf
-    in
+    let encoded_string = java_string str in
     fprintf ppf "%a.fromJSONString(%a ,%s)"
       (format_typ ~wildcard:false ~diamond:false ctx)
       ty (format_expression ctx) (EPosLit, p) encoded_string
   | EAppOp { op = DebugPrint str, _; args = [e]; _ } ->
-    fprintf ppf "System.err.println(\"%s = \" + %a.toString())" str
+    fprintf ppf "System.err.println(%s + %a.toString())"
+      (java_string (str ^ " = "))
       (format_expression ctx) e
   | EAppOp { op = (HandleExceptions, _) as op; args = exprs; _ } ->
     fprintf ppf "@[<hv 2>%a@;<0 -1>(%a@])" format_op op
@@ -610,7 +616,7 @@ let rec format_stmt ~toplevel (ctx : context) ppf (stmt : Ast.stmt Mark.pos) =
            | _ -> None)
        with
       | None -> ""
-      | Some m -> ", " ^ String.quote m)
+      | Some m -> ", " ^ java_string m)
   | SIfThenElse
       {
         if_expr;
@@ -820,13 +826,13 @@ and format_begin_trace ctx ppf (tag, pos) =
     | ScopeCall scopename ->
       let _, decl_pos = ScopeName.get_info scopename in
       fprintf ppf "new CatalaTrace.ScopeCall(%s,@ %a)"
-        (String.quote (ScopeName.original_base scopename))
+        (java_string (ScopeName.original_base scopename))
         format_pos decl_pos
     | ScopeVarDef { var = scope_var; io } ->
       let _, decl_pos = ScopeVar.get_info scope_var in
       fprintf ppf
         "new CatalaTrace.ScopeVarDef(%s,@ %a,@ CatalaTrace.Input.%s,@ %b)"
-        (String.quote (ScopeVar.original_string scope_var))
+        (java_string (ScopeVar.original_string scope_var))
         format_pos decl_pos
         (match io.io_input with
         | NoInput -> "NoInput"
@@ -834,27 +840,27 @@ and format_begin_trace ctx ppf (tag, pos) =
         | Reentrant -> "Reentrant")
         io.io_output
     | LocalVarDef { name } ->
-      fprintf ppf "new CatalaTrace.LocalVarDef(%s)" (String.quote name)
+      fprintf ppf "new CatalaTrace.LocalVarDef(%s)" (java_string name)
     | FunCall topdef ->
       let _, decl_pos = TopdefName.get_info topdef in
       fprintf ppf "new CatalaTrace.FunCall(%s,@ %a)"
-        (String.quote (TopdefName.original_base topdef))
+        (java_string (TopdefName.original_base topdef))
         format_pos decl_pos
     | LocalTupDef { names } ->
       fprintf ppf "new CatalaTrace.LocalTupDef(@[<hov 2>new String[]{%a}@])"
         (pp_print_list
            ~pp_sep:(fun ppf () -> fprintf ppf ",")
-           (fun fmt name -> pp_print_string fmt (String.quote name)))
+           (fun fmt name -> pp_print_string fmt (java_string name)))
         names
     | BranchingCondition -> fprintf ppf "new CatalaTrace.BranchingCondition()"
     | Assertion -> fprintf ppf "new CatalaTrace.Assertion()"
     | Branching None -> fprintf ppf "new CatalaTrace.IfBranching()"
     | Branching (Some cstr) ->
-      fprintf ppf "new CatalaTrace.MatchBranching(%s)" (String.quote cstr)
+      fprintf ppf "new CatalaTrace.MatchBranching(%s)" (java_string cstr)
     | Exception { label = None; cons_pos } ->
       fprintf ppf "new CatalaTrace.Exception(%a)" format_pos cons_pos
     | Exception { label = Some (lbl, pos); cons_pos } ->
-      fprintf ppf "new CatalaTrace.Exception(%s,@ %a,@ %a)" (String.quote lbl)
+      fprintf ppf "new CatalaTrace.Exception(%s,@ %a,@ %a)" (java_string lbl)
         format_pos pos format_pos cons_pos
   in
   fprintf ppf "@[<hov 2>CatalaTrace.begin(%t,@ %a);@]" format_kind format_pos
@@ -1002,7 +1008,7 @@ let format_tests ctx ppf p =
          (pp_print_list
             ~pp_sep:(fun ppf () -> fprintf ppf ",@ ")
             (fun ppf (name, _, _) ->
-              pp_print_string ppf (String.quote (ScopeName.original_base name))))
+              pp_print_string ppf (java_string (ScopeName.original_base name))))
          tests;
        fprintf ppf "@,CatalaGlobals.lang = CatalaGlobals.Language.%s;@\n"
          (match p.lang with `En -> "EN" | `Fr -> "FR" | `Pl -> "EN");
@@ -1031,7 +1037,7 @@ let format_tests ctx ppf p =
        pp_open_vbox ppf 2;
        fprintf ppf
          "if (enabled_tests.isEmpty() || enabled_tests.contains(%s)) {@\n"
-         (String.quote (ScopeName.original_base scope_name));
+         (java_string (ScopeName.original_base scope_name));
        pp_open_vbox ppf 2;
        fprintf ppf "try {@\n";
        (if Global.options.trace <> None then
@@ -1041,15 +1047,15 @@ let format_tests ctx ppf p =
        fprintf ppf "%a@\n" (format_block ~toplevel:true ctx) block;
        if Global.options.trace <> None then
          fprintf ppf "CatalaTrace.end(%s);@\n" (VarName.to_string var);
-       fprintf ppf
-         "CatalaGlobals.displayResult(\"%a\", %s, test_mode, json_mode);"
-         ScopeName.format_original scope_name (VarName.to_string var);
+       fprintf ppf "CatalaGlobals.displayResult(%s, %s, test_mode, json_mode);"
+         (java_string (ScopeName.original_base scope_name))
+         (VarName.to_string var);
        pp_close_box ppf ();
        fprintf ppf
          "@\n\
-          } catch (RuntimeException e) { CatalaGlobals.displayError(\"%a\", e);@\n\
+          } catch (RuntimeException e) { CatalaGlobals.displayError(%s, e);@\n\
           throw e; } }"
-         ScopeName.format_original scope_name;
+         (java_string (ScopeName.original_base scope_name));
        pp_close_box ppf ()
      in
      pp_print_list ~pp_sep:pp_print_space format_test ppf tests);

--- a/compiler/tests.ml
+++ b/compiler/tests.ml
@@ -162,6 +162,22 @@ let backends_format_pos =
     "OCaml", Lcalc.To_ocaml.format_pos;
   ]
 
+(* javac decodes source with the platform encoding (cp1252 on Windows), so a
+   generated Java string literal must be pure ASCII. [\uXXXX] is translated back
+   before lexing, so the value is unchanged; above the BMP Java wants a UTF-16
+   surrogate pair. [format_pos] is the seam: it embeds the source path. *)
+
+let test_java_literal_ascii_only () =
+  let pos = Catala_utils.Pos.from_info {|C:\Impôts\🎯\x.catala_fr|} 1 2 3 4 in
+  let s = Format.asprintf "%a" Scalc.To_java.format_pos pos in
+  Alcotest.(check bool)
+    "literal is pure ASCII" true
+    (String.for_all (fun c -> Char.code c < 0x80) s);
+  Alcotest.(check bool) "BMP char escaped" true (contains ~sub:{|\u00f4|} s);
+  Alcotest.(check bool)
+    "astral char becomes a surrogate pair" true
+    (contains ~sub:{|\ud83c\udfaf|} s)
+
 (* Same hazard in the trace the runtime emits: an unescaped backslash makes the
    JSON unparseable, so the trace viewer rejects every Windows trace. *)
 
@@ -257,6 +273,11 @@ let () =
             test_case (name ^ " escapes backslashes") `Quick (fun () ->
                 Alcotest.(check bool) name true (pos_escaped fmt_pos)))
           backends_format_pos );
+      ( "Java source encoding (non-ASCII in generated literals)",
+        [
+          test_case "position literal is pure ASCII" `Quick
+            test_java_literal_ascii_only;
+        ] );
       ( "Runtime trace JSON escaping (Windows backslash)",
         [
           test_case "trace escapes a Windows path" `Quick

--- a/runtimes/java/catala/runtime/CatalaDecimal.java
+++ b/runtimes/java/catala/runtime/CatalaDecimal.java
@@ -202,7 +202,7 @@ public final class CatalaDecimal extends CatalaValue<CatalaDecimal> {
             }
         }
         if (!r.equals(BigInteger.ZERO)) {
-            s.append("…");
+            s.append("\u2026");
         }
         return s.toString();
     }

--- a/runtimes/java/catala/runtime/CatalaDuration.java
+++ b/runtimes/java/catala/runtime/CatalaDuration.java
@@ -163,7 +163,7 @@ public final class CatalaDuration extends CatalaValue<CatalaDuration> {
             }
             b.append("\"days\":").append(this.period.days);
         }
-        b.append(" }");
+        b.append(" }");
         return b.toString();
     }
 }

--- a/runtimes/java/catala/runtime/CatalaMoney.java
+++ b/runtimes/java/catala/runtime/CatalaMoney.java
@@ -186,7 +186,7 @@ public final class CatalaMoney extends CatalaValue<CatalaMoney> {
         BigInteger[] unitsAndCents = this.value.divideAndRemainder(BigInteger.valueOf(100));
         String n = CatalaGlobals.number_format().format(unitsAndCents[0].abs());
         if (CatalaGlobals.lang == CatalaGlobals.Language.FR) {
-            return String.format("%s%s,%02d €", (this.value.signum() < 0 ? "-" : ""), n, unitsAndCents[1].abs());
+            return String.format("%s%s,%02d \u20ac", (this.value.signum() < 0 ? "-" : ""), n, unitsAndCents[1].abs());
         } else if (CatalaGlobals.lang == CatalaGlobals.Language.PL) {
             return String.format("%s%s.%02d PLN", (this.value.signum() < 0 ? "-" : ""), n, unitsAndCents[1].abs());
         }

--- a/runtimes/java/catala/runtime/CatalaOption.java
+++ b/runtimes/java/catala/runtime/CatalaOption.java
@@ -66,7 +66,7 @@ public final class CatalaOption<T extends CatalaValue<?>> extends CatalaValue<Ca
             return "Absent";
         } else {
             if (CatalaGlobals.lang == CatalaGlobals.Language.FR) {
-                return "Présent contenu " + get().toString(indent + 2);
+                return "Pr\u00e9sent contenu " + get().toString(indent + 2);
             } else {
                 return "Present content " + get().toString(indent + 2);
             }


### PR DESCRIPTION
- Run c and java backend tests on windows for better coverage
- Escape non-ascii strings in java runtime and for user-controlled strings (e.g. assertion messages, file names) -> when JDK17 is deprecated, we could ship files as utf8 (and revert the escapes in the runtime)