### PR TITLE
clerk: keep catala's stderr out of the JSON output of exceptions

### DIFF
--- a/build_system/clerk_driver.ml
+++ b/build_system/clerk_driver.ml
@@ -1803,7 +1803,7 @@ let json_schema_cmd =
     in
     Message.debug "Running command: '%s'..." (String.concat " " cmd);
     Sys.chdir File.original_cwd;
-    fst (Clerk_cli.run_command_line cmd)
+    fst (Clerk_cli.run_command_line ~merge_stderr:false cmd)
   in
   let doc =
     "Display the JSON-schema of the input and output JSON objects of the given \
@@ -1833,7 +1833,7 @@ let exceptions_cmd =
     in
     Message.debug "Running command: '%s'..." (String.concat " " cmd);
     Sys.chdir File.original_cwd;
-    fst (Clerk_cli.run_command_line cmd)
+    fst (Clerk_cli.run_command_line ~merge_stderr:false cmd)
   in
   let doc =
     "Prints the exception tree for the definitions of a particular variable in \

--- a/build_system/clerk_lib/clerk_cli.ml
+++ b/build_system/clerk_lib/clerk_cli.ml
@@ -573,7 +573,11 @@ let init_term ?(allow_test_flags = false) () =
     $ Cli.Flags.output_format
     $ objects)
 
-let run_command_line ?(setenv = []) ?(quiet = false) cmdline =
+let run_command_line
+    ?(setenv = [])
+    ?(quiet = false)
+    ?(merge_stderr = true)
+    cmdline =
   if cmdline = [] then 0, []
   else
     let cmd = List.hd cmdline in
@@ -593,9 +597,10 @@ let run_command_line ?(setenv = []) ?(quiet = false) cmdline =
       |> Array.of_seq
     in
     let in_fd, out_fd = Unix.pipe () in
+    let err_fd = if merge_stderr then out_fd else Unix.stderr in
     let npid =
       Unix.create_process_env cmd (Array.of_list cmdline) env Unix.stdin out_fd
-        out_fd
+        err_fd
     in
     Unix.close out_fd;
     let ic = Unix.in_channel_of_descr in_fd in

--- a/build_system/clerk_lib/clerk_cli.mli
+++ b/build_system/clerk_lib/clerk_cli.mli
@@ -76,5 +76,6 @@ val init_term : ?allow_test_flags:bool -> unit -> config Term.t
 val run_command_line :
   ?setenv:(string * string) list ->
   ?quiet:bool ->
+  ?merge_stderr:bool ->
   string list ->
   int * string list


### PR DESCRIPTION
This keeps JSON output clean for parsing even in presence of warnings