### PR TITLE
Add -linkall to enforce dynamic backend registration

### DIFF
--- a/build_system/clerk_backend/dune
+++ b/build_system/clerk_backend/dune
@@ -1,4 +1,5 @@
 (library
  (name clerk_backend)
  (public_name catala.clerk_backend)
+ (flags -linkall)
  (libraries clerk_lib clerk_utils catala.catala_utils catala.surface otoml))


### PR DESCRIPTION
Fixes a bug where the backend registration side-effects wouldn't be evaluated as the module wasn't used as an explicit dependency in the LSP.

LSP PR: https://github.com/CatalaLang/catala-language-server/pull/255