### PR TITLE
Further clerk fixes

### DIFF
--- a/build_system/clerk_backend/flags.ml
+++ b/build_system/clerk_backend/flags.ml
@@ -109,11 +109,7 @@ let default ~code_coverage ~(trace : bool) ~inplace ~config =
           | Some e -> File.check_exec e
           | None -> Lazy.force Poll.catala_exe);
         ]);
-    def Var.catala_flags
-      (lazy
-        (catala_flags
-        @ (if Message.has_color stderr then ["--color=always"] else [])
-        @ includes));
+    def Var.catala_flags (lazy (catala_flags @ includes));
     def Var.clerk_flags
       (lazy
         ("-e"

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -603,7 +603,7 @@ let ninja_run_targets
     let backends =
       match explicit_backends with
       | Some bks -> bks
-      | None -> item_backends info backends it
+      | None -> if test_only then item_backends info backends it else backends
     in
     List.map
       (fun backend ->

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -210,7 +210,7 @@ let obj_target ~build_dir:_ ~backend item =
   let name = Clerk_backend.(name (get (backend_to_config backend))) in
   Clerk_backend.obj_dep ~name item
 
-let make_target ~build_dir ~backend ?(main_exec = false) item =
+let make_target ~build_dir ~backend ?(main_exec = false) ?force_ext item =
   let open File in
   let f = Scan.target_file_name item -.- File.extension item.Scan.file_name in
   let dir = dirname f in
@@ -230,6 +230,7 @@ let make_target ~build_dir ~backend ?(main_exec = false) item =
     | `Custom rule ->
       (dir / rule_subdir rule / base) -.- List.hd rule.Config.in_exts
   in
+  let base = match force_ext with Some e -> base -.- e | None -> base in
   let needs_main = match backend with `OCaml | `C -> main_exec | _ -> false in
   Nj.Expr.Word
     (if needs_main then
@@ -511,13 +512,15 @@ let ninja_build_targets
   let backends = List.filter (( <> ) `Interpret) backends in
   (* This function is only concerned with the built artifacts *)
   let build_dir = config.Cli.file.global.build_dir in
-  let item_build_target ?backends:explicit_backends it =
+  let item_build_target ?backends:explicit_backends ?force_ext it =
     let backends =
       match explicit_backends with
       | Some bks -> bks
       | None -> item_backends info backends it
     in
-    List.map (fun backend -> make_target ~build_dir ~backend it) backends
+    List.map
+      (fun backend -> make_target ~build_dir ~backend ?force_ext it)
+      backends
   in
   let from_clerk_targets =
     List.concat_map
@@ -560,7 +563,13 @@ let ninja_build_targets
   let from_direct_targets =
     List.concat_map
       (fun (str, item, backend) ->
-        let t = item_build_target ~backends:[config_backend backend] item in
+        let force_ext =
+          if Filename.extension str <> "" then Some (File.extension str)
+          else None
+        in
+        let t =
+          item_build_target ~backends:[config_backend backend] ?force_ext item
+        in
         if t = [] then
           Message.error
             "Could not find a way to build @{<blue>%s@}.@ Check in \

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -290,8 +290,8 @@ let empty_targets =
     direct_targets = [];
   }
 
-let target_debug_message (t : user_target_args) =
-  Message.debug "Will build the following targets:";
+let target_debug_message ?(label = "build") (t : user_target_args) =
+  Message.debug "Will %s the following targets:" label;
   let ppl f =
     Format.pp_print_list ~pp_sep:Format.pp_print_space (fun ppf item ->
         Format.fprintf ppf "@{<magenta>%s@}" (f item))
@@ -1573,25 +1573,30 @@ let ci_cmd =
         ~ninja_flags ~clean_up_env:true ~autotest:true ~tests:true ~trace:false
         ~default:(empty_targets, [], [], Clerk_rules.empty_info, [])
       @@ fun nin_ppf items info ->
-      let targets =
+      let targets_build, targets_test =
         if target_args = [] then
-          {
-            (default_targets ~config info items) with
-            clerk_targets = config.file.targets;
-          }
+          let dir_targets = project_dir_targets ~config info items in
+          ( (match config.file.targets with
+            | _ :: _ as clerk_targets -> { empty_targets with clerk_targets }
+            | [] -> dir_targets),
+            dir_targets )
         else
-          sort_user_target_args config ~autotest:true ~backends items info
-            target_args
+          let targets =
+            sort_user_target_args config ~autotest:true ~backends items info
+              target_args
+          in
+          targets, targets
       in
-      target_debug_message targets;
-      let test_targets = ninja_interp_test_targets config targets in
+      target_debug_message ~label:"build" targets_build;
+      target_debug_message ~label:"test" targets_test;
+      let test_targets = ninja_interp_test_targets config targets_test in
       let build_targets =
-        ninja_build_targets config backends items info targets
+        ninja_build_targets config backends items info targets_build
       in
       let exec_targets, nj_exec_targets =
         ninja_run_targets config
           (List.filter (( <> ) `Interpret) backends)
-          ~test_only:true items info targets
+          ~test_only:true items info targets_test
       in
       let exec_targets_ninja =
         ninja_runtime_targets backends
@@ -1600,7 +1605,7 @@ let ci_cmd =
       in
       set_ninja_targets nin_ppf
         (build_targets @ test_targets @ exec_targets_ninja);
-      targets, exec_targets, items, info, test_targets
+      targets_build, exec_targets, items, info, test_targets
     in
     let open Clerk_report in
     let test_reports =

--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -467,14 +467,26 @@ let ninja_interp_test_targets
     File.(
       fun dir -> Nj.Expr.Word ((build_dir / no_trailing_slash dir) ^ "@test"))
     dirs
-  @ List.map
+  @ List.filter_map
       File.(
         fun m ->
-          Nj.Expr.Word ((build_dir / m.Clerk_rules.item.file_name) ^ "@test"))
+          if
+            m.Clerk_rules.item.Scan.has_inline_tests
+            || Lazy.force m.Clerk_rules.item.Scan.has_scope_tests > 0
+          then
+            Some
+              (Nj.Expr.Word
+                 ((build_dir / m.Clerk_rules.item.file_name) ^ "@test"))
+          else None)
       modules
-  @ List.map
+  @ List.filter_map
       File.(
-        fun item -> Nj.Expr.Word ((build_dir / item.Scan.file_name) ^ "@test"))
+        fun item ->
+          if
+            item.Scan.has_inline_tests
+            || Lazy.force item.Scan.has_scope_tests > 0
+          then Some (Nj.Expr.Word ((build_dir / item.Scan.file_name) ^ "@test"))
+          else None)
       source_files
 
 let module_backends info backends modname =
@@ -605,6 +617,12 @@ let ninja_run_targets
       | Some bks -> bks
       | None -> if test_only then item_backends info backends it else backends
     in
+    let backends =
+      if test_only && Lazy.force it.Scan.has_scope_tests = 0 then
+        if it.has_inline_tests then List.filter (( = ) `Interpret) backends
+        else []
+      else backends
+    in
     List.map
       (fun backend ->
         ( it,
@@ -631,8 +649,7 @@ let ninja_run_targets
                   List.mem bk t.Config.backends)
                 backends
             in
-            if test_only && Lazy.force it.Scan.has_scope_tests = 0 then []
-            else item_exec_target ~backends it)
+            item_exec_target ~backends it)
           (items_in_subdirs info items t.Config.ttests))
       clerk_targets
   in
@@ -641,12 +658,7 @@ let ninja_run_targets
   in
   let from_directories =
     List.concat_map
-      (fun (_, items) ->
-        List.concat_map
-          (fun it ->
-            if test_only && Lazy.force it.Scan.has_scope_tests = 0 then []
-            else item_exec_target it)
-          items)
+      (fun (_, items) -> List.concat_map (fun it -> item_exec_target it) items)
       directories
   in
   let from_sources = List.concat_map item_exec_target source_files in

--- a/build_system/clerk_lib/clerk_cli.ml
+++ b/build_system/clerk_lib/clerk_cli.ml
@@ -589,6 +589,7 @@ let run_command_line ?(setenv = []) ?(quiet = false) cmdline =
       |> String.Map.add_seq (List.to_seq setenv)
       |> String.Map.to_seq
       |> Seq.map (fun (var, value) -> var ^ "=" ^ value)
+      |> Seq.append (Array.to_seq (Message.env_forward_vars ()))
       |> Array.of_seq
     in
     let in_fd, out_fd = Unix.pipe () in

--- a/build_system/clerk_rules.ml
+++ b/build_system/clerk_rules.ml
@@ -1036,13 +1036,33 @@ let empty_info =
     inclusion_map = String.Map.empty;
   }
 
