### PR TITLE
Patch java files target installations and generate maven project files

### DIFF
--- a/.woodpecker/main.yaml
+++ b/.woodpecker/main.yaml
@@ -99,6 +99,7 @@ steps:
       - clerk test --backend=java
       - make ocaml-libs
       - make python-libs
+      - make java-libs
 
   - name: lsp
     image: *catala_image

--- a/.woodpecker/main.yaml
+++ b/.woodpecker/main.yaml
@@ -99,6 +99,7 @@ steps:
       - clerk test --backend=java
       - make ocaml-libs
       - make python-libs
+      - sudo apk add maven
       - make java-libs
 
   - name: lsp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,13 @@ in behavior visible for the end-users of the tooling.
   code did not match the `ExternalType` functor signature: `equal` and
   `compare` were missing the `_pos` parameter, and `from_json` had
   incorrect signature `_pos t` instead of `_pos _s`.
+
+* [#1093](https://github.com/CatalaLang/catala/pull/1093) Improvements
+  over java target generation:
+  - Added in the generated java target files the proper package and
+    import declaration relative to, resp., their own package and
+    (transitive) dependencies.
+  - Following [#1072](https://github.com/CatalaLang/catala/pull/1072),
+    building java targets now also generates a `maven` file
+    (`pom.xml`) which can be used to easily compile and generate `jar`
+    files.

--- a/build_system/clerk_backend/java.ml
+++ b/build_system/clerk_backend/java.ml
@@ -22,7 +22,7 @@ open File
 let catala_flags_java = Var.make_vector "CATALA_FLAGS_JAVA"
 let javac = Var.make_vector "JAVAC"
 let javac_flags = Var.make_vector "JAVAC_FLAGS"
-let jar = Var.make_vector "jar"
+let jar = Var.make_vector "JAR"
 let java = Var.make_vector "JAVA"
 
 let linking_command ~build_dir ~var_bindings link_deps item target =

--- a/build_system/clerk_backend/java.ml
+++ b/build_system/clerk_backend/java.ml
@@ -106,6 +106,8 @@ let run_artifact ~var_bindings ~test ?scope ?quiet src =
   Message.debug "Executing artifact: '%s'..." (String.concat " " cmd);
   Clerk_cli.run_command_line ?quiet cmd
 
+include Java_project_file
+
 module Spec : Sig.Spec = struct
   open Var
   module Nj = Ninja_utils
@@ -242,8 +244,18 @@ module Spec : Sig.Spec = struct
   let runtime_dir : File.t Lazy.t =
     lazy File.(Lazy.force Poll.runtime_dir / name)
 
-  let write_target_def_file ~config:_ ~dir:_ _target = ()
-  (* TODO: generate some kind of Java project file ? *)
+  let write_target_def_file
+      ~(config : Clerk_cli.config)
+      ~(dir : File.t)
+      (target : Clerk_config.target) =
+    let open File in
+    with_formatter_of_file (dir / "pom.xml")
+    @@ fun ppf ->
+    let project_name =
+      config.Clerk_cli.file.global.project_name
+      |> Option.value ~default:"default-project"
+    in
+    Java_project_file.format_target_pom_xml ~project_name ppf target
 
   let install_runtime ~config =
     let open File in

--- a/build_system/clerk_backend/java.mli
+++ b/build_system/clerk_backend/java.mli
@@ -40,4 +40,10 @@ val run_artifact :
     is needed by the Clerk_driver modules and not the clerk_rules modules that's
     why it doesn't appear in the Backend common interface. *)
 
+val format_project_pom_xml :
+  config:Clerk_cli.config ->
+  Format.formatter ->
+  Clerk_config.target list ->
+  unit
+
 include Sig.S

--- a/build_system/clerk_backend/java_project_file.ml
+++ b/build_system/clerk_backend/java_project_file.ml
@@ -1,0 +1,215 @@
+(* This file is part of the Catala build system, a specification language for
+   tax and social benefits computation rules. Copyright (C) 2020-2025 Inria,
+   contributors: Denis Merigoux <denis.merigoux@inria.fr>, Emile Rolley
+   <emile.rolley@tuta.io>, Louis Gesbert <louis.gesbert@inria.fr>,
+   Vincent Botbol <vincent.botbol@inria.fr>.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License. *)
+
+open Catala_utils
+open Clerk_utils
+
+let format_dependency ~project_name ppf (dep_name : string) =
+  let groupId, artifactId, version =
+    if dep_name = Scan.libcatala then
+      Scan.libcatala, "catala-runtime", Catala_utils.Version.v
+    else project_name, String.to_snake_case dep_name, "1.0.0"
+  in
+  Format.fprintf ppf
+    "    <dependency>\n\
+    \      <groupId>%s</groupId>\n\
+    \      <artifactId>%s</artifactId>\n\
+    \      <version>%s</version>\n\
+    \    </dependency>"
+    groupId artifactId version
+
+let format_target_pom_xml ~project_name ppf (target : Clerk_config.target) =
+  let open Format in
+  let groupId, artifactId, version, src_dir, finalName, include_dir =
+    if target.tname = Scan.libcatala then
+      ( Scan.libcatala,
+        "catala-runtime",
+        Catala_utils.Version.v,
+        "${project.basedir}",
+        "${project.artifactId}-${project.version}",
+        "**/*.java" )
+    else
+      let dir_name = String.to_snake_case target.tname in
+      ( project_name,
+        dir_name,
+        "1.0.0",
+        "${project.basedir}/..",
+        "${project.artifactId}",
+        "${project.artifactId}/**/*.java" )
+  in
+  let pp_dependencies ppf =
+    if target.dependencies = [] then ()
+    else
+      Format.fprintf ppf {|
+  <dependencies>
+%a
+  </dependencies>
+
+|}
+        (pp_print_list ~pp_sep:Format.pp_print_newline
+           (format_dependency ~project_name))
+        target.dependencies
+  in
+  fprintf ppf
+    {|<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+                             http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>%s</groupId>
+  <artifactId>%s</artifactId>
+  <version>%s</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+%t
+  <build>
+    <sourceDirectory>%s</sourceDirectory>
+    <finalName>%s</finalName>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.0</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+          <includes>
+            <include>%s</include>
+          </includes>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+          <includes>
+            <include>%s</include>
+          </includes>
+          <includePom>false</includePom>
+          <excludeResources>true</excludeResources>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>package</phase>
+            <goals> <goal>jar-no-fork</goal> </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>|}
+    groupId artifactId version pp_dependencies src_dir finalName include_dir
+    include_dir
+
+let format_project_pom_xml ~(config : Clerk_cli.config) ppf targets =
+  let open Format in
+  let project_name =
+    Option.value ~default:"default-project" config.file.global.project_name
+  in
+  let format_module ppf (target : Clerk_config.target) =
+    let mvn_mod_name =
+      if target.tname = Scan.libcatala then target.tname
+      else String.to_snake_case target.tname
+    in
+    fprintf ppf "      <module>%s</module>" mvn_mod_name
+  in
+  let format_artifact_item ppf (target : Clerk_config.target) =
+    let groupId, artifactId, version, destName =
+      if target.tname = Scan.libcatala then
+        ( Scan.libcatala,
+          "catala-runtime",
+          Version.v,
+          "catala-runtime" ^ Version.v )
+      else
+        let dir_name = String.to_snake_case target.tname in
+        project_name, dir_name, "${project.version}", dir_name
+    in
+    Format.fprintf ppf
+      {|                  <artifactItem>
+                    <groupId>%s</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>%s</version>
+                    <outputDirectory>${project.basedir}</outputDirectory>
+                    <destFileName>%s.jar</destFileName>
+                  </artifactItem>|}
+      groupId artifactId version destName
+  in
+  let groupId, artifactId, version = project_name, "clerk-project", "1.0.0" in
+  fprintf ppf
+    {|<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+             http://maven.apache.org/POM/4.0.0
+             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>%s</groupId>
+    <artifactId>%s</artifactId>
+    <version>%s</version>
+
+    <packaging>pom</packaging>
+
+    <modules>
+%a
+    </modules>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.8.1</version>
+
+          <executions>
+            <execution>
+              <id>copy-libraries</id>
+              <phase>package</phase>
+              <goals>
+                <goal>copy</goal>
+              </goals>
+              <configuration>
+                <artifactItems>
+%a
+                </artifactItems>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
+</project>|}
+    groupId artifactId version
+    (pp_print_list ~pp_sep:pp_print_newline format_module)
+    targets
+    (pp_print_list ~pp_sep:pp_print_newline format_artifact_item)
+    targets

--- a/build_system/clerk_backend/ocaml.ml
+++ b/build_system/clerk_backend/ocaml.ml
@@ -347,7 +347,8 @@ module Spec : Sig.Spec = struct
         | None -> ""
         | Some n -> Printf.sprintf "\n (public_name %s.%s)" n target.tname)
         (String.concat " "
-           (List.map String.to_id ("libcatala" :: target.dependencies)))
+           (List.map String.to_id (Scan.libcatala :: target.dependencies)
+           |> List.sort_uniq compare))
 
   let install_runtime ~config =
     let open File in

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -685,6 +685,7 @@ let install_backend_targets
   if not (List.exists (fun t -> List.mem bk t.Clerk_config.backends) targets)
   then ()
   else
