### PR TITLE
Fixes clerk related issues

### DIFF
--- a/build_system/clerk_backend/java.ml
+++ b/build_system/clerk_backend/java.ml
@@ -94,15 +94,14 @@ let linking_command ~build_dir ~var_bindings link_deps item target =
       output_string oc (Backend_paths.jar_argfile_content entries));
   Var.get var_bindings jar @ ["--create"; "--file"; jar_target; "@" ^ argfile]
 
-let run_artifact ~var_bindings ~test ~trace ?scope ?quiet src =
+let run_artifact ~var_bindings ~test ?scope ?quiet src =
   let target_main = File.remove_extension (Filename.basename src) in
   let cmd =
     Var.get var_bindings java
     @ ["-cp"; src -.- "jar"; target_main]
     @ Option.to_list scope
     @ (if test && not Global.options.debug then ["--test"] else [])
-    @ (if Global.options.output_format = JSON then ["--json"] else [])
-    @ if trace then ["--trace"] else []
+    @ if Global.options.output_format = JSON then ["--json"] else []
   in
   Message.debug "Executing artifact: '%s'..." (String.concat " " cmd);
   Clerk_cli.run_command_line ?quiet cmd

--- a/build_system/clerk_backend/java.mli
+++ b/build_system/clerk_backend/java.mli
@@ -32,7 +32,6 @@ val linking_command :
 val run_artifact :
   var_bindings:Var.bindings ->
   test:bool ->
-  trace:bool ->
   ?scope:string ->
   ?quiet:bool ->
   string ->

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1494,6 +1494,11 @@ let runtest_cmd =
       $ Cli.whole_program)
 
 let run_ninja_start ~config ~ninja_flags ~enabled_backends cont =
+  let enabled_backends =
+    (* Enforce OCaml backend: eventual targets may not have enabled it *)
+    (module Clerk_backend.OCaml : Clerk_backend.S) :: enabled_backends
+    |> List.sort_uniq compare
+  in
   let default =
     List.fold_left
       (fun default_rules (module B : Clerk_backend.S) ->

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -264,7 +264,7 @@ let run_artifact config ~backend ~var_bindings ?scope ?quiet ~test ~trace src =
     Clerk_backend.Python.run_artifact config ~test ~trace ?scope ?quiet
       ~var_bindings src
   | `Java ->
-    Clerk_backend.Java.run_artifact ~var_bindings ~test ~trace ?scope ?quiet src
+    Clerk_backend.Java.run_artifact ~var_bindings ~test ?scope ?quiet src
 
 (* - Ninja target distribution - *)
 (* these functions take place in the clerk_run continuation, and explicit its targets. *)

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -1191,12 +1191,15 @@ let run_ninja
           ~var_bindings stdlib_tree item_tree
       in
       let modules_map, targets_map, linking_deps =
-        let item_seq =
-          Seq.flat_map
-            (fun (_, _, it) -> List.to_seq it)
-            (Seq.append stdlib_tree item_tree)
-        in
-        organise_modules ~config:config.file item_seq
+        if skip_project_scan then
+          String.Map.empty, String.Map.empty, fun _ -> []
+        else
+          let item_seq =
+            Seq.flat_map
+              (fun (_, _, it) -> List.to_seq it)
+              (Seq.append stdlib_tree item_tree)
+          in
+          organise_modules ~config:config.file item_seq
       in
       let pp nj =
         Nj.format_def nin_ppf nj;

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -298,8 +298,8 @@ module Commands = struct
   let disable_trace options =
     if options.Global.trace <> None then (
       Message.warning "%a" Format.pp_print_text
-        "Trace printing is not compatible with closure conversion or the C or \
-         python backends at the moment and has been disabled.";
+        "Trace printing is not compatible with the C backend or closure \
+         conversion at the moment and has been disabled.";
       Global.enforce_options ~trace:None ())
     else options
 


### PR DESCRIPTION
Fix an issue with `clerk run --backend java --trace` where the generated CLI would complain about not having `--trace`: when compiled with `--trace`, the generated java test entrypoint will systematically output the JSON trace.

Fix `clerk start` command:
- When no `OCaml` backend is present (e.g., a target that only declares a non-ocaml backend), ninja would fail by stating it was missing OCaml stdlib/runtimes obj rules.
- When a target was present, clerk would complain that the related module couldn't be found. Indeed, we filter out the module tree but still tried considering target's modules which couldn't be found in the map.