+(* Returns the targets a module belongs to, or, failing that, the targets of its
+   dependencies *)
+let rec module_target_dependencies info m =
+  if not (String.Set.is_empty m.targets) then m.targets
+  else
+    List.fold_left
+      (fun targets (depname, _) ->
+        let m1 = String.Map.find depname info.modules_map in
+        String.Set.union targets (module_target_dependencies info m1))
+      String.Set.empty m.item.used_modules
+
 (* The backends for a given module are detected by analysing what clerk targets
    it belongs to *)
 let module_backends info modname =
   let m = String.Map.find modname info.modules_map in
   if String.Set.is_empty m.targets then
-    List.map snd (Clerk_config.registered_backends ())
+    let all_backends = List.map snd (Clerk_config.registered_backends ()) in
+    let dep_targets = module_target_dependencies info m in
+    (* Intersection of the backends supported by the module deps *)
+    String.Set.fold
+      (fun t acc ->
+        List.filter
+          (fun bk1 -> List.mem bk1 acc)
+          (String.Map.find t info.targets_map).Clerk_config.backends)
+      dep_targets all_backends
   else
+    (* Union of the backends supported by the module targets *)
     String.Set.fold
       (fun t acc ->
         List.fold_left

--- a/build_system/clerk_rules.mli
+++ b/build_system/clerk_rules.mli
@@ -90,4 +90,5 @@ val run_ninja :
 
 val module_backends : callback_info -> string -> Clerk_config.backend list
 (** Returns the list of backends supported by a given module by analysing the
-    clerk targets it belongs to *)
+    clerk targets it belongs to, or, if none, the clerk targets of its
+    dependencies *)