+    let is_java = config_backend bk = `Java in
     let bk_dir = target_dir / backend_subdir bk in
     let extensions =
       B.src_extensions
@@ -697,12 +698,16 @@ let install_backend_targets
     let install_target target =
       if not (List.mem bk target.Config.backends) then ()
       else
-        let dir = bk_dir / target.tname in
-        Message.debug "Installing target: %s" (B.name / target.tname);
+        let target_name =
+          if is_java then String.to_snake_case target.tname else target.tname
+        in
+        let dir = bk_dir / target_name in
+        Message.debug "Installing target: %s" (B.name / target_name);
         if target.Config.tname <> Clerk_rules.stdlib_target_name then
           (* install_runtime already did the cleanup for the stdlib *)
           File.remove dir;
         ensure_dir dir;
+        let tdeps = build_info.target_deps target in
         String.Map.iter
           (fun _ mod_info ->
             if String.Set.mem target.tname mod_info.Clerk_rules.targets then
@@ -727,9 +732,28 @@ let install_backend_targets
                       / basename src
                     else src
                   in
-                  copy_in ~dir ~src)
+                  if not is_java then copy_in ~dir ~src
+                  else
+                    let prefix_lines =
+                      ["package " ^ target_name ^ ";"]
+                      @ List.map
+                          (fun dep_name ->
+                            "import " ^ String.to_snake_case dep_name ^ ".*;")
+                          String.Set.(
+                            remove Clerk_rules.stdlib_target_name tdeps
+                            |> elements)
+                    in
+                    copy_in_with_prefix
+                      ~prefix:(String.concat "\n" prefix_lines ^ "\n\n")
+                      ~dir ~src)
                 extensions)
           build_info.modules_map;
+        let target =
+          if is_java && not (target.tname = Clerk_rules.stdlib_target_name) then
+            (* maven needs all the transitive dependencies *)
+            { target with dependencies = String.Set.elements tdeps }
+          else target
+        in
         B.write_target_def_file ~config ~dir target
     in
     let rec targets_and_deps acc targets =
@@ -752,12 +776,18 @@ let install_backend_targets
     let stdlib =
       String.Map.find Clerk_rules.stdlib_target_name build_info.targets_map
     in
-    List.iter install_target (targets_and_deps [stdlib] targets)
-(* if target.Config.include_sources then
- *   all_modules_deps
- *   |> List.map (fun it -> it.Scan.file_name)
- *   |> List.sort_uniq compare
- *   |> List.iter (fun src -> File.copy_in ~dir:prefix_dir ~src) *)
+    let all_targets = targets_and_deps [stdlib] targets in
+    List.iter install_target all_targets;
+    if is_java then
+      File.with_formatter_of_file (bk_dir / "pom.xml")
+      @@ fun ppf ->
+      List.filter (fun t -> List.mem bk t.Config.backends) all_targets
+      |> Clerk_backend.Java.format_project_pom_xml ~config ppf
+(*  ; if target.Config.include_sources then
+ *     all_modules_deps
+ *     |> List.map (fun it -> it.Scan.file_name)
+ *     |> List.sort_uniq compare
+ *     |> List.iter (fun src -> File.copy_in ~dir:prefix_dir ~src) *)
 
 let advertise_installed ~config ~backends info targets =
   let open Format in
@@ -814,9 +844,15 @@ let advertise_installed ~config ~backends info targets =
         File.(
           ppl
           @@ fun ppf bk ->
+          let target_name =
+            if config_backend bk = `Java then String.to_snake_case t.tname
+            else t.tname
+          in
           format ppf
             (make_relative_to ~dir:original_cwd
-               (config.Cli.file.global.target_dir / backend_subdir bk / t.tname)))
+               (config.Cli.file.global.target_dir
+               / backend_subdir bk
+               / target_name)))
         bks)
       clerk_targets
       (ppl

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -733,6 +733,7 @@ let install_backend_targets
                     else src
                   in
                   if not is_java then copy_in ~dir ~src
+                  else if item.is_stdlib then ()
                   else
                     let prefix_lines =
                       ["package " ^ target_name ^ ";"]

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -1017,12 +1017,16 @@ let organise_modules ~config items =
     Message.debug "Module graph available at @{<blue;bold>%a@}"
       (Message.link ~target:(Message.file_url f) ())
       f);
-  modmap, tmap, linking_deps
+  let target_deps (t : Clerk_config.target) =
+    G.succ target_g t.tname |> String.Set.of_list
+  in
+  modmap, tmap, linking_deps, target_deps
 
 type callback_info = {
   var_bindings : Var.bindings;
   modules_map : module_info String.Map.t;
   targets_map : Clerk_config.target String.Map.t;
+  target_deps : Clerk_config.target -> String.Set.t;
   linking_deps : Scan.item -> string list;
   inclusion_map : Scan.item String.Map.t;
 }
@@ -1032,6 +1036,7 @@ let empty_info =
     var_bindings = [];
     modules_map = String.Map.empty;
     targets_map = String.Map.empty;
+    target_deps = (fun t -> raise (String.Map.Not_found t.tname));
     linking_deps = (fun m -> raise (String.Map.Not_found m.file_name));
     inclusion_map = String.Map.empty;
   }
@@ -1190,9 +1195,12 @@ let run_ninja
         output_ninja_file nin_ppf ~config ~tests ~enabled_backends ~autotest
           ~var_bindings stdlib_tree item_tree
       in
-      let modules_map, targets_map, linking_deps =
+      let modules_map, targets_map, linking_deps, target_deps =
         if skip_project_scan then
-          String.Map.empty, String.Map.empty, fun _ -> []
+          ( String.Map.empty,
+            String.Map.empty,
+            (fun _ -> []),
+            fun _ -> String.Set.empty )
         else
           let item_seq =
             Seq.flat_map