--- a/compiler/driver.ml
+++ b/compiler/driver.ml
@@ -353,15 +353,23 @@ module Commands = struct
           exports
       in
       if test_scopes = [] then
-        Message.warning
-          "@[<hv 4>@[<hov>The program defines no test scopes.@ Please specify \
-           option @{<yellow>--scope@} to explicit what to execute@ or@ mark@ \
-           scopes@ in@ the@ program@ with@ the@ @{<cyan>#[test]@}@ attribute.@ \
-           The program defines the following scopes:@]@ %a@]"
-          (Format.pp_print_list ~pp_sep:Format.pp_print_space ScopeName.format)
-          (List.filter_map
-             (function KScope n, _ -> Some n | _ -> None)
-             exports)
+        if exports <> [] then
+          Message.warning
+            "@[<hv 4>@[<hov>The program defines no test scopes.@ Please \
+             specify option @{<yellow>--scope@} to explicit what to execute@ \
+             or@ mark@ scopes@ in@ the@ program@ with@ the@ @{<cyan>#[test]@}@ \
+             attribute.@ The program defines the following scopes:@]@ %a@]"
+            (Format.pp_print_list ~pp_sep:Format.pp_print_space ScopeName.format)
+            (List.filter_map
+               (function KScope n, _ -> Some n | _ -> None)
+               exports)
+        else
+          Message.warning
+            "@[<hov>The program defines no public or test scopes.@ Please mark \
+             scopes in the program with the @{<cyan>#[test]@}@ attribute,@ or@ \
+             declare@ the@ desired@ scopes@ within@ \
+             @{<yellow>```catala-metadata@}@ blocks@ and@ call@ them@ \
+             explicitely@ using@ the@ @{<yellow>--scope@}@ option@]"
       else
         Message.debug "Will execute the following test scopes:@ %a"
           (Format.pp_print_list ~pp_sep:Format.pp_print_space ScopeName.format)


### PR DESCRIPTION
This is a follow-up for #1072

See the individual patches for details:
- fixes color forwarding to catala sub-processes
- fixes `clerk build` with cmxs targets
- changes `clerk run` to always use the cli-supplied backend(s), defaulting to `interpret`, notwithstanding what backends are declared in clerk.toml (was previously taking the intersection, which could lead to silently doing nothing)
- fixes backend analysis of non-target modules that depend on targets (resolving `clerk build` issue with `impot/revenu/tests/Interface` on `catala-examples`)
- changes `clerk ci` to only build targets instead of all files it could find (tests are still run on all files)