@@ -1254,7 +1262,14 @@ let run_ninja
              ~inputs:[Nj.Expr.Word File.(Var.(!builddir / ".@test"))]);
       let inclusion_map = inclusion_map items in
       let callback_info =
-        { var_bindings; modules_map; targets_map; linking_deps; inclusion_map }
+        {
+          var_bindings;
+          modules_map;
+          targets_map;
+          target_deps;
+          linking_deps;
+          inclusion_map;
+        }
       in
       let () =
         (* Check for missing externals *)
@@ -1307,9 +1322,16 @@ let scan_project ~config =
     |> Seq.append (scan_project_items ~cleanup:false ~config)
     |> Seq.flat_map (fun (_, _, it) -> List.to_seq it)
   in
-  let modules_map, targets_map, linking_deps =
+  let modules_map, targets_map, linking_deps, target_deps =
     organise_modules ~config:config.Clerk_cli.file items
   in
   let inclusion_map = inclusion_map items in
   ( List.of_seq items,
-    { var_bindings; modules_map; targets_map; linking_deps; inclusion_map } )
+    {
+      var_bindings;
+      modules_map;
+      targets_map;
+      linking_deps;
+      inclusion_map;
+      target_deps;
+    } )

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -40,6 +40,8 @@ type callback_info = {
   var_bindings : Var.bindings;
   modules_map : module_info String.Map.t;
   targets_map : Clerk_config.target String.Map.t;
+  target_deps : Clerk_config.target -> String.Set.t;
+      (** returns the names of the given target's dependencies *)
   linking_deps : Scan.item -> string list;
       (** item -> modules, topologically ordered *)
   inclusion_map : Scan.item String.Map.t;

--- a/compiler/catala_utils/file.ml
+++ b/compiler/catala_utils/file.ml
@@ -193,11 +193,12 @@ let contents filename =
   with_in_channel filename (fun ic ->
       really_input_string ic (in_channel_length ic))
 
-let copy ~src ~dst =
+let copy ~prefix ~src ~dst =
   let chunk = 4096 in
   let buf = Bytes.create chunk in
   let ic = open_in_bin src in
   let oc = open_out_bin dst in
+  Option.iter (output_string oc) prefix;
   let rec loop () =
     match input ic buf 0 chunk with
     | 0 -> ()
@@ -211,6 +212,12 @@ let copy ~src ~dst =
       close_in ic)
     loop
 
+let copy_with_prefix ~prefix ~src ~dst = copy ~prefix:(Some prefix) ~src ~dst
+
+let copy_in_with_prefix ~prefix ~src ~dir =
+  copy ~prefix:(Some prefix) ~src ~dst:(dir / Filename.basename src)
+
+let copy ~src ~dst = copy ~prefix:None ~src ~dst
 let copy_in ~src ~dir = copy ~src ~dst:(dir / Filename.basename src)
 
 let newer f1 f2 =

--- a/compiler/catala_utils/file.mli
+++ b/compiler/catala_utils/file.mli
@@ -106,6 +106,12 @@ val copy : src:t -> dst:t -> unit
 val copy_in : src:t -> dir:t -> unit
 (** Same as [copy], but copies the file into the given, existing dir. *)
 
+val copy_with_prefix : prefix:string -> src:t -> dst:t -> unit
+(** Same as [copy] but also prepend a [prefix] to the file. *)
+
+val copy_in_with_prefix : prefix:string -> src:t -> dir:t -> unit
+(** Same as [copy_in] but also prepend a [prefix] to the file. *)
+
 val copy_dir :
   ?filter:(t -> bool) -> ?newer_only:bool -> src:t -> dst:t -> unit -> unit
 (** Recursively copy a directory with its contents using [copy]. [filter] is


### PR DESCRIPTION
This PR attempts to fix an issue with java target generation where the generated files could not be imported easily.
These files should have a `package <package_name>;` directive so that the target directory can be copied over directly in an existing java project. Moreover, the `<package_name>` must follow java convention, which is capitalized camel case. Hence, for java, we adapt the directory name (and the `package` directive) as such.

Also fix duplicate copying of the stdlib in java.

Fixes #1094 